### PR TITLE
Show edit button only when it makes sense

### DIFF
--- a/app/shared/modals/reservation-info/ReservationEditForm.js
+++ b/app/shared/modals/reservation-info/ReservationEditForm.js
@@ -83,6 +83,7 @@ class UnconnectedReservationEditForm extends Component {
 
   render() {
     const {
+      allowEditing,
       handleSubmit,
       isAdmin,
       isEditing,
@@ -119,7 +120,7 @@ class UnconnectedReservationEditForm extends Component {
         {this.renderAddressRow('billingAddress')}
         {this.renderStaticInfoRow('accessCode')}
         {isAdmin && !reservationIsEditable && this.renderStaticInfoRow('comments')}
-        {isAdmin && reservationIsEditable && (
+        {isAdmin && allowEditing && reservationIsEditable && (
           <div className="form-controls">
             {!isEditing && (
               <Button
@@ -156,6 +157,7 @@ class UnconnectedReservationEditForm extends Component {
 }
 
 UnconnectedReservationEditForm.propTypes = {
+  allowEditing: PropTypes.bool.isRequired,
   handleSubmit: PropTypes.func.isRequired,
   isAdmin: PropTypes.bool.isRequired,
   isEditing: PropTypes.bool.isRequired,

--- a/app/shared/modals/reservation-info/ReservationEditForm.spec.js
+++ b/app/shared/modals/reservation-info/ReservationEditForm.spec.js
@@ -30,6 +30,7 @@ describe('shared/modals/reservation-info/ReservationEditForm', () => {
     resource: resource.id,
   });
   const defaultProps = {
+    allowEditing: false,
     handleSubmit: () => null,
     isAdmin: true,
     isEditing: false,
@@ -180,7 +181,17 @@ describe('shared/modals/reservation-info/ReservationEditForm', () => {
 
       it('are not rendered if user is not an admin', () => {
         const props = {
+          allowEditing: true,
           isAdmin: false,
+          reservationIsEditable: true,
+        };
+        expect(getFormControls(props)).to.have.length(0);
+      });
+
+      it('are not rendered if editing is not allowed', () => {
+        const props = {
+          allowEditing: false,
+          isAdmin: true,
           reservationIsEditable: true,
         };
         expect(getFormControls(props)).to.have.length(0);
@@ -188,6 +199,7 @@ describe('shared/modals/reservation-info/ReservationEditForm', () => {
 
       it('are not rendered if reservation is not editable', () => {
         const props = {
+          allowEditing: true,
           isAdmin: true,
           reservationIsEditable: false,
         };
@@ -196,6 +208,7 @@ describe('shared/modals/reservation-info/ReservationEditForm', () => {
 
       it('are rendered if user is admin and reservation is editable', () => {
         const props = {
+          allowEditing: true,
           isAdmin: true,
           reservationIsEditable: true,
         };
@@ -206,6 +219,7 @@ describe('shared/modals/reservation-info/ReservationEditForm', () => {
         function getEditButton(props) {
           const onStartEditClick = () => null;
           const defaults = {
+            allowEditing: true,
             isAdmin: true,
             onStartEditClick,
             reservationIsEditable: true,
@@ -227,6 +241,7 @@ describe('shared/modals/reservation-info/ReservationEditForm', () => {
         function getEditButton(props) {
           const onCancelEditClick = () => null;
           const defaults = {
+            allowEditing: true,
             isAdmin: true,
             onCancelEditClick,
             reservationIsEditable: true,
@@ -247,6 +262,7 @@ describe('shared/modals/reservation-info/ReservationEditForm', () => {
       describe('save button', () => {
         function getSaveButton(props) {
           const defaults = {
+            allowEditing: true,
             isAdmin: true,
             reservationIsEditable: true,
           };

--- a/app/shared/modals/reservation-info/ReservationInfoModal.js
+++ b/app/shared/modals/reservation-info/ReservationInfoModal.js
@@ -55,6 +55,11 @@ class ReservationInfoModal extends Component {
       reservation.state === 'confirmed' ||
       (reservation.state === 'requested' && !isAdmin)
     );
+    const allowEditing = Boolean(
+      (reservation.eventSubject || reservation.eventSubject === '') ||
+      (reservation.eventDescription || reservation.eventDescription === '') ||
+      (reservation.numberOfParticipants || reservation.numberOfParticipants === '')
+    );
 
     return (
       <Modal
@@ -71,6 +76,7 @@ class ReservationInfoModal extends Component {
             <div>
               <ReservationStateLabel reservation={reservation} />
               <ReservationEditForm
+                allowEditing={allowEditing}
                 initialValues={reservation}
                 isAdmin={isAdmin}
                 isEditing={isEditing}


### PR DESCRIPTION
Shows edit button only if reservation has editable fields.
This is quick fix before reservation times become editable. Then
all reservations will have editable fields.
Closes #550.