### PR TITLE
Show resource page back button only when coming from search results page

### DIFF
--- a/app/pages/resource/ResourcePage.js
+++ b/app/pages/resource/ResourcePage.js
@@ -141,6 +141,7 @@ class UnconnectedResourcePage extends Component {
 
     const mainImageIndex = findIndex(images, image => image.type === 'main');
     const mainImage = mainImageIndex != null ? images[mainImageIndex] : null;
+    const showBackButton = !!location.state && !!location.state.fromSearchResults;
 
     return (
       <div className="app-ResourcePage">
@@ -150,6 +151,7 @@ class UnconnectedResourcePage extends Component {
             onBackClick={this.handleBackButton}
             onMapClick={actions.toggleResourceMap}
             resource={resource}
+            showBackButton={showBackButton}
             showMap={showMap}
             unit={unit}
           />

--- a/app/pages/resource/resource-header/ResourceHeader.js
+++ b/app/pages/resource/resource-header/ResourceHeader.js
@@ -12,7 +12,16 @@ import iconClock from 'assets/icons/clock-o.svg';
 import iconMap from 'assets/icons/map.svg';
 import FavoriteButton from 'shared/favorite-button';
 
-function ResourceHeader({ onBackClick, onMapClick, isLoggedIn, resource, showMap, unit, t }) {
+function ResourceHeader({
+  onBackClick,
+  onMapClick,
+  isLoggedIn,
+  resource,
+  showBackButton,
+  showMap,
+  unit,
+  t,
+}) {
   const peopleCapacityText = t('ResourceCard.peopleCapacity', { people: resource.peopleCapacity });
   const maxPeriodText = getMaxPeriodText(t, resource);
   const priceText = getHourlyPrice(t, resource);
@@ -22,13 +31,15 @@ function ResourceHeader({ onBackClick, onMapClick, isLoggedIn, resource, showMap
     <section className="app-ResourceHeader">
       <Grid>
         <div className="app-ResourceHeader__content">
-          <Button
-            bsStyle="link"
-            className="app-ResourceHeader__back-button"
-            onClick={onBackClick}
-          >
-            {t('ResourceHeader.backButton')}
-          </Button>
+          {showBackButton && (
+            <Button
+              bsStyle="link"
+              className="app-ResourceHeader__back-button"
+              onClick={onBackClick}
+            >
+              {t('ResourceHeader.backButton')}
+            </Button>
+          )}
           <h1>{resource.name}</h1>
           <div className="app-ResourceHeader__info-wrapper">
             <div className="app-ResourceHeader__info">
@@ -36,7 +47,11 @@ function ResourceHeader({ onBackClick, onMapClick, isLoggedIn, resource, showMap
               <span className="app-ResourceHeader__info-label">{typeName}</span>
             </div>
             <div className="app-ResourceHeader__info">
-              <img alt={peopleCapacityText} className="app-ResourceHeader__info-icon" src={iconUser} />
+              <img
+                alt={peopleCapacityText}
+                className="app-ResourceHeader__info-icon"
+                src={iconUser}
+              />
               <span className="app-ResourceHeader__info-label">{peopleCapacityText}</span>
             </div>
             <div className="app-ResourceHeader__info">
@@ -52,24 +67,18 @@ function ResourceHeader({ onBackClick, onMapClick, isLoggedIn, resource, showMap
               <span className="app-ResourceHeader__info-label">{unit.name}</span>
             </div>
             <div className="app-ResourceHeader__buttons">
-              {!showMap &&
-                <Button
-                  className="app-ResourceHeader__map-button"
-                  onClick={onMapClick}
-                >
+              {!showMap && (
+                <Button className="app-ResourceHeader__map-button" onClick={onMapClick}>
                   <img alt={t('ResourceHeader.mapButton')} src={iconMap} />
                   <span>{t('ResourceHeader.mapButton')}</span>
                 </Button>
-              }
-              {showMap &&
-                <Button
-                  className="app-ResourceHeader__map-button"
-                  onClick={onMapClick}
-                >
+              )}
+              {showMap && (
+                <Button className="app-ResourceHeader__map-button" onClick={onMapClick}>
                   <img alt={t('ResourceHeader.resourceButton')} src={iconMap} />
                   <span>{t('ResourceHeader.resourceButton')}</span>
                 </Button>
-              }
+              )}
               {isLoggedIn && <FavoriteButton resource={resource} />}
             </div>
           </div>
@@ -84,11 +93,12 @@ ResourceHeader.propTypes = {
   onBackClick: PropTypes.func.isRequired,
   onMapClick: PropTypes.func.isRequired,
   resource: PropTypes.object.isRequired,
+  showBackButton: PropTypes.bool.isRequired,
   showMap: PropTypes.bool.isRequired,
   t: PropTypes.func.isRequired,
   unit: PropTypes.object.isRequired,
 };
 
-ResourceHeader = injectT(ResourceHeader);  // eslint-disable-line
+ResourceHeader = injectT(ResourceHeader); // eslint-disable-line
 
 export default ResourceHeader;

--- a/app/pages/resource/resource-header/ResourceHeader.spec.js
+++ b/app/pages/resource/resource-header/ResourceHeader.spec.js
@@ -16,6 +16,7 @@ describe('pages/resource/resource-header/ResourceHeader', () => {
     onMapClick: () => null,
     isLoggedIn: false,
     resource: Immutable(resource),
+    showBackButton: true,
     showMap: false,
     unit: Immutable(unit),
   };
@@ -25,11 +26,23 @@ describe('pages/resource/resource-header/ResourceHeader', () => {
   }
 
   describe('render', () => {
-    it('renders back button', () => {
-      const backButton = getWrapper().find('.app-ResourceHeader__back-button');
+    describe('Back button', () => {
+      it('renders when enabled', () => {
+        const backButton = getWrapper({ showBackButton: true }).find(
+          '.app-ResourceHeader__back-button'
+        );
 
-      expect(backButton).to.have.length(1);
-      expect(backButton.prop('onClick')).to.equal(defaultProps.onBackClick);
+        expect(backButton).to.have.length(1);
+        expect(backButton.prop('onClick')).to.equal(defaultProps.onBackClick);
+      });
+
+      it('does not render when not enabled', () => {
+        const backButton = getWrapper({ showBackButton: false }).find(
+          '.app-ResourceHeader__back-button'
+        );
+
+        expect(backButton).to.have.length(0);
+      });
     });
 
     it('renders title button', () => {

--- a/app/shared/resource-card/ResourceCard.js
+++ b/app/shared/resource-card/ResourceCard.js
@@ -13,39 +13,37 @@ import { injectT } from 'i18n';
 import iconMap from 'assets/icons/map.svg';
 import BackgroundImage from 'shared/background-image';
 import { getMainImage } from 'utils/imageUtils';
-import { getResourcePageUrl, getHourlyPrice } from 'utils/resourceUtils';
+import { getHourlyPrice, getResourcePageUrlComponents } from 'utils/resourceUtils';
 import ResourceAvailability from './ResourceAvailability';
 
 class ResourceCard extends Component {
-
   handleSearchByType = () => {
     const filters = { search: this.props.resource.type.name };
     browserHistory.push(`/search?${queryString.stringify(filters)}`);
-  }
+  };
 
   handleSearchByDistance = () => {
     const filters = { distance: this.props.resource.distance };
     browserHistory.push(`/search?${queryString.stringify(filters)}`);
-  }
+  };
 
   handleSearchByPeopleCapacity = () => {
     const filters = { people: this.props.resource.peopleCapacity };
     browserHistory.push(`/search?${queryString.stringify(filters)}`);
-  }
+  };
 
   handleSearchByUnit = () => {
     const filters = { unit: this.props.unit.id };
     browserHistory.push(`/search?${queryString.stringify(filters)}`);
-  }
+  };
 
   handleLinkClick = () => {
-    const scrollTop = window.pageYOffset ||
-      document.documentElement.scrollTop ||
-      document.body.scrollTop;
+    const scrollTop =
+      window.pageYOffset || document.documentElement.scrollTop || document.body.scrollTop;
     const { location } = this.props;
     const { pathname, search } = location;
     browserHistory.replace({ pathname, search, state: { scrollTop } });
-  }
+  };
 
   renderDistance(distance) {
     const km = distance / 1000;
@@ -58,25 +56,21 @@ class ResourceCard extends Component {
 
   render() {
     const { date, resource, t, unit } = this.props;
+    const { pathname, query } = getResourcePageUrlComponents(resource, date);
+    const linkTo = {
+      pathname,
+      search: query ? `?${query}` : undefined,
+      state: { fromSearchResults: true },
+    };
 
     return (
       <div
-        className={classnames(
-          'app-ResourceCard',
-          { 'app-ResourceCard__stacked': this.props.stacked },
-        )}
-
+        className={classnames('app-ResourceCard', {
+          'app-ResourceCard__stacked': this.props.stacked,
+        })}
       >
-        <Link
-          className="app-ResourceCard__image-link"
-          onClick={this.handleLinkClick}
-          to={getResourcePageUrl(resource, date)}
-        >
-          <BackgroundImage
-            height={420}
-            image={getMainImage(resource.images)}
-            width={700}
-          />
+        <Link className="app-ResourceCard__image-link" onClick={this.handleLinkClick} to={linkTo}>
+          <BackgroundImage height={420} image={getMainImage(resource.images)} width={700} />
         </Link>
         <div className="app-ResourceCard__content">
           <div className="app-ResourceCard__unit-name">
@@ -90,12 +84,10 @@ class ResourceCard extends Component {
             </a>
             <ResourceAvailability date={date} resource={resource} />
           </div>
-          <Link onClick={this.handleLinkClick} to={getResourcePageUrl(resource, date)}>
+          <Link onClick={this.handleLinkClick} to={linkTo}>
             <h4>{resource.name}</h4>
           </Link>
-          <div className="app-ResourceCard__description">
-            {resource.description}
-          </div>
+          <div className="app-ResourceCard__description">{resource.description}</div>
         </div>
         <div className="app-ResourceCard__info">
           <Col md={4} sm={2} xs={4}>
@@ -105,8 +97,14 @@ class ResourceCard extends Component {
               role="button"
               tabIndex="-1"
             >
-              <img alt={resource.type.name} className="app-ResourceCard__info-icon" src={iconHome} />
-              <span className="app-ResourceCard__info-label">{resource.type ? resource.type.name : '\u00A0'}</span>
+              <img
+                alt={resource.type.name}
+                className="app-ResourceCard__info-icon"
+                src={iconHome}
+              />
+              <span className="app-ResourceCard__info-label">
+                {resource.type ? resource.type.name : '\u00A0'}
+              </span>
             </a>
           </Col>
           <Col md={4} sm={2} xs={4}>
@@ -116,7 +114,11 @@ class ResourceCard extends Component {
               role="button"
               tabIndex="-1"
             >
-              <img alt={resource.peopleCapacity} className="app-ResourceCard__info-icon" src={iconUser} />
+              <img
+                alt={resource.peopleCapacity}
+                className="app-ResourceCard__info-icon"
+                src={iconUser}
+              />
               <span className="app-ResourceCard__info-label app-ResourceCard__peopleCapacity">
                 {t('ResourceCard.peopleCapacity', { people: resource.peopleCapacity })}
               </span>
@@ -124,7 +126,11 @@ class ResourceCard extends Component {
           </Col>
           <Col md={4} sm={2} xs={4}>
             <div className="app-ResourceCard__info-detail">
-              <img alt={resource.type.name} className="app-ResourceCard__info-icon" src={iconTicket} />
+              <img
+                alt={resource.type.name}
+                className="app-ResourceCard__info-icon"
+                src={iconTicket}
+              />
               <span className="app-ResourceCard__info-label app-ResourceCard__hourly-price">
                 {getHourlyPrice(t, resource) || '\u00A0'}
               </span>
@@ -133,8 +139,12 @@ class ResourceCard extends Component {
           <Col md={4} sm={3} xs={4}>
             <div className="app-ResourceCard__info-detail">
               <img alt={resource.type.name} className="app-ResourceCard__info-icon" src={iconMap} />
-              <span className="app-ResourceCard__info-label app-ResourceCard__street-address">{unit.streetAddress}</span>
-              <span className="app-ResourceCard__info-label app-ResourceCard__zip-address">{unit.addressZip} {unit.municipality}</span>
+              <span className="app-ResourceCard__info-label app-ResourceCard__street-address">
+                {unit.streetAddress}
+              </span>
+              <span className="app-ResourceCard__info-label app-ResourceCard__zip-address">
+                {unit.addressZip} {unit.municipality}
+              </span>
             </div>
           </Col>
           <Col md={4} sm={2} xs={4}>
@@ -144,7 +154,11 @@ class ResourceCard extends Component {
               role="button"
               tabIndex="-1"
             >
-              <img alt={resource.type.name} className="app-ResourceCard__info-icon" src={iconMapMarker} />
+              <img
+                alt={resource.type.name}
+                className="app-ResourceCard__info-icon"
+                src={iconMapMarker}
+              />
               <span className="app-ResourceCard__info-label app-ResourceCard__distance">
                 {resource.distance ? this.renderDistance(resource.distance) : '\u00A0'}
               </span>

--- a/app/shared/resource-card/ResourceCard.spec.js
+++ b/app/shared/resource-card/ResourceCard.spec.js
@@ -8,32 +8,34 @@ import BackgroundImage from 'shared/background-image';
 import Image from 'utils/fixtures/Image';
 import Resource from 'utils/fixtures/Resource';
 import Unit from 'utils/fixtures/Unit';
-import { getResourcePageUrl } from 'utils/resourceUtils';
+import { getResourcePageUrlComponents } from 'utils/resourceUtils';
 import { shallowWithIntl } from 'utils/testUtils';
 import ResourceAvailability from './ResourceAvailability';
 import ResourceCard from './ResourceCard';
 
 describe('shared/resource-card/ResourceCard', () => {
   function getResource(extra) {
-    return Immutable(Resource.build({
-      equipment: [
-        {
-          id: '1',
-          name: 'television',
+    return Immutable(
+      Resource.build({
+        equipment: [
+          {
+            id: '1',
+            name: 'television',
+          },
+          {
+            id: '2',
+            name: 'printer',
+          },
+        ],
+        images: [Image.build()],
+        maxPricePerHour: '30',
+        peopleCapacity: '16',
+        type: {
+          name: 'workplace',
         },
-        {
-          id: '2',
-          name: 'printer',
-        },
-      ],
-      images: [Image.build()],
-      maxPricePerHour: '30',
-      peopleCapacity: '16',
-      type: {
-        name: 'workplace',
-      },
-      ...extra,
-    }));
+        ...extra,
+      })
+    );
   }
   const defaultProps = {
     date: '2015-10-10',
@@ -46,13 +48,15 @@ describe('shared/resource-card/ResourceCard', () => {
       },
     },
     resource: getResource(),
-    unit: Immutable(Unit.build({
-      id: 'unit_value',
-      name: 'unit_name',
-      addressZip: '00100',
-      municipality: 'helsinki',
-      streetAddress: 'Fabiankatu',
-    })),
+    unit: Immutable(
+      Unit.build({
+        id: 'unit_value',
+        name: 'unit_name',
+        addressZip: '00100',
+        municipality: 'helsinki',
+        streetAddress: 'Fabiankatu',
+      })
+    ),
   };
 
   function getWrapper(extraProps) {
@@ -106,9 +110,7 @@ describe('shared/resource-card/ResourceCard', () => {
     it('renders distance', () => {
       const distanceLabel = getWrapper({
         resource: getResource({ distance: 11123 }),
-      }).find(
-        '.app-ResourceCard__distance'
-      );
+      }).find('.app-ResourceCard__distance');
 
       expect(distanceLabel).to.have.length(1);
       expect(distanceLabel.text()).to.equal('11 km');
@@ -117,9 +119,7 @@ describe('shared/resource-card/ResourceCard', () => {
     it('renders distance with a decimal if distance is smaller than 10 km', () => {
       const distanceLabel = getWrapper({
         resource: getResource({ distance: 123 }),
-      }).find(
-        '.app-ResourceCard__distance'
-      );
+      }).find('.app-ResourceCard__distance');
 
       expect(distanceLabel).to.have.length(1);
       expect(distanceLabel.text()).to.equal('0.1 km');
@@ -128,9 +128,7 @@ describe('shared/resource-card/ResourceCard', () => {
 
   describe('price', () => {
     it('renders a hourly price', () => {
-      const hourlyPriceSpan = getWrapper().find(
-        '.app-ResourceCard__hourly-price'
-      );
+      const hourlyPriceSpan = getWrapper().find('.app-ResourceCard__hourly-price');
 
       expect(hourlyPriceSpan.is('span')).to.be.true;
       expect(hourlyPriceSpan.text()).to.contain('30 €/h');
@@ -141,9 +139,7 @@ describe('shared/resource-card/ResourceCard', () => {
         maxPricePerHour: 0,
         minPricePerHour: 0,
       });
-      const hourlyPriceSpan = getWrapper({ resource }).find(
-        '.app-ResourceCard__hourly-price'
-      );
+      const hourlyPriceSpan = getWrapper({ resource }).find('.app-ResourceCard__hourly-price');
 
       expect(hourlyPriceSpan.is('span')).to.be.true;
       expect(hourlyPriceSpan.text()).to.contain('ResourceIcons.free');
@@ -154,9 +150,7 @@ describe('shared/resource-card/ResourceCard', () => {
         maxPricePerHour: '',
         minPricePerHour: '',
       });
-      const hourlyPriceSpan = getWrapper({ resource }).find(
-        '.app-ResourceCard__hourly-price'
-      );
+      const hourlyPriceSpan = getWrapper({ resource }).find('.app-ResourceCard__hourly-price');
 
       expect(hourlyPriceSpan.is('span')).to.be.true;
       expect(hourlyPriceSpan.text()).to.contain('ResourceIcons.free');
@@ -165,11 +159,16 @@ describe('shared/resource-card/ResourceCard', () => {
 
   it('contains links to correct resource page', () => {
     const links = getWrapper().find(Link);
-    const expectedUrl = getResourcePageUrl(defaultProps.resource, defaultProps.date);
+    const urlComponents = getResourcePageUrlComponents(defaultProps.resource, defaultProps.date);
+    const expected = {
+      pathname: urlComponents.pathname,
+      search: `?${urlComponents.query}`,
+      state: { fromSearchResults: true },
+    };
 
     expect(links.length).to.equal(2);
-    expect(links.at(0).props().to).to.equal(expectedUrl);
-    expect(links.at(1).props().to).to.equal(expectedUrl);
+    expect(links.at(0).props().to).to.deep.equal(expected);
+    expect(links.at(1).props().to).to.deep.equal(expected);
   });
 
   it('renders the name of the resource inside a h4 header', () => {
@@ -180,7 +179,9 @@ describe('shared/resource-card/ResourceCard', () => {
   });
 
   it('renders the name of the given unit in props', () => {
-    const unitName = getWrapper().find('.app-ResourceCard__unit-name').find('span');
+    const unitName = getWrapper()
+      .find('.app-ResourceCard__unit-name')
+      .find('span');
     const expected = defaultProps.unit.name;
 
     expect(unitName.text()).to.contain(expected);
@@ -213,7 +214,9 @@ describe('shared/resource-card/ResourceCard', () => {
   });
 
   it('renders the type of the given resource in props', () => {
-    const typeLabel = getWrapper().find('.app-ResourceCard__unit-name').find('span');
+    const typeLabel = getWrapper()
+      .find('.app-ResourceCard__unit-name')
+      .find('span');
     expect(typeLabel).to.have.length(1);
     expect(typeLabel.text()).to.equal(defaultProps.unit.name);
   });
@@ -236,7 +239,9 @@ describe('shared/resource-card/ResourceCard', () => {
     });
 
     it('calls browserHistory.push with correct path', () => {
-      getWrapper().instance().handleSearchByType();
+      getWrapper()
+        .instance()
+        .handleSearchByType();
       const actualPath = browserHistoryMock.lastCall.args[0];
       const expectedPath = '/search?search=workplace';
 
@@ -259,7 +264,9 @@ describe('shared/resource-card/ResourceCard', () => {
     it('calls browserHistory.push with correct path', () => {
       getWrapper({
         resource: getResource({ distance: 5000 }),
-      }).instance().handleSearchByDistance();
+      })
+        .instance()
+        .handleSearchByDistance();
       const actualPath = browserHistoryMock.lastCall.args[0];
       const expectedPath = '/search?distance=5000';
 
@@ -280,7 +287,9 @@ describe('shared/resource-card/ResourceCard', () => {
     });
 
     it('calls browserHistory.push with correct path', () => {
-      getWrapper().instance().handleSearchByPeopleCapacity();
+      getWrapper()
+        .instance()
+        .handleSearchByPeopleCapacity();
       const actualPath = browserHistoryMock.lastCall.args[0];
       const expectedPath = '/search?people=16';
 
@@ -301,7 +310,9 @@ describe('shared/resource-card/ResourceCard', () => {
     });
 
     it('calls browserHistory.push with correct path', () => {
-      getWrapper().instance().handleSearchByUnit();
+      getWrapper()
+        .instance()
+        .handleSearchByUnit();
       const actualPath = browserHistoryMock.lastCall.args[0];
       const expectedPath = '/search?unit=unit_value';
 
@@ -322,7 +333,9 @@ describe('shared/resource-card/ResourceCard', () => {
     });
 
     it('calls browserHistory.replace', () => {
-      getWrapper().instance().handleLinkClick();
+      getWrapper()
+        .instance()
+        .handleLinkClick();
 
       expect(browserHistoryMock.callCount).to.equal(1);
       expect(browserHistoryMock.lastCall.args).to.have.length(1);

--- a/app/utils/__tests__/resourceUtils.spec.js
+++ b/app/utils/__tests__/resourceUtils.spec.js
@@ -17,6 +17,7 @@ import {
   getResourcePageUrl,
   getTermsAndConditions,
   reservingIsRestricted,
+  getResourcePageUrlComponents,
 } from 'utils/resourceUtils';
 
 describe('Utils: resourceUtils', () => {
@@ -24,13 +25,16 @@ describe('Utils: resourceUtils', () => {
     const maxReservationsPerUser = 1;
     const now = '2015-10-10T06:00:00+03:00';
     describe('if has more own open reservations than maxReservationsPerUser', () => {
-      const reservations = [{
-        end: '2015-10-10T07:00:00+03:00',
-        isOwn: true,
-      }, {
-        end: '2015-10-10T08:00:00+03:00',
-        isOwn: false,
-      }];
+      const reservations = [
+        {
+          end: '2015-10-10T07:00:00+03:00',
+          isOwn: true,
+        },
+        {
+          end: '2015-10-10T08:00:00+03:00',
+          isOwn: false,
+        },
+      ];
       const resource = {
         maxReservationsPerUser,
         reservations,
@@ -48,13 +52,16 @@ describe('Utils: resourceUtils', () => {
       });
     });
     describe('if has more own passed reservations than maxReservationsPerUser', () => {
-      const reservations = [{
-        end: '2015-10-10T05:00:00+03:00',
-        isOwn: true,
-      }, {
-        end: '2015-10-10T08:00:00+03:00',
-        isOwn: false,
-      }];
+      const reservations = [
+        {
+          end: '2015-10-10T05:00:00+03:00',
+          isOwn: true,
+        },
+        {
+          end: '2015-10-10T08:00:00+03:00',
+          isOwn: false,
+        },
+      ];
       const resource = {
         maxReservationsPerUser,
         reservations,
@@ -385,11 +392,13 @@ describe('Utils: resourceUtils', () => {
 
     describe('if reserving is limited in a future date', () => {
       it('returns correct data', () => {
-        const openingHours = [{
-          opens: '2016-12-12T12:00:00+03:00',
-          closes: '2016-12-12T18:00:00+03:00',
-          date: '2016-12-12',
-        }];
+        const openingHours = [
+          {
+            opens: '2016-12-12T12:00:00+03:00',
+            closes: '2016-12-12T18:00:00+03:00',
+            date: '2016-12-12',
+          },
+        ];
         const date = '2016-12-12';
         const resource = { openingHours, reservableBefore: '2016-10-10' };
         const availabilityData = getAvailabilityDataForWholeDay(resource, date);
@@ -401,11 +410,13 @@ describe('Utils: resourceUtils', () => {
 
     describe('if there are no reservations', () => {
       it('returns the time between opening hours', () => {
-        const openingHours = [{
-          opens: '2015-10-10T12:00:00+03:00',
-          closes: '2015-10-10T18:00:00+03:00',
-          date: '2015-10-10',
-        }];
+        const openingHours = [
+          {
+            opens: '2015-10-10T12:00:00+03:00',
+            closes: '2015-10-10T18:00:00+03:00',
+            date: '2015-10-10',
+          },
+        ];
         const reservations = [];
         const resource = getResource(openingHours, reservations);
         const availabilityData = getAvailabilityDataForWholeDay(resource);
@@ -421,11 +432,13 @@ describe('Utils: resourceUtils', () => {
 
     describe('if there are reservations', () => {
       it('returns the time between opening hours minus reservations', () => {
-        const openingHours = [{
-          opens: '2015-10-10T12:00:00+03:00',
-          closes: '2015-10-10T18:00:00+03:00',
-          date: '2015-10-10',
-        }];
+        const openingHours = [
+          {
+            opens: '2015-10-10T12:00:00+03:00',
+            closes: '2015-10-10T18:00:00+03:00',
+            date: '2015-10-10',
+          },
+        ];
         const reservations = [
           {
             begin: '2015-10-10T13:00:00+03:00',
@@ -448,11 +461,13 @@ describe('Utils: resourceUtils', () => {
       });
 
       it('does not minus cancelled reservations from available time', () => {
-        const openingHours = [{
-          opens: '2015-10-10T12:00:00+03:00',
-          closes: '2015-10-10T18:00:00+03:00',
-          date: '2015-10-10',
-        }];
+        const openingHours = [
+          {
+            opens: '2015-10-10T12:00:00+03:00',
+            closes: '2015-10-10T18:00:00+03:00',
+            date: '2015-10-10',
+          },
+        ];
         const reservations = [
           {
             begin: '2015-10-10T13:00:00+03:00',
@@ -472,11 +487,13 @@ describe('Utils: resourceUtils', () => {
       });
 
       it('does not minus denied reservations from available time', () => {
-        const openingHours = [{
-          opens: '2015-10-10T12:00:00+03:00',
-          closes: '2015-10-10T18:00:00+03:00',
-          date: '2015-10-10',
-        }];
+        const openingHours = [
+          {
+            opens: '2015-10-10T12:00:00+03:00',
+            closes: '2015-10-10T18:00:00+03:00',
+            date: '2015-10-10',
+          },
+        ];
         const reservations = [
           {
             begin: '2015-10-10T13:00:00+03:00',
@@ -497,11 +514,13 @@ describe('Utils: resourceUtils', () => {
 
       describe('if the whole day is reserved', () => {
         it('returns correct data', () => {
-          const openingHours = [{
-            opens: '2015-10-10T12:00:00+03:00',
-            closes: '2015-10-10T18:00:00+03:00',
-            date: '2015-10-10',
-          }];
+          const openingHours = [
+            {
+              opens: '2015-10-10T12:00:00+03:00',
+              closes: '2015-10-10T18:00:00+03:00',
+              date: '2015-10-10',
+            },
+          ];
           const reservations = [
             {
               begin: '2015-10-10T12:00:00+03:00',
@@ -674,10 +693,7 @@ describe('Utils: resourceUtils', () => {
         { id: 4, state: 'something' },
       ];
       const resource = { reservations };
-      const expected = [
-        { id: 2, state: 'confirmed' },
-        { id: 4, state: 'something' },
-      ];
+      const expected = [{ id: 2, state: 'confirmed' }, { id: 4, state: 'something' }];
 
       expect(getOpenReservations(resource)).to.deep.equal(expected);
     });
@@ -690,10 +706,7 @@ describe('Utils: resourceUtils', () => {
         { id: 4, state: 'something' },
       ];
       const resource = { reservations };
-      const expected = [
-        { id: 2, state: 'confirmed' },
-        { id: 4, state: 'something' },
-      ];
+      const expected = [{ id: 2, state: 'confirmed' }, { id: 4, state: 'something' }];
 
       expect(getOpenReservations(resource)).to.deep.equal(expected);
     });
@@ -748,6 +761,67 @@ describe('Utils: resourceUtils', () => {
       const expected = `/resources/${resource.id}?${queryString.stringify({ date, time })}`;
 
       expect(resourcePageUrl).to.equal(expected);
+    });
+  });
+
+  describe('getResourcePageUrlComponents', () => {
+    it('returns an empty pathname and query if resource is undefined', () => {
+      const resource = undefined;
+      const resourcePageUrlComponents = getResourcePageUrlComponents(resource);
+
+      expect(resourcePageUrlComponents.pathname).to.equal('');
+      expect(resourcePageUrlComponents.query).to.equal('');
+    });
+
+    it('returns an empty string if resource does not have id', () => {
+      const resource = {};
+      const resourcePageUrlComponents = getResourcePageUrlComponents(resource);
+
+      expect(resourcePageUrlComponents.pathname).to.equal('');
+      expect(resourcePageUrlComponents.query).to.equal('');
+    });
+
+    it('returns correct url if date is not given', () => {
+      const resource = { id: 'some-id' };
+      const resourcePageUrlComponents = getResourcePageUrlComponents(resource);
+      const expected = `/resources/${resource.id}`;
+
+      expect(resourcePageUrlComponents.pathname).to.equal(expected);
+      expect(resourcePageUrlComponents.query).to.equal('');
+    });
+
+    it('returns correct url if date is given', () => {
+      const resource = { id: 'some-id' };
+      const date = '2015-10-10';
+      const resourcePageUrlComponents = getResourcePageUrlComponents(resource, date);
+      const expectedPathname = `/resources/${resource.id}`;
+      const expectedQuery = 'date=2015-10-10';
+
+      expect(resourcePageUrlComponents.pathname).to.equal(expectedPathname);
+      expect(resourcePageUrlComponents.query).to.equal(expectedQuery);
+    });
+
+    it('returns correct url if date is given in datetime format', () => {
+      const resource = { id: 'some-id' };
+      const date = '2015-10-10T08:00:00+03:00';
+      const resourcePageUrlComponents = getResourcePageUrlComponents(resource, date);
+      const expectedPathname = `/resources/${resource.id}`;
+      const expectedQuery = 'date=2015-10-10';
+
+      expect(resourcePageUrlComponents.pathname).to.equal(expectedPathname);
+      expect(resourcePageUrlComponents.query).to.equal(expectedQuery);
+    });
+
+    it('returns correct url if date and time are given', () => {
+      const resource = { id: 'some-id' };
+      const date = '2015-10-10';
+      const time = '2015-10-10T08:00:00+03:00';
+      const resourcePageUrlComponents = getResourcePageUrlComponents(resource, date, time);
+      const expectedPathname = `/resources/${resource.id}`;
+      const expectedQuery = queryString.stringify({ date, time });
+
+      expect(resourcePageUrlComponents.pathname).to.equal(expectedPathname);
+      expect(resourcePageUrlComponents.query).to.equal(expectedQuery);
     });
   });
 


### PR DESCRIPTION
- Add `showBackButton` prop to ResourceHeader
- ResourceCard will pass `fromSearchResults` in Link's location state for ResourcePage to determine if the back button should be shown