### PR TITLE
Search time range changes

### DIFF
--- a/app/assets/styles/_react-select.scss
+++ b/app/assets/styles/_react-select.scss
@@ -1,4 +1,5 @@
-.Select .Select-control {
+// Increase specificity with class name repetition
+.Select.Select .Select-control {
   border: 2px solid $input-border;
   border-radius: 2px;
   box-sizing: border-box;
@@ -17,7 +18,11 @@
     color: $dark-gray;
   }
 }
-.has-value.Select--single > .Select-control .Select-value .Select-value-label {
+
+.has-value.has-value.Select--single
+  > .Select-control
+  .Select-value
+  .Select-value-label {
   color: $black;
 }
 

--- a/app/constants/AppConstants.js
+++ b/app/constants/AppConstants.js
@@ -25,10 +25,7 @@ export default {
     'Accept-Language': 'fi',
     'Content-Type': 'application/json',
   },
-  REQUIRED_STAFF_EVENT_FIELDS: [
-    'eventDescription',
-    'reserverName',
-  ],
+  REQUIRED_STAFF_EVENT_FIELDS: ['eventDescription', 'reserverName'],
   RESERVATION_STATE_LABELS: {
     cancelled: {
       labelBsStyle: 'default',
@@ -64,6 +61,7 @@ export default {
     search: '',
     start: '',
     unit: '',
+    useTimeRange: false,
   },
   TIME_FORMAT: 'H:mm',
   TRACKING: SETTINGS.TRACKING,

--- a/app/i18n/messages/en.json
+++ b/app/i18n/messages/en.json
@@ -256,7 +256,7 @@
   "SideNavbar.close": "Close",
   "SideNavbar.toggle": "Guest",
   "TestSiteMessage.text": "This is the test version of Varaamo",
-  "TimeRangeControl.timeRangeTitle": "Time range and minimun duration",
+  "TimeRangeControl.timeRangeTitle": "Time range and minimum duration",
   "TimeRangeControl.title": "{date} at {start}-{end} {hours}h booking",
   "TimeSlot.available": "Free",
   "TimeSlot.editing": "Edited",

--- a/app/pages/search/controls/CheckboxControl.js
+++ b/app/pages/search/controls/CheckboxControl.js
@@ -1,18 +1,22 @@
 import React, { PropTypes } from 'react';
 import Toggle from 'react-toggle';
+import classnames from 'classnames';
 
 import { injectT } from 'i18n';
 
-function CheckboxControl({ id, label, onConfirm, value }) {
+function CheckboxControl({ id, label, labelClassName, onConfirm, toggleClassName, value }) {
+  const toggleClassNames = classnames('app-CheckboxControl__toggle', toggleClassName);
+  const labelClassNames = classnames('app-CheckboxControl__label', labelClassName);
+
   return (
     <div className="app-CheckboxControl">
       <Toggle
-        className="app-CheckboxControl__toggle"
+        className={toggleClassNames}
         defaultChecked={value}
         id={id}
         onChange={e => onConfirm(e.target.checked)}
       />
-      <label className="app-CheckboxControl__label" htmlFor={id}>
+      <label className={labelClassNames} htmlFor={id}>
         {label}
       </label>
     </div>
@@ -22,7 +26,9 @@ function CheckboxControl({ id, label, onConfirm, value }) {
 CheckboxControl.propTypes = {
   id: PropTypes.string.isRequired,
   label: PropTypes.string.isRequired,
+  labelClassName: PropTypes.string,
   onConfirm: PropTypes.func.isRequired,
+  toggleClassName: PropTypes.string,
   value: PropTypes.bool,
 };
 

--- a/app/pages/search/controls/DatePickerControl.js
+++ b/app/pages/search/controls/DatePickerControl.js
@@ -9,10 +9,6 @@ import moment from 'moment';
 import MomentLocaleUtils from 'react-day-picker/moment';
 
 import { injectT } from 'i18n';
-import {
-  calculateDuration,
-  calculateEndTime,
-} from 'utils/timeUtils';
 import SearchControlOverlay from './SearchControlOverlay';
 import iconCalendar from './images/calendar.svg';
 
@@ -20,60 +16,46 @@ class DatePickerControl extends React.Component {
   static propTypes = {
     currentLanguage: PropTypes.string.isRequired,
     date: PropTypes.string,
-    duration: PropTypes.number,
-    end: PropTypes.string,
     onConfirm: PropTypes.func.isRequired,
-    start: PropTypes.string,
     t: PropTypes.func.isRequired,
   };
 
   constructor(props) {
     super(props);
-    const { date, duration, end, start } = this.props;
+    const { date } = this.props;
     this.state = {
       date,
-      duration,
-      end,
-      start,
       visible: false,
     };
   }
 
   componentWillUpdate(nextProps) {
-    const { date, duration, end, start } = nextProps;
-    if (date !== this.props.date || duration !== this.props.duration ||
-      end !== this.props.end || start !== this.props.start) {
-      this.setState({ date, duration, end, start });
+    const { date } = nextProps;
+    if (date !== this.props.date) {
+      this.setState({ date });
     }
   }
 
   hideOverlay = () => {
     this.setState({ visible: false });
-  }
+  };
 
   showOverlay = () => {
     this.setState({ visible: true });
-  }
+  };
 
   handleConfirm = (value) => {
-    const { duration, end, start } = this.state;
     const date = value;
-    this.props.onConfirm({ date, duration, end, start });
+    this.props.onConfirm({ date });
     this.hideOverlay();
-  }
-
-  handleTimeRange = ({ duration, end, start }) => {
-    const { date } = this.state;
-    const endValue = calculateEndTime(end, start);
-    const durationValue = calculateDuration(duration, start, endValue);
-    this.setState({ duration: durationValue, start, end: endValue, visible: false });
-    this.props.onConfirm({ date, duration: durationValue, end: endValue, start });
-  }
+  };
 
   render() {
     const { currentLanguage, t } = this.props;
     const { date } = this.state;
-    const selectedDay = moment(date, 'L').startOf('day').toDate();
+    const selectedDay = moment(date, 'L')
+      .startOf('day')
+      .toDate();
 
     return (
       <div className="app-DatePickerControl">
@@ -96,10 +78,7 @@ class DatePickerControl extends React.Component {
           rootClose
           show={this.state.visible}
         >
-          <SearchControlOverlay
-            onHide={this.hideOverlay}
-            title={t('DatePickerControl.header')}
-          >
+          <SearchControlOverlay onHide={this.hideOverlay} title={t('DatePickerControl.header')}>
             <DayPicker
               disabledDays={day => new Date(day).setHours(23, 59, 59, 59) < new Date()}
               enableOutsideDays

--- a/app/pages/search/controls/DatePickerControl.spec.js
+++ b/app/pages/search/controls/DatePickerControl.spec.js
@@ -71,7 +71,9 @@ describe('pages/search/controls/DatePickerControl', () => {
   });
 
   it('renders DayPicker for selecting date', () => {
-    const expected = moment(defaults.date).startOf('day').toDate();
+    const expected = moment(defaults.date)
+      .startOf('day')
+      .toDate();
     const wrapper = getWrapper();
     const dayPicker = wrapper.find(DayPicker);
     expect(dayPicker).to.have.length(1);
@@ -131,25 +133,11 @@ describe('pages/search/controls/DatePickerControl', () => {
     });
   });
 
-  describe('componentWillUpdate', () => {
-    it('updates state with correct values', () => {
-      const duration = 90;
-      const end = '15:00';
-      const start = '11:00';
-      const instance = getWrapper().instance();
-      instance.componentWillUpdate({ duration, end, start });
-      expect(instance.state.duration).to.equal(duration);
-      expect(instance.state.end).to.equal(end);
-      expect(instance.state.start).to.equal(start);
-    });
-  });
-
   describe('handleConfirm', () => {
     it('calls onConfirm with correct value', () => {
       const onConfirm = simple.mock();
       const date = '12.12.2017';
-      const { duration, end, start } = defaults;
-      const expected = { date, duration, end, start };
+      const expected = { date };
       const instance = getWrapper({ onConfirm }).instance();
       instance.handleConfirm(date);
       expect(onConfirm.callCount).to.equal(1);
@@ -162,45 +150,6 @@ describe('pages/search/controls/DatePickerControl', () => {
       instance.handleConfirm();
       expect(instance.hideOverlay.callCount).to.equal(1);
       simple.restore();
-    });
-  });
-
-  describe('handleTimeRange', () => {
-    it('calls onConfirm with correct value', () => {
-      const onConfirm = simple.mock();
-      const { date } = defaults;
-      const duration = 60;
-      const end = '18:00';
-      const start = '10:00';
-      const props = { duration, end, start };
-      const expected = { ...props, date };
-      const instance = getWrapper({ onConfirm }).instance();
-      instance.state.visible = true;
-      instance.handleTimeRange(props);
-
-      expect(onConfirm.callCount).to.equal(1);
-      expect(onConfirm.lastCall.args).to.deep.equal([expected]);
-      expect(instance.state.duration).to.equal(duration);
-      expect(instance.state.end).to.equal(end);
-      expect(instance.state.start).to.equal(start);
-      expect(instance.state.visible).to.be.false;
-    });
-
-    it('calls onConfirm with correct end value when start is after end', () => {
-      const onConfirm = simple.mock();
-      const { date } = defaults;
-      const duration = 30;
-      const end = '09:00';
-      const start = '10:00';
-      const expectedEnd = '10:30';
-      const props = { duration, end, start };
-      const expected = { ...props, date, end: expectedEnd };
-      const instance = getWrapper({ onConfirm }).instance();
-      instance.handleTimeRange(props);
-
-      expect(onConfirm.callCount).to.equal(1);
-      expect(onConfirm.lastCall.args).to.deep.equal([expected]);
-      expect(instance.state.end).to.equal(expectedEnd);
     });
   });
 

--- a/app/pages/search/controls/PositionControl.js
+++ b/app/pages/search/controls/PositionControl.js
@@ -1,9 +1,9 @@
 import React, { PropTypes } from 'react';
-import Toggle from 'react-toggle';
 import { createSliderWithTooltip } from 'rc-slider';
 import Slider from 'rc-slider/lib/Slider';
 
 import { injectT } from 'i18n';
+import CheckboxControl from './CheckboxControl';
 
 const TooltipSlider = createSliderWithTooltip(Slider);
 
@@ -26,14 +26,14 @@ class PositionControl extends React.Component {
     };
   }
 
-  handleToggleChange = (e) => {
-    this.setState({ toggled: e.target.checked });
-    this.props.onPositionSwitch(e);
-  }
+  handleToggleChange = (value) => {
+    this.setState({ toggled: value });
+    this.props.onPositionSwitch();
+  };
 
   handleDistanceSliderChange = (value) => {
     this.setState({ distance: value });
-  }
+  };
 
   handleConfirm = (value) => {
     if (value > this.state.maxDistance) {
@@ -41,28 +41,28 @@ class PositionControl extends React.Component {
     } else {
       this.props.onConfirm(value);
     }
-  }
+  };
 
-  distanceFormatter = value => (
-    value > this.state.maxDistance ?
-    this.props.t('PositionControl.noDistanceLimit') :
-    `${value / 1000} km`
-  );
+  distanceFormatter = (value) => {
+    if (value > this.state.maxDistance) {
+      return this.props.t('PositionControl.noDistanceLimit');
+    }
+    return `${value / 1000} km`;
+  };
 
   render() {
     const { t, geolocated } = this.props;
     return (
       <div className="app-PositionControl">
-        <Toggle
-          className="app-PositionControl__geolocation-toggle"
-          defaultChecked={geolocated}
+        <CheckboxControl
           id="geolocation-status"
-          onChange={this.handleToggleChange}
+          label={t('PositionControl.useDistance')}
+          labelClassName="app-SearchControlsCheckbox__label"
+          onConfirm={this.handleToggleChange}
+          toggleClassName="app-SearchControlsCheckbox__toggle"
+          value={geolocated}
         />
-        <label className="app-PositionControl__label" htmlFor="geolocation-status">
-          {t('PositionControl.useDistance')}
-        </label>
-        {this.state.toggled &&
+        {this.state.toggled && (
           <TooltipSlider
             className="app-PositionControl__distance_slider"
             disabled={!this.state.toggled}
@@ -75,12 +75,12 @@ class PositionControl extends React.Component {
             tipProps={{ overlayClassName: 'app-PositionControl__distance_slider_tooltip' }}
             value={this.state.distance}
           />
-        }
-        {this.state.toggled &&
+        )}
+        {this.state.toggled && (
           <div>
             {t('PositionControl.maxDistance')}: {this.distanceFormatter(this.state.distance)}
           </div>
-        }
+        )}
       </div>
     );
   }

--- a/app/pages/search/controls/PositionControl.spec.js
+++ b/app/pages/search/controls/PositionControl.spec.js
@@ -1,10 +1,10 @@
 import { expect } from 'chai';
 import React from 'react';
 import simple from 'simple-mock';
-import Toggle from 'react-toggle';
 
 import { shallowWithIntl } from 'utils/testUtils';
 import PositionControl from './PositionControl';
+import CheckboxControl from './CheckboxControl';
 
 function getWrapper(props) {
   const defaults = {
@@ -22,12 +22,12 @@ describe('pages/search/controls/PositionControl', () => {
     expect(wrapper.is('div.app-PositionControl')).to.be.true;
   });
 
-  it('renders a Toggle with correct props', () => {
+  it('renders a CheckboxControl with correct props', () => {
     const wrapper = getWrapper({ geolocated: true });
-    const modal = wrapper.find(Toggle);
+    const modal = wrapper.find(CheckboxControl);
     expect(modal).to.have.length(1);
-    expect(modal.prop('defaultChecked')).to.be.true;
-    expect(modal.prop('onChange')).to.equal(wrapper.instance().handleToggleChange);
+    expect(modal.prop('value')).to.be.true;
+    expect(modal.prop('onConfirm')).to.equal(wrapper.instance().handleToggleChange);
   });
 
   it('renders a slider with correct props if geolocation toggle is on', () => {
@@ -72,17 +72,15 @@ describe('pages/search/controls/PositionControl', () => {
   describe('handleToggleChange', () => {
     it('calls onPositionSwitch', () => {
       const onPositionSwitch = simple.mock();
-      const value = { target: { checked: true } };
       const instance = getWrapper({ onPositionSwitch }).instance();
-      instance.handleToggleChange(value);
+      instance.handleToggleChange(true);
       expect(onPositionSwitch.callCount).to.equal(1);
-      expect(onPositionSwitch.lastCall.args).to.deep.equal([value]);
     });
 
     it('sets toggled state', () => {
       const instance = getWrapper().instance();
       expect(instance.state.toggled).to.be.false;
-      const value = { target: { checked: true } };
+      const value = true;
       instance.handleToggleChange(value);
       expect(instance.state.toggled).to.be.true;
     });

--- a/app/pages/search/controls/SearchControlsContainer.js
+++ b/app/pages/search/controls/SearchControlsContainer.js
@@ -209,7 +209,9 @@ class UnconnectedSearchControlsContainer extends Component {
                   <CheckboxControl
                     id="charge"
                     label={t('SearchControlsContainer.chargeLabel')}
+                    labelClassName="app-SearchControlsCheckbox__label"
                     onConfirm={value => this.handleFiltersChange({ charge: value })}
+                    toggleClassName="app-SearchControlsCheckbox__toggle"
                     value={filters.charge}
                   />
                 </Col>

--- a/app/pages/search/controls/SearchControlsContainer.js
+++ b/app/pages/search/controls/SearchControlsContainer.js
@@ -31,7 +31,6 @@ import TimeRangeControl from './TimeRangeControl';
 import iconTimes from './images/times.svg';
 
 class UnconnectedSearchControlsContainer extends Component {
-
   componentDidMount() {
     const { actions, urlSearchFilters } = this.props;
     actions.changeSearchFilters(urlSearchFilters);
@@ -64,20 +63,18 @@ class UnconnectedSearchControlsContainer extends Component {
   }
 
   handleDateChange = ({ date, duration, end, start }) => {
-    const dateInCorrectFormat = (
-      moment(date, 'L').format(constants.DATE_FORMAT)
-    );
+    const dateInCorrectFormat = moment(date, 'L').format(constants.DATE_FORMAT);
     this.handleFiltersChange({
       date: dateInCorrectFormat,
       duration,
       end,
       start,
     });
-  }
+  };
 
   handleFiltersChange = (newFilters) => {
     this.props.actions.changeSearchFilters(newFilters);
-  }
+  };
 
   handlePositionSwitch = () => {
     if (!this.props.position) {
@@ -85,11 +82,11 @@ class UnconnectedSearchControlsContainer extends Component {
     } else {
       this.props.actions.disableGeoposition();
     }
-  }
+  };
 
   handleSearchBoxChange = (value) => {
     this.props.actions.changeSearchFilters({ search: value });
-  }
+  };
 
   handleTimeRangeChange = ({ duration, end, start }) => {
     this.handleFiltersChange({
@@ -97,7 +94,7 @@ class UnconnectedSearchControlsContainer extends Component {
       end,
       start,
     });
-  }
+  };
 
   handleTimeRangeSwitch = (value) => {
     if (value) {
@@ -105,7 +102,7 @@ class UnconnectedSearchControlsContainer extends Component {
     } else {
       this.props.actions.disableTimeRange();
     }
-  }
+  };
 
   handleSearch = (newFilters = {}, options = {}) => {
     const { scrollToSearchResults } = this.props;
@@ -115,7 +112,7 @@ class UnconnectedSearchControlsContainer extends Component {
     if (!options.preventScrolling) {
       scrollToSearchResults();
     }
-  }
+  };
 
   handleReset = () => {
     const emptyFilters = Object.assign({}, constants.SUPPORTED_SEARCH_FILTERS);
@@ -123,7 +120,7 @@ class UnconnectedSearchControlsContainer extends Component {
       this.props.actions.disableGeoposition();
     }
     this.handleFiltersChange(emptyFilters);
-  }
+  };
 
   render() {
     const {
@@ -208,6 +205,7 @@ class UnconnectedSearchControlsContainer extends Component {
                     onChange={this.handleTimeRangeChange}
                     onTimeRangeSwitch={this.handleTimeRangeSwitch}
                     start={filters.start}
+                    useTimeRange={filters.useTimeRange}
                   />
                 </Col>
                 <Col className="app-SearchControlsContainer__control" md={4} sm={6}>
@@ -231,7 +229,7 @@ class UnconnectedSearchControlsContainer extends Component {
                 >
                   {t('SearchControlsContainer.searchButton')}
                 </Button>
-                {hasFilters &&
+                {hasFilters && (
                   <Button
                     bsStyle="link"
                     className="app-SearchControlsContainer__reset-button"
@@ -241,7 +239,7 @@ class UnconnectedSearchControlsContainer extends Component {
                     <img alt="" src={iconTimes} />
                     {t('SearchControlsContainer.resetButton')}
                   </Button>
-                }
+                )}
               </Col>
             </Row>
           </div>
@@ -281,6 +279,7 @@ function mapDispatchToProps(dispatch) {
 }
 
 export { UnconnectedSearchControlsContainer };
-export default connect(searchControlsSelector, mapDispatchToProps)(
-  UnconnectedSearchControlsContainer
-);
+export default connect(
+  searchControlsSelector,
+  mapDispatchToProps
+)(UnconnectedSearchControlsContainer);

--- a/app/pages/search/controls/SearchControlsContainer.js
+++ b/app/pages/search/controls/SearchControlsContainer.js
@@ -62,13 +62,10 @@ class UnconnectedSearchControlsContainer extends Component {
     return hasFilters;
   }
 
-  handleDateChange = ({ date, duration, end, start }) => {
+  handleDateChange = ({ date }) => {
     const dateInCorrectFormat = moment(date, 'L').format(constants.DATE_FORMAT);
     this.handleFiltersChange({
       date: dateInCorrectFormat,
-      duration,
-      end,
-      start,
     });
   };
 

--- a/app/pages/search/controls/SearchControlsContainer.spec.js
+++ b/app/pages/search/controls/SearchControlsContainer.spec.js
@@ -15,9 +15,7 @@ import PositionControl from './PositionControl';
 import SearchBox from './SearchBox';
 import SelectControl from './SelectControl';
 import TimeRangeControl from './TimeRangeControl';
-import {
-  UnconnectedSearchControlsContainer as SearchControlsContainer,
-} from './SearchControlsContainer';
+import { UnconnectedSearchControlsContainer as SearchControlsContainer } from './SearchControlsContainer';
 
 describe('pages/search/controls/SearchControlsContainer', () => {
   const defaultProps = {
@@ -123,7 +121,9 @@ describe('pages/search/controls/SearchControlsContainer', () => {
       expect(selectControl).to.have.length(3);
       expect(selectControl.at(2).prop('id')).to.equal('people');
       expect(selectControl.at(2).prop('isLoading')).to.equal(defaultProps.isFetchingPurposes);
-      expect(selectControl.at(2).prop('label')).to.equal('SearchControlsContainer.peopleCapacityLabel');
+      expect(selectControl.at(2).prop('label')).to.equal(
+        'SearchControlsContainer.peopleCapacityLabel'
+      );
       expect(selectControl.at(2).prop('onConfirm')).to.exist;
       expect(selectControl.at(2).prop('options')).to.deep.equal(peopleOptions);
       expect(selectControl.at(2).prop('value')).to.equal(defaultProps.filters.people);
@@ -150,7 +150,9 @@ describe('pages/search/controls/SearchControlsContainer', () => {
       expect(timeRangeControl.prop('duration')).to.equal(filters.duration);
       expect(timeRangeControl.prop('end')).to.equal(filters.end);
       expect(timeRangeControl.prop('onChange')).to.equal(wrapper.instance().handleTimeRangeChange);
-      expect(timeRangeControl.prop('onTimeRangeSwitch')).to.equal(wrapper.instance().handleTimeRangeSwitch);
+      expect(timeRangeControl.prop('onTimeRangeSwitch')).to.equal(
+        wrapper.instance().handleTimeRangeSwitch
+      );
       expect(timeRangeControl.prop('start')).to.equal(filters.start);
     });
 
@@ -279,8 +281,8 @@ describe('pages/search/controls/SearchControlsContainer', () => {
   });
 
   describe('handleDateChange', () => {
-    const { date, duration, end, start } = defaultProps.filters;
-    const expected = { date, duration, end, start };
+    const { date } = defaultProps.filters;
+    const expected = { date };
     let instance;
 
     before(() => {
@@ -376,7 +378,9 @@ describe('pages/search/controls/SearchControlsContainer', () => {
 
     before(() => {
       browserHistoryMock = simple.mock(browserHistory, 'push');
-      getWrapper().instance().handleSearch(newFilters);
+      getWrapper()
+        .instance()
+        .handleSearch(newFilters);
     });
 
     after(() => {
@@ -427,7 +431,9 @@ describe('pages/search/controls/SearchControlsContainer', () => {
         fetchPurposes: simple.mock(),
         changeSearchFilters: () => null,
       };
-      getWrapper({ actions }).instance().componentDidMount();
+      getWrapper({ actions })
+        .instance()
+        .componentDidMount();
 
       expect(actions.fetchPurposes.callCount).to.equal(1);
     });

--- a/app/pages/search/controls/TimeRangeControl.js
+++ b/app/pages/search/controls/TimeRangeControl.js
@@ -14,6 +14,7 @@ class TimeRangeControl extends React.Component {
     onTimeRangeSwitch: PropTypes.func.isRequired,
     start: PropTypes.string,
     t: PropTypes.func.isRequired,
+    useTimeRange: PropTypes.bool.isRequired,
   };
 
   constructor(props) {
@@ -25,8 +26,10 @@ class TimeRangeControl extends React.Component {
 
   getEndTimeOptions() {
     const { start } = this.props;
-    const startTime = moment(start, constants.FILTER.timeFormat)
-      .add(constants.FILTER.timePeriod, constants.FILTER.timePeriodType);
+    const startTime = moment(start, constants.FILTER.timeFormat).add(
+      constants.FILTER.timePeriod,
+      constants.FILTER.timePeriodType
+    );
     const endOfDay = moment('23:30', constants.FILTER.timeFormat);
     return this.getTimeOptions(startTime, endOfDay);
   }
@@ -71,10 +74,7 @@ class TimeRangeControl extends React.Component {
 
   getTimeOptions(start, end) {
     const range = moment.range(start, end);
-    const duration = moment.duration(
-      constants.FILTER.timePeriod,
-      constants.FILTER.timePeriodType,
-    );
+    const duration = moment.duration(constants.FILTER.timePeriod, constants.FILTER.timePeriodType);
     const options = [];
     range.by(duration, (time) => {
       const value = time.format(constants.FILTER.timeFormat);
@@ -106,11 +106,10 @@ class TimeRangeControl extends React.Component {
 
   handleToggleChange = (e) => {
     this.props.onTimeRangeSwitch(e.target.checked);
-  }
+  };
 
   render() {
-    const { duration, end, start, t } = this.props;
-    const useTimeRange = Boolean(duration && end && start);
+    const { duration, end, start, t, useTimeRange } = this.props;
 
     return (
       <div className="app-TimeRangeControl">
@@ -123,41 +122,40 @@ class TimeRangeControl extends React.Component {
         <label className="app-TimeRangeControl__label" htmlFor="timerange-status">
           {t('TimeRangeControl.timeRangeTitle')}
         </label>
-        {useTimeRange &&
-          <div className="app-TimeRangeControl__range">
-            <Select
-              className="app-TimeRangeControl__range-start"
-              clearable={false}
-              name="time-filter-start-select"
-              onChange={this.handleStart}
-              options={this.getStartTimeOptions()}
-              placeholder=""
-              searchable={false}
-              value={start}
-            />
-            <div className="app-TimeRangeControl__range-separator">-</div>
-            <Select
-              className="app-TimeRangeControl__range-end"
-              clearable={false}
-              name="time-filter-end-select"
-              onChange={this.handleEnd}
-              options={this.getEndTimeOptions()}
-              placeholder=""
-              searchable={false}
-              value={end}
-            />
-            <Select
-              className="app-TimeRangeControl__range-duration"
-              clearable={false}
-              name="time-filter-duration-select"
-              onChange={this.handleDuration}
-              options={this.getDurationOptions()}
-              placeholder=""
-              searchable={false}
-              value={duration}
-            />
-          </div>
-        }
+
+        <div className="app-TimeRangeControl__range">
+          <Select
+            className="app-TimeRangeControl__range-start"
+            clearable={false}
+            name="time-filter-start-select"
+            onChange={this.handleStart}
+            options={this.getStartTimeOptions()}
+            placeholder=""
+            searchable={false}
+            value={start}
+          />
+          <div className="app-TimeRangeControl__range-separator">-</div>
+          <Select
+            className="app-TimeRangeControl__range-end"
+            clearable={false}
+            name="time-filter-end-select"
+            onChange={this.handleEnd}
+            options={this.getEndTimeOptions()}
+            placeholder=""
+            searchable={false}
+            value={end}
+          />
+          <Select
+            className="app-TimeRangeControl__range-duration"
+            clearable={false}
+            name="time-filter-duration-select"
+            onChange={this.handleDuration}
+            options={this.getDurationOptions()}
+            placeholder=""
+            searchable={false}
+            value={duration}
+          />
+        </div>
       </div>
     );
   }

--- a/app/pages/search/controls/TimeRangeControl.js
+++ b/app/pages/search/controls/TimeRangeControl.js
@@ -1,11 +1,11 @@
 import React, { PropTypes } from 'react';
 import Select from 'react-select';
-import Toggle from 'react-toggle';
 import moment from 'moment';
 
 import { injectT } from 'i18n';
 import constants from 'constants/AppConstants';
 import { calculateDuration, calculateEndTime } from 'utils/timeUtils';
+import CheckboxControl from './CheckboxControl';
 
 class TimeRangeControl extends React.Component {
   static propTypes = {
@@ -108,8 +108,8 @@ class TimeRangeControl extends React.Component {
     onChange({ duration: durationValue, end: endValue, start });
   }
 
-  handleToggleChange = (e) => {
-    this.props.onTimeRangeSwitch(e.target.checked);
+  handleToggleChange = (value) => {
+    this.props.onTimeRangeSwitch(value);
   };
 
   render() {
@@ -117,16 +117,14 @@ class TimeRangeControl extends React.Component {
 
     return (
       <div className="app-TimeRangeControl">
-        <Toggle
-          checked={useTimeRange}
-          className="app-TimeRangeControl-toggle"
+        <CheckboxControl
           id="timerange-status"
-          onChange={this.handleToggleChange}
+          label={t('TimeRangeControl.timeRangeTitle')}
+          labelClassName="app-SearchControlsCheckbox__label"
+          onConfirm={this.handleToggleChange}
+          toggleClassName="app-SearchControlsCheckbox__toggle"
+          value={useTimeRange}
         />
-        <label className="app-TimeRangeControl__label" htmlFor="timerange-status">
-          {t('TimeRangeControl.timeRangeTitle')}
-        </label>
-
         <div className="app-TimeRangeControl__range">
           <Select
             className="app-TimeRangeControl__range-start"

--- a/app/pages/search/controls/TimeRangeControl.js
+++ b/app/pages/search/controls/TimeRangeControl.js
@@ -5,6 +5,7 @@ import moment from 'moment';
 
 import { injectT } from 'i18n';
 import constants from 'constants/AppConstants';
+import { calculateDuration, calculateEndTime } from 'utils/timeUtils';
 
 class TimeRangeControl extends React.Component {
   static propTypes = {
@@ -95,13 +96,16 @@ class TimeRangeControl extends React.Component {
   handleEnd(option) {
     const end = option.value;
     const { duration, onChange, start } = this.props;
-    onChange({ duration, end, start });
+    const durationValue = calculateDuration(duration, start, end);
+    onChange({ duration: durationValue, end, start });
   }
 
   handleStart(option) {
     const start = option.value;
     const { duration, end, onChange } = this.props;
-    onChange({ duration, end, start });
+    const endValue = calculateEndTime(end, start);
+    const durationValue = calculateDuration(duration, start, endValue);
+    onChange({ duration: durationValue, end: endValue, start });
   }
 
   handleToggleChange = (e) => {

--- a/app/pages/search/controls/TimeRangeControl.spec.js
+++ b/app/pages/search/controls/TimeRangeControl.spec.js
@@ -11,6 +11,7 @@ const defaults = {
   onChange: simple.mock(),
   onTimeRangeSwitch: simple.mock(),
   start: '10:00',
+  useTimeRange: false,
 };
 function getWrapper(props) {
   return shallowWithIntl(<TimeRangeControl {...defaults} {...props} />);

--- a/app/pages/search/controls/_search-controls.scss
+++ b/app/pages/search/controls/_search-controls.scss
@@ -133,18 +133,11 @@
 // ---------------------
 
 .app-PositionControl {
-  padding-top: 15px;
-
   &__toggle-content > label {
     display: flex;
     justify-content: space-between;
     font-weight: normal;
     white-space: normal;
-  }
-  &__label {
-    line-height: $line-height-computed;
-    display: inline-block;
-    font-weight: normal;
   }
 
   &__distance_slider {
@@ -301,28 +294,24 @@
 }
 
 .app-TimeRangeControl {
-  padding: 15px 0 0 0;
   max-width: 400px;
-  margin: 0 auto;
 
-  &__header {
-    display: inline-block;
-    margin-bottom: 15px;
+  @media (min-width: $screen-sm-min) {
+    margin: 0 auto;
   }
-  &__label {
-    line-height: $line-height-computed;
-    display: inline-block;
-    font-weight: normal;
-  }
+
   &__range {
     align-items: baseline;
     display: flex;
     flex-direction: row;
     justify-content: space-between;
+    margin-top: 8px;
+
     &-separator {
       padding: 0;
       margin: 0 6px;
     }
+
     .Select {
       flex: 1 2 25%;
       &:last-child {
@@ -377,5 +366,18 @@
   &__content {
     background-color: $white;
     padding: 20px;
+  }
+}
+
+.app-SearchControlsCheckbox {
+  @media (max-width: $screen-md-max) {
+    &__toggle {
+      float: left;
+    }
+
+    &__label {
+      display: block;
+      padding-left: 60px;
+    }
   }
 }

--- a/app/pages/search/controls/_search-controls.scss
+++ b/app/pages/search/controls/_search-controls.scss
@@ -39,6 +39,7 @@
         font-size: 16px;
         a {
           padding-left: 24px;
+          cursor: pointer;
           position: relative;
           text-decoration: underline;
           &::before {
@@ -54,7 +55,7 @@
             width: $line-height-computed;
           }
         }
-        a[aria-selected="true"]::before {
+        a[aria-selected='true']::before {
           background-image: url('./images/angle-down.svg');
         }
       }
@@ -146,7 +147,7 @@
     font-weight: normal;
   }
 
-  &__distance_slider{
+  &__distance_slider {
     margin-top: 15px;
     &_tooltip {
       z-index: 40000;
@@ -167,7 +168,6 @@
     background-color: $copper;
   }
 }
-
 
 // DatePickerControl styles
 // ------------------------
@@ -190,7 +190,8 @@
     img {
       margin-right: 6px;
     }
-    img, span {
+    img,
+    span {
       vertical-align: middle;
     }
   }
@@ -219,7 +220,7 @@
   }
 
   .DayPicker-NavBar {
-    padding: .75rem .5rem;
+    padding: 0.75rem 0.5rem;
   }
 
   .DayPicker-Caption {

--- a/app/state/reducers/ui/searchReducer.js
+++ b/app/state/reducers/ui/searchReducer.js
@@ -14,6 +14,7 @@ const initialState = Immutable({
     duration: 0,
     start: '',
     end: '',
+    useTimeRange: false,
   },
   page: 1,
   position: null,
@@ -26,7 +27,6 @@ const initialState = Immutable({
 
 function searchReducer(state = initialState, action) {
   switch (action.type) {
-
     case types.API.SEARCH_RESULTS_GET_SUCCESS: {
       const results = Object.keys(action.payload.entities.resources || {});
       const paginatedResources = Object.values(action.payload.entities.paginatedResources || {});
@@ -64,18 +64,16 @@ function searchReducer(state = initialState, action) {
     }
 
     case types.UI.DISABLE_TIME_RANGE: {
-      const duration = 0;
-      const end = '';
-      const start = '';
-      const filters = pickSupportedFilters({ duration, end, start });
+      const filters = pickSupportedFilters({ useTimeRange: false });
       return state.merge({ filters }, { deep: true });
     }
 
     case types.UI.ENABLE_TIME_RANGE: {
-      const duration = getDuration();
-      const end = getEndTimeString();
-      const start = getStartTimeString();
-      const filters = pickSupportedFilters({ duration, end, start });
+      const duration = getDuration(state.filters.duration);
+      const end = getEndTimeString(state.filters.end);
+      const start = getStartTimeString(state.filters.start);
+      const useTimeRange = true;
+      const filters = pickSupportedFilters({ duration, end, start, useTimeRange });
       return state.merge({ filters }, { deep: true });
     }
 

--- a/app/state/reducers/ui/searchReducer.spec.js
+++ b/app/state/reducers/ui/searchReducer.spec.js
@@ -65,10 +65,7 @@ describe('state/reducers/ui/searchReducer', () => {
           },
         })
       );
-      const resources = [
-        Resource.build(),
-        Resource.build(),
-      ];
+      const resources = [Resource.build(), Resource.build()];
 
       it('sets the given resource ids to results', () => {
         const action = searchResourcesSuccess(resources);
@@ -181,6 +178,7 @@ describe('state/reducers/ui/searchReducer', () => {
           purpose: '',
           search: '',
           start: '',
+          useTimeRange: false,
         };
         const action = clearSearchResults();
         const initialState = Immutable({ filters });
@@ -214,11 +212,13 @@ describe('state/reducers/ui/searchReducer', () => {
       const enableGeopositionSuccess = createAction(types.UI.ENABLE_GEOPOSITION_SUCCESS);
 
       it('sets the given position coords to filters', () => {
-        const position = { coords: {
-          accuracy: 10,
-          latitude: 11,
-          longitude: 12,
-        } };
+        const position = {
+          coords: {
+            accuracy: 10,
+            latitude: 11,
+            longitude: 12,
+          },
+        };
         const action = enableGeopositionSuccess(position);
         const initialState = Immutable({
           position: null,

--- a/app/state/selectors/__tests__/uiSearchFiltersSelector.spec.js
+++ b/app/state/selectors/__tests__/uiSearchFiltersSelector.spec.js
@@ -19,6 +19,7 @@ function getState(date = '2015-10-10', start = '08:30') {
           search: '',
           start,
           unit: '',
+          useTimeRange: false,
         },
       },
     },

--- a/app/state/selectors/__tests__/urlSearchFiltersSelector.spec.js
+++ b/app/state/selectors/__tests__/urlSearchFiltersSelector.spec.js
@@ -18,6 +18,7 @@ function getProps(date = '2015-10-10', start = '08:30') {
         search: '',
         start,
         unit: '',
+        useTimeRange: false,
       },
     },
   };

--- a/app/state/selectors/uiSearchFiltersSelector.js
+++ b/app/state/selectors/uiSearchFiltersSelector.js
@@ -2,6 +2,7 @@ import omit from 'lodash/omit';
 import { createSelector } from 'reselect';
 
 import constants from 'constants/AppConstants';
+import { textBoolean } from 'utils/searchUtils';
 import { getDateString } from 'utils/timeUtils';
 
 const filtersSelector = state => state.ui.search.filters;
@@ -14,10 +15,11 @@ const uiSearchFiltersSelector = createSelector(
       omit(constants.SUPPORTED_SEARCH_FILTERS, ['lat', 'lon']),
       filters,
       {
-        charge: (filters.charge === 'true' || filters.charge === true),
+        charge: textBoolean(filters.charge),
         date: getDateString(filters.date),
         page: parseInt(filters.page, 10) || 1,
-      },
+        useTimeRange: textBoolean(filters.useTimeRange),
+      }
     );
 
     return uiSearchFilters;

--- a/app/state/selectors/urlSearchFiltersSelector.js
+++ b/app/state/selectors/urlSearchFiltersSelector.js
@@ -2,6 +2,7 @@ import omit from 'lodash/omit';
 import { createSelector } from 'reselect';
 
 import constants from 'constants/AppConstants';
+import { textBoolean } from 'utils/searchUtils';
 import { getDateString } from 'utils/timeUtils';
 
 const filtersSelector = (state, props) => props.location.query;
@@ -14,10 +15,11 @@ const urlSearchFiltersSelector = createSelector(
       omit(constants.SUPPORTED_SEARCH_FILTERS, ['lat', 'lon']),
       filters,
       {
-        charge: (filters.charge === 'true' || filters.charge === true),
+        charge: textBoolean(filters.charge),
         date: getDateString(filters.date),
         page: parseInt(filters.page, 10) || 1,
-      },
+        useTimeRange: textBoolean(filters.useTimeRange),
+      }
     );
     return urlSearchFilters;
   }

--- a/app/utils/__tests__/timeUtils.spec.js
+++ b/app/utils/__tests__/timeUtils.spec.js
@@ -59,14 +59,15 @@ describe('Utils: timeUtils', () => {
       expect(actual.start).to.exist;
     });
 
-    it('returns an object with availableBetween, end and start in correct form ', () => {
+    it('returns an object with availableBetween, end and start in correct form', () => {
       const date = '2015-10-10';
       const duration = 30;
       const end = '18:00';
       const start = '08:30';
       const timeZone = moment().format('Z');
+      const useTimeRange = true;
       const expected = `${date}T${start}:00${timeZone},${date}T${end}:00${timeZone},${duration}`;
-      const actual = getDateStartAndEndTimes(date, start, end, duration);
+      const actual = getDateStartAndEndTimes(date, useTimeRange, start, end, duration);
 
       expect(actual.availableBetween).to.equal(expected);
       expect(actual.end).to.equal(`${date}T23:59:59Z`);
@@ -79,10 +80,24 @@ describe('Utils: timeUtils', () => {
       const end = '23:30';
       const start = '08:30';
       const timeZone = moment().format('Z');
+      const useTimeRange = true;
       const expected = `${date}T${start}:00${timeZone},${date}T${end}:00${timeZone},${duration}`;
-      const actual = getDateStartAndEndTimes(date, start, end, duration);
+      const actual = getDateStartAndEndTimes(date, useTimeRange, start, end, duration);
 
       expect(actual.availableBetween).to.equal(expected);
+      expect(actual.end).to.equal(`${date}T23:59:59Z`);
+      expect(actual.start).to.equal(`${date}T00:00:00Z`);
+    });
+
+    it('returns an object without availableBetween property when useTimeRange flag is not enabled', () => {
+      const date = '2015-10-10';
+      const duration = 30;
+      const end = '23:30';
+      const start = '08:30';
+      const useTimeRange = false;
+      const actual = getDateStartAndEndTimes(date, useTimeRange, start, end, duration);
+
+      expect(actual.availableBetween).not.to.exist;
       expect(actual.end).to.equal(`${date}T23:59:59Z`);
       expect(actual.start).to.equal(`${date}T00:00:00Z`);
     });
@@ -287,13 +302,19 @@ describe('Utils: timeUtils', () => {
         });
 
         it('the first time slot ends 30 minutes after start', () => {
-          const expected = moment.utc(start).add(duration).toISOString();
+          const expected = moment
+            .utc(start)
+            .add(duration)
+            .toISOString();
 
           expect(slots[0].end).to.equal(expected);
         });
 
         it('the last time slot starts 30 minutes before the time range ends', () => {
-          const expected = moment.utc(end).subtract(duration).toISOString();
+          const expected = moment
+            .utc(end)
+            .subtract(duration)
+            .toISOString();
 
           expect(slots[3].start).to.equal(expected);
         });

--- a/app/utils/searchUtils.js
+++ b/app/utils/searchUtils.js
@@ -9,21 +9,23 @@ function getFetchParamsFromFilters(filters) {
   const all = Object.assign(
     {},
     pickSupportedFilters(filters),
-    getDateStartAndEndTimes(filters.date, filters.start, filters.end, filters.duration),
+    getDateStartAndEndTimes(
+      filters.date,
+      filters.useTimeRange,
+      filters.start,
+      filters.end,
+      filters.duration
+    ),
     { purpose: filters.purpose === 'all' ? '' : filters.purpose },
     { page: filters.page || 1 }
   );
 
-  return omit(all, 'date', 'duration');
+  return omit(all, 'date', 'duration', 'useTimeRange');
 }
 
 function getSearchPageUrl(filters = {}) {
   const query = queryString.stringify(
-    Object.assign(
-      {},
-      filters,
-      { date: getDateString(filters.date) }
-    )
+    Object.assign({}, filters, { date: getDateString(filters.date) })
   );
 
   return `/search?${query}`;
@@ -33,8 +35,8 @@ function pickSupportedFilters(filters) {
   return pick(filters, Object.keys(constants.SUPPORTED_SEARCH_FILTERS));
 }
 
-export {
-  getFetchParamsFromFilters,
-  getSearchPageUrl,
-  pickSupportedFilters,
-};
+function textBoolean(value) {
+  return value === 'true' || value === true;
+}
+
+export { getFetchParamsFromFilters, getSearchPageUrl, pickSupportedFilters, textBoolean };


### PR DESCRIPTION
- On search page, after opening Advanced search, always display the time range options, not just after the checkbox is checked
- When the date is changed, do not reset the time range options
- Improvements to time range options getting reset to empty values
- Improvements to visual issues in the search components during varying page widths