### PR TITLE
Add cancel button to reservation info modal

### DIFF
--- a/app/i18n/messages/en.json
+++ b/app/i18n/messages/en.json
@@ -129,6 +129,7 @@
   "ReservationInfoModal.accessCode": "PIN code",
   "ReservationInfoModal.address": "Address",
   "ReservationInfoModal.billingAddress": "Invoicing address",
+  "ReservationInfoModal.cancelButton": "Cancel event",
   "ReservationInfoModal.confirmButton": "Confirm reservation",
   "ReservationInfoModal.denyButton": "Deny reservation",
   "ReservationInfoModal.phoneNumber": "Telephone",

--- a/app/i18n/messages/fi.json
+++ b/app/i18n/messages/fi.json
@@ -127,6 +127,7 @@
   "ReservationInfo.maxNumberOfReservations": "Maksimimäärä varauksia per käyttäjä: {maxReservationsPerUser}",
   "ReservationInfo.reservationMaxLength": "Varauksen maksimipituus: {asHours} tuntia",
   "ReservationInfoModal.accessCode": "PIN-koodi",
+  "ReservationInfoModal.cancelButton": "Peru tapahtuma",
   "ReservationInfoModal.confirmButton": "Hyväksy tapahtuma",
   "ReservationInfoModal.denyButton": "Hylkää tapahtuma",
   "ReservationInfoModal.reservationTime": "Varauksen ajankohta",

--- a/app/i18n/messages/sv.json
+++ b/app/i18n/messages/sv.json
@@ -129,6 +129,7 @@
   "ReservationInfoModal.accessCode": "PIN-kod",
   "ReservationInfoModal.address": "Adress",
   "ReservationInfoModal.billingAddress": "Faktureringsadress",
+  "ReservationInfoModal.cancelButton": "Cancel event",
   "ReservationInfoModal.confirmButton": "Confirm reservation",
   "ReservationInfoModal.denyButton": "Deny reservation",
   "ReservationInfoModal.phoneNumber": "Telefonnummer",

--- a/app/shared/modals/reservation-info/ReservationInfoModalContainer.js
+++ b/app/shared/modals/reservation-info/ReservationInfoModalContainer.js
@@ -12,7 +12,10 @@ import { bindActionCreators } from 'redux';
 import {
   commentReservation, confirmPreliminaryReservation, denyPreliminaryReservation,
 } from 'actions/reservationActions';
-import { hideReservationInfoModal } from 'actions/uiActions';
+import {
+  hideReservationInfoModal, openReservationCancelModal, selectReservationToCancel,
+} from 'actions/uiActions';
+import ReservationCancelModal from 'shared/modals/reservation-cancel';
 import ReservationStateLabel from 'shared/reservation-state-label';
 import TimeRange from 'shared/time-range';
 import { injectT } from 'i18n';
@@ -21,6 +24,7 @@ import reservationInfoModalSelector from './reservationInfoModalSelector';
 class UnconnectedReservationInfoModalContainer extends Component {
   constructor(props) {
     super(props);
+    this.handleCancelClick = this.handleCancelClick.bind(this);
     this.handleConfirmClick = this.handleConfirmClick.bind(this);
     this.handleDenyClick = this.handleDenyClick.bind(this);
     this.handleSave = this.handleSave.bind(this);
@@ -34,6 +38,12 @@ class UnconnectedReservationInfoModalContainer extends Component {
       return `${street}, ${ending}`;
     }
     return `${street} ${ending}`;
+  }
+
+  handleCancelClick() {
+    const { actions, reservation } = this.props;
+    actions.selectReservationToCancel(reservation);
+    actions.openReservationCancelModal();
   }
 
   handleConfirmClick() {
@@ -94,6 +104,11 @@ class UnconnectedReservationInfoModalContainer extends Component {
       show,
       t,
     } = this.props;
+
+    const showCancelButton = reservationIsEditable && (
+      reservation.state === 'confirmed' ||
+      (reservation.state === 'requested' && !isAdmin)
+    );
 
     return (
       <Modal
@@ -187,7 +202,17 @@ class UnconnectedReservationInfoModalContainer extends Component {
               {t('ReservationInfoModal.confirmButton')}
             </Button>
           )}
+          {showCancelButton && (
+            <Button
+              bsStyle="danger"
+              disabled={isEditingReservations}
+              onClick={this.handleCancelClick}
+            >
+              {t('ReservationInfoModal.cancelButton')}
+            </Button>
+          )}
         </Modal.Footer>
+        <ReservationCancelModal />
       </Modal>
     );
   }
@@ -213,6 +238,8 @@ function mapDispatchToProps(dispatch) {
     confirmPreliminaryReservation,
     denyPreliminaryReservation,
     hideReservationInfoModal,
+    openReservationCancelModal,
+    selectReservationToCancel,
   };
 
   return { actions: bindActionCreators(actionCreators, dispatch) };

