### PR TITLE
Feature/501 event name to regular reservations

### DIFF
--- a/app/i18n/messages/en.json
+++ b/app/i18n/messages/en.json
@@ -109,6 +109,7 @@
   "ReservationForm.commentsPlaceholder": "Any additional information about the reservation",
   "ReservationForm.emailError": "Enter a valid e-mail address",
   "ReservationForm.eventDescriptionLabel": "Description of the event",
+  "ReservationForm.eventSubjectInfo": "Event name is visible to staff only. Giving a name to the event makes it easier to guide the guests to the right space. Please remember to also tell the name to people arriving to the event.",
   "ReservationForm.eventSubjectLabel": "Name of the event",
   "ReservationForm.maxLengthError": "The maximum length of the field is {maxLength} characters",
   "ReservationForm.numberOfParticipantsLabel": "Number of participants",

--- a/app/i18n/messages/en.json
+++ b/app/i18n/messages/en.json
@@ -109,6 +109,7 @@
   "ReservationForm.commentsPlaceholder": "Any additional information about the reservation",
   "ReservationForm.emailError": "Enter a valid e-mail address",
   "ReservationForm.eventDescriptionLabel": "Description of the event",
+  "ReservationForm.eventSubjectLabel": "Name of the event",
   "ReservationForm.maxLengthError": "The maximum length of the field is {maxLength} characters",
   "ReservationForm.numberOfParticipantsLabel": "Number of participants",
   "ReservationForm.requiredError": "Mandatory information",

--- a/app/i18n/messages/fi.json
+++ b/app/i18n/messages/fi.json
@@ -109,6 +109,7 @@
   "ReservationForm.commentsPlaceholder": "Varauksen mahdolliset lisätiedot",
   "ReservationForm.emailError": "Syötä kunnollinen sähköpostiosoite",
   "ReservationForm.eventDescriptionLabel": "Tilaisuuden kuvaus",
+  "ReservationForm.eventSubjectLabel": "Tilaisuuden nimi",
   "ReservationForm.maxLengthError": "Kentän maksimipituus on {maxLength} merkkiä",
   "ReservationForm.numberOfParticipantsLabel": "Osallistujamäärä",
   "ReservationForm.requiredError": "Pakollinen tieto",

--- a/app/i18n/messages/fi.json
+++ b/app/i18n/messages/fi.json
@@ -109,6 +109,7 @@
   "ReservationForm.commentsPlaceholder": "Varauksen mahdolliset lisätiedot",
   "ReservationForm.emailError": "Syötä kunnollinen sähköpostiosoite",
   "ReservationForm.eventDescriptionLabel": "Tilaisuuden kuvaus",
+  "ReservationForm.eventSubjectInfo": "Tilaisuuden nimen näkee ainoastaan henkilökunta. Antamalla tilaisuudelle nimen helpotat saapuvien vieraiden opastamista oikeaan tilaan. Muistathan ilmoittaa nimen myös tilaisuuteen saapuville.",
   "ReservationForm.eventSubjectLabel": "Tilaisuuden nimi",
   "ReservationForm.maxLengthError": "Kentän maksimipituus on {maxLength} merkkiä",
   "ReservationForm.numberOfParticipantsLabel": "Osallistujamäärä",

--- a/app/i18n/messages/sv.json
+++ b/app/i18n/messages/sv.json
@@ -109,6 +109,7 @@
   "ReservationForm.commentsPlaceholder": "Eventuell ytterligare information om bokningen",
   "ReservationForm.emailError": "Mata in en giltig e-postadress",
   "ReservationForm.eventDescriptionLabel": "Beskrivning av evenemanget",
+  "ReservationForm.eventSubjectInfo": "Event name is visible to staff only. Giving a name to the event makes it easier to guide the guests to the right space. Please remember to also tell the name to people arriving to the event.",
   "ReservationForm.eventSubjectLabel": "Name of the event",
   "ReservationForm.maxLengthError": "Den maximala längden på fältet är {maxLength} tecken",
   "ReservationForm.numberOfParticipantsLabel": "Antal deltagare",

--- a/app/i18n/messages/sv.json
+++ b/app/i18n/messages/sv.json
@@ -109,6 +109,7 @@
   "ReservationForm.commentsPlaceholder": "Eventuell ytterligare information om bokningen",
   "ReservationForm.emailError": "Mata in en giltig e-postadress",
   "ReservationForm.eventDescriptionLabel": "Beskrivning av evenemanget",
