### PR TITLE
Avoid deep merging on SEARCH_RESULTS_GET_SUCCESS

### DIFF
--- a/app/state/reducers/dataReducer.js
+++ b/app/state/reducers/dataReducer.js
@@ -44,9 +44,12 @@ function dataReducer(state = initialState, action) {
     case types.API.PURPOSES_GET_SUCCESS:
     case types.API.RESERVATIONS_GET_SUCCESS:
     case types.API.RESOURCE_GET_SUCCESS:
-    case types.API.SEARCH_RESULTS_GET_SUCCESS:
     case types.API.UNITS_GET_SUCCESS: {
       return handleData(state, action.payload.entities);
+    }
+
+    case types.API.SEARCH_RESULTS_GET_SUCCESS: {
+      return state.merge(action.payload.entities);
     }
 
     case types.API.RESOURCES_GET_SUCCESS: {

--- a/app/state/reducers/dataReducer.spec.js
+++ b/app/state/reducers/dataReducer.spec.js
@@ -381,6 +381,49 @@ describe('state/reducers/dataReducer', () => {
       });
     });
 
+    describe('API.SEARCH_RESULTS_GET_SUCCESS', () => {
+      const searchResultsGetSuccess = createAction(
+        types.API.SEARCH_RESULTS_GET_SUCCESS,
+        resource => ({ entities: { resources: { [resource.id]: resource } } })
+      );
+
+      it('adds resources to state', () => {
+        const resource = Resource.build();
+        const initialState = Immutable({
+          resources: {},
+        });
+        const action = searchResultsGetSuccess(resource);
+        const nextState = dataReducer(initialState, action);
+
+        const expected = Immutable({
+          [resource.id]: resource,
+        });
+
+        expect(nextState.resources).to.deep.equal(expected);
+      });
+
+
+      it('does not keep old fields in resource', () => {
+        const originalResource = Resource.build({
+          distance: 400000,
+          state: 'requested',
+        });
+        const updatedResource = Resource.build({
+          id: originalResource.id,
+          state: 'confirmed',
+        });
+        const initialState = Immutable({
+          resources: { [originalResource.id]: originalResource },
+        });
+        const action = searchResultsGetSuccess(updatedResource);
+        const nextState = dataReducer(initialState, action);
+        const actualResource = nextState.resources[originalResource.id];
+
+        expect(actualResource).to.deep.equal(updatedResource);
+      });
+    });
+
+
     describe('API.USER_GET_SUCCESS', () => {
       const userGetSuccess = createAction(types.API.USER_GET_SUCCESS);
 


### PR DESCRIPTION
Deep merging was keeping fields like "distance" on the resource data.