### PR TITLE
Fix comment modal on Firefox and IE

### DIFF
--- a/app/pages/search/controls/SearchControlsContainer.js
+++ b/app/pages/search/controls/SearchControlsContainer.js
@@ -114,7 +114,6 @@ class UnconnectedSearchControlsContainer extends Component {
           bsStyle="primary"
           className="search-button"
           onClick={() => this.handleSearch()}
-          type="submit"
         >
           {t('SearchControls.search')}
         </Button>

--- a/app/shared/comment-form/CommentForm.js
+++ b/app/shared/comment-form/CommentForm.js
@@ -13,7 +13,8 @@ class CommentForm extends Component {
     this.handleSave = this.handleSave.bind(this);
   }
 
-  handleSave() {
+  handleSave(event) {
+    event.preventDefault();
     const comments = findDOMNode(this.refs.commentsInput).value;
     this.props.onSave(comments);
   }

--- a/app/shared/comment-form/CommentForm.spec.js
+++ b/app/shared/comment-form/CommentForm.spec.js
@@ -72,12 +72,13 @@ describe('shared/comment-form/CommentForm', () => {
 
   describe('handleSave', () => {
     const comments = 'Some comments';
+    const mockEvent = { preventDefault: () => null };
 
     before(() => {
       simple.mock(ReactDom, 'findDOMNode').returnWith({ value: comments });
       const instance = getWrapper().instance();
       defaultProps.onSave.reset();
-      instance.handleSave();
+      instance.handleSave(mockEvent);
     });
 
     after(() => {

--- a/app/shared/modals/reservation-info/ReservationInfoModalContainer.js
+++ b/app/shared/modals/reservation-info/ReservationInfoModalContainer.js
@@ -138,7 +138,6 @@ class UnconnectedReservationInfoModalContainer extends Component {
               bsStyle="success"
               disabled={isEditingReservations}
               onClick={this.handleSave}
-              type="submit"
             >
               {isEditingReservations ? t('common.saving') : t('common.save')}
             </Button>


### PR DESCRIPTION
Submit button inside a comment form was making the page refresh on Firefox and IE.
Closes #490.