### PR TITLE
Improve admin reservation filters

### DIFF
--- a/app/pages/user-reservations/reservation-filters/AdminReservationFilters.js
+++ b/app/pages/user-reservations/reservation-filters/AdminReservationFilters.js
@@ -7,8 +7,19 @@ import constants from 'constants/AppConstants';
 import { injectT } from 'i18n';
 
 class AdminReservationFilters extends Component {
+  constructor(props) {
+    super(props);
+    this.handleChange = this.handleChange.bind(this);
+  }
+
+  handleChange({ value }) {
+    if (value) {
+      this.props.onFiltersChange({ state: value });
+    }
+  }
+
   render() {
-    const { filters, onFiltersChange, t } = this.props;
+    const { filters, t } = this.props;
     const stateOptions = [
       {
         label: t('AdminReservationFilters.allOptionLabel'),
@@ -33,8 +44,9 @@ class AdminReservationFilters extends Component {
           className="reservation-state-select"
           clearable={false}
           name="reservation-state-select"
-          onChange={option => onFiltersChange({ state: option.value })}
+          onChange={this.handleChange}
           options={stateOptions}
+          searchable={false}
           value={filters.state}
         />
       </div>


### PR DESCRIPTION
Small improvements to admin reservation filters functionality. (I noticed these while improving selects in #561)
- Removes searchability. There are only couple of options and without
searching the select is less confusing.
- Removes possibility for clearing the select value completely.