### PR TITLE
Adjust positioning for date picker 

### DIFF
--- a/app/shared/date-picker/DatePicker.js
+++ b/app/shared/date-picker/DatePicker.js
@@ -6,11 +6,11 @@ import { DateField, DatePicker as RDPDatePicker } from 'react-date-picker';
 const dateFormat = 'YYYY-MM-DD';
 const localizedDateFormat = 'D.M.YYYY';
 
-
 DatePicker.propTypes = {
   dateFormat: PropTypes.string,
   formControl: PropTypes.bool,
   onChange: PropTypes.func.isRequired,
+  positionRight: PropTypes.bool,
   value: PropTypes.string.isRequired,
 };
 
@@ -21,7 +21,10 @@ function DatePicker(props) {
   }
   return (
     <DateField
-      className={classnames('date-picker', { 'form-control': props.formControl })}
+      className={classnames('date-picker', {
+        'date-picker--position-right': props.positionRight,
+        'form-control': props.formControl,
+      })}
       clearIcon={false}
       collapseOnDateClick
       dateFormat={pickerDateFormat}
@@ -31,10 +34,7 @@ function DatePicker(props) {
       updateOnDateClick
       value={moment(props.value).format(pickerDateFormat)}
     >
-      <RDPDatePicker
-        highlightWeekends={false}
-        weekNumbers={false}
-      />
+      <RDPDatePicker highlightWeekends={false} weekNumbers={false} />
     </DateField>
   );
 }

--- a/app/shared/date-picker/_date-picker.scss
+++ b/app/shared/date-picker/_date-picker.scss
@@ -7,7 +7,7 @@
     width: 70%;
   }
 
-  &.react-date-field--focused{
+  &.react-date-field--focused {
     border-color: $input-border-focus;
     box-shadow: $input-box-shadow-focus;
   }
@@ -49,12 +49,21 @@
     }
   }
 
-  & > .react-date-field__picker {
+  > .react-date-field__picker {
     // Forced width to avoid content hidden behind small container in IE11
     width: 282px;
   }
 
-  &.form-control[readOnly]{
+  &.form-control[readOnly] {
     background-color: $white;
+  }
+
+  &--position-right {
+    > .react-date-field__picker.react-date-picker__calendar {
+      @media (min-width: $screen-sm-min) {
+        left: auto;
+        right: -1px;
+      }
+    }
   }
 }

--- a/app/shared/recurring-reservation-controls/RecurringReservationControls.js
+++ b/app/shared/recurring-reservation-controls/RecurringReservationControls.js
@@ -52,7 +52,7 @@ function RecurringReservationControls({
             />
           </div>
         </Col>
-        {frequency !== '' &&
+        {frequency !== '' && (
           <Col sm={3} xs={12}>
             <FormGroup controlId="numberOfOccurrencesGroup">
               <ControlLabel>
@@ -66,22 +66,21 @@ function RecurringReservationControls({
               />
             </FormGroup>
           </Col>
-        }
-        {frequency !== '' &&
+        )}
+        {frequency !== '' && (
           <Col sm={4} xs={12}>
             <FormGroup controlId="LastTimeGroup">
-              <ControlLabel>
-                {t('RecurringReservationControls.lastTimeLabel')}
-              </ControlLabel>
+              <ControlLabel>{t('RecurringReservationControls.lastTimeLabel')}</ControlLabel>
               <DatePicker
                 dateFormat="D.M.YYYY"
                 formControl
                 onChange={changeLastTime}
+                positionRight
                 value={lastTime}
               />
             </FormGroup>
           </Col>
-        }
+        )}
       </Row>
     </div>
   );


### PR DESCRIPTION
- Add `positionRight` prop for DatePicker to optionally right-align calendar picker and corresponding input
-  Use the prop in RecurringReservationControls