--- a/app/shared/modals/reservation-info/ReservationInfoModalContainer.spec.js
+++ b/app/shared/modals/reservation-info/ReservationInfoModalContainer.spec.js
@@ -38,6 +38,8 @@ describe('shared/modals/reservation-info/ReservationInfoModalContainer', () => {
       commentReservation: simple.stub(),
       confirmPreliminaryReservation: () => null,
       hideReservationInfoModal: simple.stub(),
+      openReservationCancelModal: () => null,
+      selectReservationToCancel: () => null,
     },
     isAdmin: false,
     isEditingReservations: false,
@@ -352,6 +354,93 @@ describe('shared/modals/reservation-info/ReservationInfoModalContainer', () => {
           expect(getConfirmButton(props)).to.have.length(1);
         });
       });
+
+      describe('cancel button', () => {
+        function getCancelButton(props) {
+          const wrapper = getWrapper({ ...props });
+          const onClick = wrapper.instance().handleCancelClick;
+          return wrapper.find(Modal.Footer).find(Button).filter({ onClick });
+        }
+
+        describe('if reservation is not editable', () => {
+          const reservationIsEditable = false;
+
+          it('is not rendered', () => {
+            const props = {
+              reservationIsEditable,
+              reservation: { ...reservation, state: 'confirmed' },
+            };
+            expect(getCancelButton(props)).to.have.length(0);
+          });
+        });
+
+        describe('if reservation is editable', () => {
+          const reservationIsEditable = true;
+
+          it('is rendered if reservation state is "confirmed"', () => {
+            const props = {
+              reservationIsEditable,
+              reservation: { ...reservation, state: 'confirmed' },
+            };
+            expect(getCancelButton(props)).to.have.length(1);
+          });
+
+          it('is rendered for regular users if reservation state is "requested"', () => {
+            const props = {
+              isAdmin: false,
+              reservationIsEditable,
+              reservation: { ...reservation, state: 'requested' },
+            };
+            expect(getCancelButton(props)).to.have.length(1);
+          });
+
+          it('is not rendered for admins if reservation state is "requested"', () => {
+            const props = {
+              isAdmin: true,
+              reservationIsEditable,
+              reservation: { ...reservation, state: 'requested' },
+            };
+            expect(getCancelButton(props)).to.have.length(0);
+          });
+
+          it('is not rendered if reservation state is "cancelled"', () => {
+            const props = {
+              reservationIsEditable,
+              reservation: { ...reservation, state: 'cancelled' },
+            };
+            expect(getCancelButton(props)).to.have.length(0);
+          });
+
+          it('is not rendered if reservation state is "denied"', () => {
+            const props = {
+              reservationIsEditable,
+              reservation: { ...reservation, state: 'denied' },
+            };
+            expect(getCancelButton(props)).to.have.length(0);
+          });
+        });
+      });
+    });
+  });
+
+  describe('handleCancelClick', () => {
+    function callHandleCancelClick(extraActions) {
+      const actions = { ...defaultProps.actions, ...extraActions };
+      const instance = getWrapper({ actions }).instance();
+      instance.handleCancelClick();
+    }
+
+    it('calls props.actions.selectReservationToCancel with props.reservation', () => {
+      const selectReservationToCancel = simple.mock();
+      callHandleCancelClick({ selectReservationToCancel });
+      expect(selectReservationToCancel.callCount).to.equal(1);
+      expect(selectReservationToCancel.lastCall.args).to.deep.equal([reservation]);
+    });
+
+    it('calls the props.actions.openReservationCancelModal', () => {
+      const openReservationCancelModal = simple.mock();
+      callHandleCancelClick({ openReservationCancelModal });
+      expect(openReservationCancelModal.callCount).to.equal(1);
     });
   });
 

--- a/app/state/reducers/ui/reservationInfoModalReducer.js
+++ b/app/state/reducers/ui/reservationInfoModalReducer.js
@@ -10,6 +10,10 @@ const initialState = Immutable({
 function reservationInfoModalReducer(state = initialState, action) {
   switch (action.type) {
 
+    case types.API.RESERVATION_DELETE_SUCCESS: {
+      return initialState;
+    }
+
     case types.API.RESERVATION_PUT_SUCCESS: {
       return state.merge({
         reservation: action.payload,

--- a/app/state/reducers/ui/reservationInfoModalReducer.spec.js
+++ b/app/state/reducers/ui/reservationInfoModalReducer.spec.js
@@ -14,6 +14,15 @@ describe('state/reducers/ui/reservationInfoModalReducer', () => {
     expect(actual).to.deep.equal(initialState);
   });
 
+  describe('RESERVATION_DELETE_SUCCESS', () => {
+    it('resets state', () => {
+      const actual = reducer({ show: true, reservation: {} }, {
+        type: 'RESERVATION_DELETE_SUCCESS',
+      });
+      expect(actual).to.deep.equal(initialState);
+    });
+  });
+
   describe('RESERVATION_PUT_SUCCESS', () => {
     const reservation = { id: 'r-1', foo: 'bar' };
     const action = {


### PR DESCRIPTION
Adds cancel button to reservation info modal.

Opening another modal on top of the info modal might not be optimal
but was the quickest solution at this point.

Closes #506.