+  "ReservationForm.eventSubjectLabel": "Name of the event",
   "ReservationForm.maxLengthError": "Den maximala längden på fältet är {maxLength} tecken",
   "ReservationForm.numberOfParticipantsLabel": "Antal deltagare",
   "ReservationForm.requiredError": "Obligatorisk information",

--- a/app/pages/resource/reservation-confirmation/ConfirmReservationModal.js
+++ b/app/pages/resource/reservation-confirmation/ConfirmReservationModal.js
@@ -35,6 +35,8 @@ class ConfirmReservationModal extends Component {
 
     if (resource.needManualConfirmation) {
       formFields.push(...constants.RESERVATION_FORM_FIELDS);
+    } else {
+      formFields.push('eventSubject');
     }
 
     if (isAdmin) {

--- a/app/pages/resource/reservation-confirmation/ConfirmReservationModal.spec.js
+++ b/app/pages/resource/reservation-confirmation/ConfirmReservationModal.spec.js
@@ -148,6 +148,10 @@ describe('pages/resource/reservation-confirmation/ConfirmReservationModal', () =
           expect(formFields).to.contain('staffEvent');
         });
 
+        it('form fields do not include eventSubject', () => {
+          expect(formFields).to.not.contain('eventSubject');
+        });
+
         it('form fields include comments', () => {
           expect(formFields).to.contain('comments');
         });
@@ -171,6 +175,10 @@ describe('pages/resource/reservation-confirmation/ConfirmReservationModal', () =
 
         it('form fields include comments', () => {
           expect(formFields).to.contain('comments');
+        });
+
+        it('form fields do not include eventSubject', () => {
+          expect(formFields).to.not.contain('eventSubject');
         });
 
         it('form fields include RESERVATION_FORM_FIELDS', () => {
@@ -200,6 +208,10 @@ describe('pages/resource/reservation-confirmation/ConfirmReservationModal', () =
 
         it('form fields do not include comments', () => {
           expect(formFields).to.not.contain('comments');
+        });
+
+        it('form fields do not include eventSubject', () => {
+          expect(formFields).to.not.contain('eventSubject');
         });
 
         it('form fields include RESERVATION_FORM_FIELDS', () => {
@@ -233,6 +245,10 @@ describe('pages/resource/reservation-confirmation/ConfirmReservationModal', () =
           expect(formFields).to.contain('comments');
         });
 
+        it('form fields include eventSubject', () => {
+          expect(formFields).to.contain('eventSubject');
+        });
+
         it('form fields do not include RESERVATION_FORM_FIELDS', () => {
           forEach(constants.RESERVATION_FORM_FIELDS, (field) => {
             expect(formFields).to.not.contain(field);
@@ -259,6 +275,10 @@ describe('pages/resource/reservation-confirmation/ConfirmReservationModal', () =
 
         it('form fields do not include comments', () => {
           expect(formFields).to.not.contain('comments');
+        });
+
+        it('form fields include eventSubject', () => {
+          expect(formFields).to.contain('eventSubject');
         });
 
         it('form fields do not include RESERVATION_FORM_FIELDS', () => {

--- a/app/pages/resource/reservation-confirmation/ReservationForm.js
+++ b/app/pages/resource/reservation-confirmation/ReservationForm.js
@@ -67,7 +67,7 @@ export function validate(values, { fields, requiredFields, t }) {
 }
 
 class UnconnectedReservationForm extends Component {
-  renderField(name, type, label, controlProps = {}, help = null) {
+  renderField(name, type, label, controlProps = {}, help = null, info = null) {
     if (!includes(this.props.fields, name)) {
       return null;
     }
@@ -78,6 +78,7 @@ class UnconnectedReservationForm extends Component {
         component={ReduxFormField}
         controlProps={controlProps}
         help={help}
+        info={info}
         label={`${label}${isRequired ? '*' : ''}`}
         name={name}
         type={type}
@@ -118,7 +119,10 @@ class UnconnectedReservationForm extends Component {
           {this.renderField(
             'eventSubject',
             'text',
-            t('ReservationForm.eventSubjectLabel')
+            t('ReservationForm.eventSubjectLabel'),
+            {},
+            null,
+            t('ReservationForm.eventSubjectInfo'),
           )}
           {this.renderField(
             'reserverName',

--- a/app/pages/resource/reservation-confirmation/ReservationForm.js
+++ b/app/pages/resource/reservation-confirmation/ReservationForm.js
@@ -116,6 +116,11 @@ class UnconnectedReservationForm extends Component {
             </Well>
           )}
           {this.renderField(
+            'eventSubject',
+            'text',
+            t('ReservationForm.eventSubjectLabel')
+          )}
+          {this.renderField(
             'reserverName',
             'text',
             t('ReservationForm.reserverNameLabel')

--- a/app/shared/form-fields/FormControl.js
+++ b/app/shared/form-fields/FormControl.js
@@ -5,11 +5,13 @@ import RBFormControl from 'react-bootstrap/lib/FormControl';
 import FormGroup from 'react-bootstrap/lib/FormGroup';
 import HelpBlock from 'react-bootstrap/lib/HelpBlock';
 
-function FormControl({ controlProps = {}, help, id, label, type, validationState }) {
+import InfoPopover from 'shared/info-popover';
+
+function FormControl({ controlProps = {}, help, id, info, label, type, validationState }) {
   return (
     <FormGroup controlId={id} validationState={validationState}>
       <Col componentClass={ControlLabel} sm={3}>
-        {label}
+        {label} {info && <InfoPopover id={`${id}-info`} placement="right" text={info} />}
       </Col>
       <Col sm={9}>
         <RBFormControl
@@ -27,6 +29,7 @@ FormControl.propTypes = {
   controlProps: PropTypes.object,
   help: PropTypes.string,
   id: PropTypes.string.isRequired,
+  info: PropTypes.string,
   label: PropTypes.string.isRequired,
   type: PropTypes.string.isRequired,
   validationState: PropTypes.string,

--- a/app/shared/form-fields/FormControl.spec.js
+++ b/app/shared/form-fields/FormControl.spec.js
@@ -7,6 +7,7 @@ import RBFormControl from 'react-bootstrap/lib/FormControl';
 import FormGroup from 'react-bootstrap/lib/FormGroup';
 import HelpBlock from 'react-bootstrap/lib/HelpBlock';
 
+import InfoPopover from 'shared/info-popover';
 import FormControl from './FormControl';
 
 describe('shared/form-fields/FormControl', () => {
@@ -42,19 +43,29 @@ describe('shared/form-fields/FormControl', () => {
     });
 
     describe('the first Col', () => {
-      let col;
-
-      before(() => {
-        col = getWrapper().find(Col).at(0);
-      });
+      function getColWrapper(props) {
+        return getWrapper(props).find(Col).at(0);
+      }
 
       it('gets correct props', () => {
-        expect(col.props().componentClass).to.equal(ControlLabel);
-        expect(col.props().sm).to.equal(3);
+        expect(getColWrapper().props().componentClass).to.equal(ControlLabel);
+        expect(getColWrapper().props().sm).to.equal(3);
       });
 
       it('contains the label text given in props', () => {
-        expect(col.props().children).to.equal(defaultProps.label);
+        expect(getColWrapper().props().children).to.contain(defaultProps.label);
+      });
+
+      it('does not contain InfoPopover if info not given', () => {
+        const popover = getColWrapper().find(InfoPopover);
+        expect(popover).to.have.length(0);
+      });
+
+      it('contains InfoPopover if info is given', () => {
+        const info = 'Some info';
+        const popover = getColWrapper({ info }).find(InfoPopover);
+        expect(popover).to.have.length(1);
+        expect(popover.prop('text')).to.equal(info);
       });
     });
 

--- a/app/shared/form-fields/ReduxFormField.js
+++ b/app/shared/form-fields/ReduxFormField.js
@@ -3,12 +3,13 @@ import React, { PropTypes } from 'react';
 import Checkbox from './Checkbox';
 import FormControl from './FormControl';
 
-function ReduxFormField({ controlProps = {}, help, input, label, meta, name, type }) {
+function ReduxFormField({ controlProps = {}, help, info, input, label, meta, name, type }) {
   const showError = meta.error && meta.touched;
   const props = {
     controlProps: Object.assign({}, input, controlProps),
     help: showError ? meta.error : help,
     id: name,
+    info,
     label,
     type,
     validationState: showError ? 'error' : undefined,
@@ -24,6 +25,7 @@ function ReduxFormField({ controlProps = {}, help, input, label, meta, name, typ
 ReduxFormField.propTypes = {
   controlProps: PropTypes.object,
   help: PropTypes.string,
+  info: PropTypes.string,
   input: PropTypes.object.isRequired,
   label: PropTypes.string.isRequired,
   meta: PropTypes.object.isRequired,

--- a/app/shared/form-fields/ReduxFormField.spec.js
+++ b/app/shared/form-fields/ReduxFormField.spec.js
@@ -89,6 +89,12 @@ describe('shared/form-fields/ReduxFormField', () => {
       expect(actualProps.id).to.equal(defaultProps.name);
     });
 
+    it('info is the info given in props', () => {
+      const info = 'Some info';
+      const actualProps = getWrapper({ info }).find(FormControl).props();
+      expect(actualProps.info).to.equal(info);
+    });
+
     it('label is the label given in props', () => {
       const actualProps = getWrapper().find(FormControl).props();
       expect(actualProps.label).to.equal(defaultProps.label);

--- a/app/shared/info-popover/InfoPopover.js
+++ b/app/shared/info-popover/InfoPopover.js
@@ -1,0 +1,22 @@
+import React, { PropTypes } from 'react';
+import Glyphicon from 'react-bootstrap/lib/Glyphicon';
+import Popover from 'react-bootstrap/lib/Popover';
+import OverlayTrigger from 'react-bootstrap/lib/OverlayTrigger';
+
+InfoPopover.propTypes = {
+  id: PropTypes.string.isRequired,
+  placement: PropTypes.string,
+  text: PropTypes.string.isRequired,
+};
+function InfoPopover({ id, placement, text }) {
+  const popover = <Popover id={id}>{text}</Popover>;
+
+  return (
+    <OverlayTrigger overlay={popover} placement={placement || 'top'} trigger={['hover', 'focus']}>
+      <Glyphicon className="info-popover" glyph="question-sign" />
+    </OverlayTrigger>
+  );
+}
+
+
+export default InfoPopover;

--- a/app/shared/info-popover/InfoPopover.spec.js
+++ b/app/shared/info-popover/InfoPopover.spec.js
@@ -1,0 +1,39 @@
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+import React from 'react';
+import Glyphicon from 'react-bootstrap/lib/Glyphicon';
+import OverlayTrigger from 'react-bootstrap/lib/OverlayTrigger';
+import Popover from 'react-bootstrap/lib/Popover';
+
+import InfoPopover from './InfoPopover';
+
+function getWrapper(props) {
+  const defaults = {
+    id: 'info-id',
+    text: 'This is a popover!',
+  };
+  return shallow(<InfoPopover {...defaults} {...props} />);
+}
+
+describe('shared/info-popover/InfoPopover', () => {
+  it('renders an OverlayTrigger with correct placement', () => {
+    const placement = 'right';
+    const trigger = getWrapper({ placement }).find(OverlayTrigger);
+    expect(trigger).to.have.length(1);
+    expect(trigger.prop('placement')).to.equal(placement);
+  });
+
+  it('renders a popover with correct text', () => {
+    const text = 'Some text';
+    const overlayTrigger = getWrapper({ text }).find(OverlayTrigger);
+    const overlay = overlayTrigger.prop('overlay');
+    expect(overlay.type).to.equal(Popover);
+    expect(overlay.props.children).to.equal(text);
+  });
+
+  it('renders a "question-sign" glyphicon', () => {
+    const glyphicon = getWrapper().find(Glyphicon);
+    expect(glyphicon).to.have.length(1);
+    expect(glyphicon.prop('glyph')).to.equal('question-sign');
+  });
+});

--- a/app/shared/info-popover/index.js
+++ b/app/shared/info-popover/index.js
@@ -1,0 +1,3 @@
+import InfoPopover from './InfoPopover';
+
+export default InfoPopover;

--- a/app/shared/info-popover/info-popover.less
+++ b/app/shared/info-popover/info-popover.less
@@ -1,0 +1,3 @@
+.info-popover {
+  color: @brand-primary;
+}

--- a/app/shared/shared.less
+++ b/app/shared/shared.less
@@ -5,6 +5,7 @@
 @import './favorite-button/favorite-button';
 @import './footer/footer';
 @import './form-fields/form-fields';
+@import './info-popover/info-popover';
 @import './modals/modals';
 @import './navbar/navbar';
 @import './notifications/notifications';


### PR DESCRIPTION
Adds event name field to regular reservations.
This requires some changes to resource info in the API so currently this can be tested only in "Ryhmätyötila (num. 40)" resource with id `auunfu22eqxq?date=2017-02-21`.

Closes #501.