### PR TITLE
Feature/701 more informative home page - part 1

### DIFF
--- a/app/shared/side-navbar/SideNavbar.js
+++ b/app/shared/side-navbar/SideNavbar.js
@@ -13,7 +13,7 @@ class SideNavbar extends Component {
     t: PropTypes.func.isRequired,
   };
 
-  state = { open: false };
+  state = { open: true };
 
   onToggleSideBar = () => {
     this.setState({ open: !this.state.open });

--- a/app/shared/side-navbar/SideNavbar.spec.js
+++ b/app/shared/side-navbar/SideNavbar.spec.js
@@ -27,7 +27,7 @@ describe('shared/side-navbar/SideNavbar', () => {
     expect(wrapper.prop('docked')).to.be.true;
     expect(wrapper.prop('className')).to.equal('app-SideNavbar');
     expect(wrapper.prop('onSetOpen')).to.equal(wrapper.instance().onSetSidebarOpen);
-    expect(wrapper.prop('open')).to.be.false;
+    expect(wrapper.prop('open')).to.be.true;
   });
 
   it('renders sidebar content', () => {
@@ -59,7 +59,7 @@ describe('shared/side-navbar/SideNavbar', () => {
   it('toggles open state when calling onToggleSideBar', () => {
     const wrapper = getWrapper();
     const instance = wrapper.instance();
-    expect(instance.state.open).to.be.false;
+    instance.state.open = false;
     instance.onToggleSideBar();
     expect(instance.state.open).to.be.true;
     instance.onToggleSideBar();
@@ -69,7 +69,7 @@ describe('shared/side-navbar/SideNavbar', () => {
   it('sets open state when calling onSetSidebarOpen', () => {
     const wrapper = getWrapper();
     const instance = wrapper.instance();
-    expect(instance.state.open).to.be.false;
+    instance.state.open = false;
     instance.onSetSidebarOpen(true);
     expect(instance.state.open).to.be.true;
     instance.onSetSidebarOpen(true);
@@ -81,14 +81,12 @@ describe('shared/side-navbar/SideNavbar', () => {
   it('sets closed state when calling closeSidebar', () => {
     const wrapper = getWrapper();
     const instance = wrapper.instance();
-    instance.setState({ open: true });
-    expect(instance.state.open).to.be.true;
+    instance.state.open = true;
     instance.closeSidebar();
     expect(instance.state.open).to.be.false;
     instance.closeSidebar();
     expect(instance.state.open).to.be.false;
   });
-
 
   describe('with initials', () => {
     it('renders initials in toggle', () => {

--- a/app/shared/sidebar/Sidebar.js
+++ b/app/shared/sidebar/Sidebar.js
@@ -17,7 +17,7 @@ Sidebar.defaultProps = {
 
 const styles = {
   sidebar: {
-    width: '100vw',
+    width: '90vw',
     maxWidth: '400px',
     zIndex: 20001,
   },


### PR DESCRIPTION
This PR:
- Makes the navbar open on initial page load by default.
- Makes sure the navbar never expands the whole screen even on smaller mobile devices.

Refs #701.