### PR TITLE
Vertically align time slots in reservation calendar

### DIFF
--- a/app/pages/resource/reservation-calendar/time-slots/TimeSlotPlaceholder.js
+++ b/app/pages/resource/reservation-calendar/time-slots/TimeSlotPlaceholder.js
@@ -1,0 +1,24 @@
+import React, { PropTypes } from 'react';
+
+export default function TimeSlotPlaceholder({ mobileOffset, size }) {
+  return (
+    <div
+      className={`app-TimeSlotPlaceholder app-TimeSlotPlaceholder--mobile-offset-${mobileOffset}`}
+    >
+      {Array(size)
+        .fill()
+        .map((_, placeholderIndex) => (
+          <button
+            className="app-TimeSlot app-TimeSlot--placeholder"
+            disabled
+            key={`timeslot-placeholder-${placeholderIndex}`}
+          />
+        ))}
+    </div>
+  );
+}
+
+TimeSlotPlaceholder.propTypes = {
+  mobileOffset: PropTypes.number.isRequired,
+  size: PropTypes.number.isRequired,
+};

--- a/app/pages/resource/reservation-calendar/time-slots/TimeSlots.js
+++ b/app/pages/resource/reservation-calendar/time-slots/TimeSlots.js
@@ -55,7 +55,7 @@ class TimeSlots extends Component {
 
     const selectedDateIndex = findIndex(
       slots,
-      slot => moment(slot[0].start).format(constants.DATE_FORMAT) === selectedDate
+      slot => !!slot[0] && moment(slot[0].start).format(constants.DATE_FORMAT) === selectedDate
     );
 
     const mobilePlaceholderSizes = timeSlotPlaceholderSizes

--- a/app/pages/resource/reservation-calendar/time-slots/TimeSlots.spec.js
+++ b/app/pages/resource/reservation-calendar/time-slots/TimeSlots.spec.js
@@ -7,25 +7,33 @@ import Resource from 'utils/fixtures/Resource';
 import { shallowWithIntl } from 'utils/testUtils';
 import TimeSlots from './TimeSlots';
 import TimeSlotComponent from './TimeSlot';
+import TimeSlotPlaceholder from './TimeSlotPlaceholder';
 
 describe('pages/resource/reservation-calendar/time-slots/TimeSlots', () => {
-  const defaultSlots = [[{
-    asISOString: '2016-10-10T10:00:00.000Z/2016-10-10T11:00:00.000Z',
-    asString: '10:00-11:00',
-    end: '2016-10-10T11:00:00.000Z',
-    index: 0,
-    reserved: false,
-    resource: 'some-resource-id',
-    start: '2016-10-10T10:00:00.000Z',
-  }], [{
-    asISOString: '2016-10-11T10:00:00.000Z/2016-10-11T11:00:00.000Z',
-    asString: '10:00-11:00',
-    end: '2016-10-11T11:00:00.000Z',
-    index: 0,
-    reserved: false,
-    resource: 'some-resource-id',
-    start: '2016-10-11T10:00:00.000Z',
-  }]];
+  const defaultSlots = [
+    [
+      {
+        asISOString: '2016-10-10T10:00:00.000Z/2016-10-10T11:00:00.000Z',
+        asString: '10:00-11:00',
+        end: '2016-10-10T11:00:00.000Z',
+        index: 0,
+        reserved: false,
+        resource: 'some-resource-id',
+        start: '2016-10-10T10:00:00.000Z',
+      },
+    ],
+    [
+      {
+        asISOString: '2016-10-11T10:00:00.000Z/2016-10-11T11:00:00.000Z',
+        asString: '10:00-11:00',
+        end: '2016-10-11T11:00:00.000Z',
+        index: 0,
+        reserved: false,
+        resource: 'some-resource-id',
+        start: '2016-10-11T10:00:00.000Z',
+      },
+    ],
+  ];
   const defaultProps = {
     addNotification: simple.stub(),
     isAdmin: false,
@@ -34,11 +42,13 @@ describe('pages/resource/reservation-calendar/time-slots/TimeSlots', () => {
     isLoggedIn: true,
     onClick: simple.stub(),
     resource: Resource.build(),
-    selected: [{
-      begin: defaultSlots[0][0].start,
-      end: defaultSlots[0][0].end,
-      resource: defaultSlots[0][0].resource,
-    }],
+    selected: [
+      {
+        begin: defaultSlots[0][0].start,
+        end: defaultSlots[0][0].end,
+        resource: defaultSlots[0][0].resource,
+      },
+    ],
     selectedDate: '2016-10-10',
     slots: Immutable(defaultSlots),
   };
@@ -83,36 +93,46 @@ describe('pages/resource/reservation-calendar/time-slots/TimeSlots', () => {
   });
 
   it('renders reserved slot and slots after reserved as not selectable', () => {
-    const slots = [[{
-      asISOString: '2016-10-10T10:00:00.000Z/2016-10-10T11:00:00.000Z',
-      asString: '10:00-11:00',
-      end: '2016-10-10T11:00:00.000Z',
-      index: 0,
-      reserved: false,
-      resource: 'some-resource-id',
-      start: '2016-10-10T10:00:00.000Z',
-    }, {
-      asISOString: '2016-10-10T11:00:00.000Z/2016-10-10T12:00:00.000Z',
-      asString: '11:00-12:00',
-      end: '2016-10-10T12:00:00.000Z',
-      index: 0,
-      reserved: true,
-      resource: 'some-resource-id',
-      start: '2016-10-10T11:00:00.000Z',
-    }], [{
-      asISOString: '2016-10-11T10:00:00.000Z/2016-10-11T11:00:00.000Z',
-      asString: '10:00-11:00',
-      end: '2016-10-11T11:00:00.000Z',
-      index: 0,
-      reserved: false,
-      resource: 'some-resource-id',
-      start: '2016-10-11T10:00:00.000Z',
-    }]];
-    const selected = [{
-      begin: slots[0][0].start,
-      end: slots[0][0].end,
-      resource: slots[0][0].resource,
-    }];
+    const slots = [
+      [
+        {
+          asISOString: '2016-10-10T10:00:00.000Z/2016-10-10T11:00:00.000Z',
+          asString: '10:00-11:00',
+          end: '2016-10-10T11:00:00.000Z',
+          index: 0,
+          reserved: false,
+          resource: 'some-resource-id',
+          start: '2016-10-10T10:00:00.000Z',
+        },
+        {
+          asISOString: '2016-10-10T11:00:00.000Z/2016-10-10T12:00:00.000Z',
+          asString: '11:00-12:00',
+          end: '2016-10-10T12:00:00.000Z',
+          index: 0,
+          reserved: true,
+          resource: 'some-resource-id',
+          start: '2016-10-10T11:00:00.000Z',
+        },
+      ],
+      [
+        {
+          asISOString: '2016-10-11T10:00:00.000Z/2016-10-11T11:00:00.000Z',
+          asString: '10:00-11:00',
+          end: '2016-10-11T11:00:00.000Z',
+          index: 0,
+          reserved: false,
+          resource: 'some-resource-id',
+          start: '2016-10-11T10:00:00.000Z',
+        },
+      ],
+    ];
+    const selected = [
+      {
+        begin: slots[0][0].start,
+        end: slots[0][0].end,
+        resource: slots[0][0].resource,
+      },
+    ];
     const timeSlots = getWrapper({ selected, slots }).find(TimeSlotComponent);
 
     expect(timeSlots).to.have.length(3);
@@ -142,5 +162,98 @@ describe('pages/resource/reservation-calendar/time-slots/TimeSlots', () => {
     const timeSlots = getWrapper(props).find(TimeSlotComponent);
 
     expect(timeSlots).to.have.length(2);
+  });
+
+  it('renders a positional placeholder if the start times differ', () => {
+    const slots = [
+      [
+        {
+          asISOString: '2016-10-10T10:00:00.000Z/2016-10-10T11:00:00.000Z',
+          asString: '10:00-11:00',
+          end: '2016-10-10T11:00:00.000Z',
+          index: 0,
+          reserved: false,
+          resource: 'some-resource-id',
+          start: '2016-10-10T10:00:00.000Z',
+        },
+      ],
+      [
+        {
+          asISOString: '2016-10-11T11:00:00.000Z/2016-10-11T12:00:00.000Z',
+          asString: '11:00-12:00',
+          end: '2016-10-11T12:00:00.000Z',
+          index: 0,
+          reserved: false,
+          resource: 'some-resource-id',
+          start: '2016-10-11T11:00:00.000Z',
+        },
+      ],
+    ];
+    const placeholder = getWrapper({ slots }).find(TimeSlotPlaceholder);
+    expect(placeholder).to.have.length(1);
+    expect(placeholder.prop('size')).to.equal(2);
+  });
+
+  it('renders positional placeholders with mobile offsets if all mobile view columns have placeholders', () => {
+    const slots = [
+      [
+        {
+          asISOString: '2016-10-10T10:00:00.000Z/2016-10-10T11:00:00.000Z',
+          asString: '10:00-11:00',
+          end: '2016-10-10T11:00:00.000Z',
+          index: 0,
+          reserved: false,
+          resource: 'some-resource-id',
+          start: '2016-10-10T10:00:00.000Z',
+        },
+      ],
+      [
+        {
+          asISOString: '2016-10-11T12:00:00.000Z/2016-10-11T13:00:00.000Z',
+          asString: '12:00-13:00',
+          end: '2016-10-11T13:00:00.000Z',
+          index: 0,
+          reserved: false,
+          resource: 'some-resource-id',
+          start: '2016-10-11T12:00:00.000Z',
+        },
+      ],
+      [
+        {
+          asISOString: '2016-10-12T10:00:00.000Z/2016-10-12T11:00:00.000Z',
+          asString: '13:00-14:00',
+          end: '2016-10-12T14:00:00.000Z',
+          index: 0,
+          reserved: false,
+          resource: 'some-resource-id',
+          start: '2016-10-12T13:00:00.000Z',
+        },
+      ],
+      [
+        {
+          asISOString: '2016-10-13T10:00:00.000Z/2016-10-13T11:00:00.000Z',
+          asString: '14:00-15:00',
+          end: '2016-10-13T15:00:00.000Z',
+          index: 0,
+          reserved: false,
+          resource: 'some-resource-id',
+          start: '2016-10-13T14:00:00.000Z',
+        },
+      ],
+      [
+        {
+          asISOString: '2016-10-14T10:00:00.000Z/2016-10-14T11:00:00.000Z',
+          asString: '10:00-11:00',
+          end: '2016-10-14T11:00:00.000Z',
+          index: 0,
+          reserved: false,
+          resource: 'some-resource-id',
+          start: '2016-10-14T10:00:00.000Z',
+        },
+      ],
+    ];
+    const placeholder = getWrapper({ selectedDate: '2016-10-11', slots }).find(TimeSlotPlaceholder);
+    expect(placeholder).to.have.length(3);
+    expect(placeholder.first().prop('mobileOffset')).to.equal(4);
   });
 });

--- a/app/pages/resource/reservation-calendar/time-slots/_time-slots.scss
+++ b/app/pages/resource/reservation-calendar/time-slots/_time-slots.scss
@@ -32,6 +32,7 @@
     color: $dark-gray;
     font-size: 14px;
     font-weight: normal;
+    margin-top: 20px;
   }
 
   .app-TimeSlot {
@@ -116,6 +117,28 @@
       margin-right: 2px;
       height: 20px;
       width: 20px;
+    }
+
+    &--placeholder {
+      background: transparent;
+      pointer-events: none;
+
+      &:hover {
+        cursor: default;
+        background: transparent !important;
+      }
+    }
+  }
+}
+
+.app-TimeSlotPlaceholder {
+  pointer-events: none;
+
+  @media (max-width: $screen-sm-max) {
+    @for $i from 1 through 48 {
+      &--mobile-offset-#{$i} {
+        margin-top: $i * -36px;
+      }
     }
   }
 }


### PR DESCRIPTION
- To align times, add a placeholder component to reservation calendar day columns with start time later than earliest start time
- Manage vertical offset for "mobile" 3 day view 
- Take into account days when unit is closed (in time slots, start field: date only, no end field)
