### PR TITLE
Reduce popover z-index properties for reservations

### DIFF
--- a/app/shared/availability-view/availability-view.less
+++ b/app/shared/availability-view/availability-view.less
@@ -266,6 +266,7 @@
 }
 
 .reservation-slot-popover {
+  z-index: 1000;
   .popover-content {
     display: flex;
     flex-wrap: nowrap;
@@ -280,6 +281,7 @@
   }
 }
 .reservation-popover {
+  z-index: 1000;
   hr {
     margin-top: 5px;
     margin-bottom: 5px;


### PR DESCRIPTION
Reduce popover z-index properties for reservations so popovers stay
behind modals.

Closes #602 .