### PR TITLE
If resource has external reservation url then hide status

### DIFF
--- a/app/shared/resource-card/ResourceAvailability.js
+++ b/app/shared/resource-card/ResourceAvailability.js
@@ -6,28 +6,19 @@ import { injectT } from 'i18n';
 import { getAvailabilityDataForNow, getAvailabilityDataForWholeDay } from 'utils/resourceUtils';
 
 function ResourceAvailability({ date, resource, t }) {
-  let status;
-  let bsStyle;
-  let values;
-
+  const { externalReservationUrl } = resource;
   const now = moment();
-  if (moment(date).isBefore(now, 'day')) {
+  if (moment(date).isBefore(now, 'day') || !!externalReservationUrl) {
     return <span />;
   }
 
-  if (moment(date).isSame(now, 'day')) {
-    const availabilityData = getAvailabilityDataForNow(resource, date);
-    bsStyle = availabilityData.bsStyle;
-    status = availabilityData.status;
-    values = availabilityData.values;
-  }
+  const availabilityData = moment(date).isSame(now, 'day')
+    ? getAvailabilityDataForNow(resource, date)
+    : getAvailabilityDataForWholeDay(resource, date);
 
-  if (moment(date).isAfter(now, 'day')) {
-    const availabilityData = getAvailabilityDataForWholeDay(resource, date);
-    bsStyle = availabilityData.bsStyle;
-    status = availabilityData.status;
-    values = availabilityData.values;
-  }
+  const bsStyle = availabilityData.bsStyle;
+  const status = availabilityData.status;
+  const values = availabilityData.values;
 
   return (
     <Label bsStyle={bsStyle} className="resource-availability">

--- a/app/shared/resource-card/ResourceAvailability.spec.js
+++ b/app/shared/resource-card/ResourceAvailability.spec.js
@@ -38,6 +38,27 @@ describe('shared/resource-list/ResourceAvailability', () => {
     });
   });
 
+  describe('if resource has an external reservation url', () => {
+    const resource = Resource.build({
+      externalReservationUrl: 'http://test.com',
+    });
+    const now = '2016-10-10T06:00:00+03:00';
+    const date = '2016-10-10';
+
+    beforeEach(() => {
+      MockDate.set(now);
+    });
+
+    afterEach(() => {
+      MockDate.reset();
+    });
+
+    it('renders an empty span', () => {
+      const wrapper = getWrapper({ date, resource });
+      expect(wrapper.equals(<span />)).to.be.true;
+    });
+  });
+
   describe('if date given in props is the current date', () => {
     const now = '2016-10-10T06:00:00+03:00';
     const date = '2016-10-10';


### PR DESCRIPTION
Fix for #820 
- Do not show reservation status if resource has an external reservation system