### PR TITLE
Fix/missing time slot icon

### DIFF
--- a/app/pages/resource/reservation-calendar/time-slots/_time-slots.scss
+++ b/app/pages/resource/reservation-calendar/time-slots/_time-slots.scss
@@ -56,6 +56,11 @@
       ~ .app-TimeSlot:not(.app-TimeSlot--disabled):not(.app-TimeSlot--selected) {
       color: $black;
       background-color: $silver;
+
+      &.app-TimeSlot--own-reservation {
+        color: $white;
+        background-color: $theme-info;
+      }
     }
   }
 

--- a/app/pages/resource/reservation-calendar/time-slots/_time-slots.scss
+++ b/app/pages/resource/reservation-calendar/time-slots/_time-slots.scss
@@ -131,7 +131,7 @@
       }
     }
 
-    &--icon {
+    &__icon {
       display: inline-block;
       vertical-align: text-top;
       margin-right: 2px;


### PR DESCRIPTION
Fixed issue with missing icons in reservation calendar. Also fixed minor issue when editing own reservation: Highlight between selected and hover should not override own reservation slot color.