### PR TITLE
Highlight selected date in reservation calendar

### DIFF
--- a/app/pages/resource/reservation-calendar/time-slots/TimeSlots.js
+++ b/app/pages/resource/reservation-calendar/time-slots/TimeSlots.js
@@ -100,7 +100,9 @@ class TimeSlots extends Component {
 
       return (
         <div className={className} key={`dateslot-${index}`}>
-          <h6>{slot && slot.start ? moment(slot.start).format('dd D.M') : ''}</h6>
+          <h6 className="app-TimeSlots--date--header">
+            {slot && slot.start ? moment(slot.start).format('dd D.M') : ''}
+          </h6>
 
           {!!placeholderSize && (
             <TimeSlotPlaceholder mobileOffset={mobilePlaceholderOffset} size={placeholderSize} />

--- a/app/pages/resource/reservation-calendar/time-slots/_time-slots.scss
+++ b/app/pages/resource/reservation-calendar/time-slots/_time-slots.scss
@@ -35,6 +35,16 @@
     margin-top: 20px;
   }
 
+  &--date--header {
+    margin: 0 0 4px 0;
+    padding: 10px;
+  }
+
+  &--date--selected > &--date--header {
+    color: white;
+    background-color: $dark-gray;
+  }
+
   .app-TimeSlot {
     $slot-height: 32px;
     display: block;


### PR DESCRIPTION
Currently in reservation calendar selected date is not highlighted in any way in the weekly or mobile view. This fixes that.