### PR TITLE
Fix/reservation calendar hover highlight

### DIFF
--- a/app/pages/resource/reservation-calendar/time-slots/TimeSlot.js
+++ b/app/pages/resource/reservation-calendar/time-slots/TimeSlot.js
@@ -11,6 +11,7 @@ class TimeSlot extends PureComponent {
     addNotification: PropTypes.func.isRequired,
     isAdmin: PropTypes.bool.isRequired,
     showClear: PropTypes.bool.isRequired,
+    isHighlighted: PropTypes.bool.isRequired,
     isLoggedIn: PropTypes.bool.isRequired,
     isSelectable: PropTypes.bool.isRequired,
     onClear: PropTypes.func.isRequired,
@@ -70,6 +71,7 @@ class TimeSlot extends PureComponent {
     const {
       isAdmin,
       showClear,
+      isHighlighted,
       isLoggedIn,
       isSelectable,
       onClear,
@@ -104,6 +106,7 @@ class TimeSlot extends PureComponent {
             (isAdmin || isOwnReservation) && slot.reservationEnding,
           'app-TimeSlot--reserved': slot.reserved,
           'app-TimeSlot--selected': selected,
+          'app-TimeSlot--highlight': isHighlighted,
         })}
       >
         <button

--- a/app/pages/resource/reservation-calendar/time-slots/TimeSlot.js
+++ b/app/pages/resource/reservation-calendar/time-slots/TimeSlot.js
@@ -4,10 +4,7 @@ import { findDOMNode } from 'react-dom';
 
 import { injectT } from 'i18n';
 import { scrollTo } from 'utils/domUtils';
-
-function padLeft(number) {
-  return number < 10 ? `0${number}` : String(number);
-}
+import { padLeft } from 'utils/timeUtils';
 
 class TimeSlot extends PureComponent {
   static propTypes = {

--- a/app/pages/resource/reservation-calendar/time-slots/TimeSlot.spec.js
+++ b/app/pages/resource/reservation-calendar/time-slots/TimeSlot.spec.js
@@ -14,6 +14,7 @@ describe('pages/resource/reservation-calendar/time-slots/TimeSlot', () => {
     addNotification: simple.stub(),
     isAdmin: false,
     isEditing: true,
+    isHighlighted: false,
     isLoggedIn: true,
     isSelectable: true,
     onClear: simple.stub(),

--- a/app/pages/resource/reservation-calendar/time-slots/TimeSlot.spec.js
+++ b/app/pages/resource/reservation-calendar/time-slots/TimeSlot.spec.js
@@ -1,5 +1,4 @@
 import { expect } from 'chai';
-import moment from 'moment';
 import React from 'react';
 import Immutable from 'seamless-immutable';
 import simple from 'simple-mock';
@@ -7,6 +6,7 @@ import simple from 'simple-mock';
 import Resource from 'utils/fixtures/Resource';
 import TimeSlotFixture from 'utils/fixtures/TimeSlot';
 import { shallowWithIntl } from 'utils/testUtils';
+import { padLeft } from 'utils/timeUtils';
 import TimeSlot from './TimeSlot';
 
 describe('pages/resource/reservation-calendar/time-slots/TimeSlot', () => {
@@ -47,7 +47,8 @@ describe('pages/resource/reservation-calendar/time-slots/TimeSlot', () => {
   });
 
   it('renders slot start time as button text', () => {
-    const expected = moment.utc(defaultProps.slot.start).format('HH:mm');
+    const start = new Date(defaultProps.slot.start);
+    const expected = `${padLeft(start.getHours())}:${padLeft(start.getMinutes())}`;
     expect(getWrapper().text()).to.contain(expected);
   });
 

--- a/app/pages/resource/reservation-calendar/time-slots/TimeSlots.js
+++ b/app/pages/resource/reservation-calendar/time-slots/TimeSlots.js
@@ -33,6 +33,12 @@ class TimeSlots extends Component {
     hoveredTimeSlot: null,
   };
 
+  onClear = () => {
+    const { onClear } = this.props;
+    onClear();
+    this.setState(() => ({ hoveredTimeSlot: null }));
+  };
+
   onCancel = () => {
     const { onClick, selected } = this.props;
     if (selected.length < 1) {
@@ -178,13 +184,13 @@ class TimeSlots extends Component {
       isAdmin,
       isEditing,
       isLoggedIn,
-      onClear,
       onClick,
       resource,
       selected,
       t,
       time,
     } = this.props;
+    const { hoveredTimeSlot } = this.state;
     if (!slot.end) {
       return (
         <h6 className="app-TimeSlots--closed" key={slot.start}>
@@ -203,16 +209,18 @@ class TimeSlots extends Component {
     const isSelected = utils.isSlotSelected(slot, selected);
     const isFirstSelected = utils.isFirstSelected(slot, selected);
     const shouldShowReservationPopover = selected.length === 1 && isFirstSelected;
+    const isHighlighted = utils.isHighlighted(slot, selected, hoveredTimeSlot);
 
     const timeSlot = (
       <TimeSlot
         addNotification={addNotification}
         isAdmin={isAdmin}
         isEditing={isEditing}
+        isHighlighted={isHighlighted}
         isLoggedIn={isLoggedIn}
         isSelectable={isSelectable}
         key={slot.start}
-        onClear={onClear}
+        onClear={this.onClear}
         onClick={onClick}
         onMouseEnter={this.onMouseEnter}
         onMouseLeave={this.onMouseLeave}

--- a/app/pages/resource/reservation-calendar/time-slots/_time-slots.scss
+++ b/app/pages/resource/reservation-calendar/time-slots/_time-slots.scss
@@ -45,25 +45,6 @@
     background-color: $dark-gray;
   }
 
-  /** This logic "hovers" all the timeslots between selected and hovered */
-  &--date:hover {
-    .app-TimeSlot--selected ~ .app-TimeSlot:not(.app-TimeSlot--disabled) {
-      color: $white;
-      background-color: $dark-gray;
-    }
-
-    .app-TimeSlot:hover
-      ~ .app-TimeSlot:not(.app-TimeSlot--disabled):not(.app-TimeSlot--selected) {
-      color: $black;
-      background-color: $silver;
-
-      &.app-TimeSlot--own-reservation {
-        color: $white;
-        background-color: $theme-info;
-      }
-    }
-  }
-
   .app-TimeSlot {
     $slot-height: 36px;
     position: relative;
@@ -134,6 +115,11 @@
       .app-TimeSlot__icon {
         @include icon-check($white);
       }
+    }
+
+    &--highlight {
+      color: $white;
+      background-color: $dark-gray;
     }
 
     &__icon {

--- a/app/pages/resource/reservation-calendar/utils.js
+++ b/app/pages/resource/reservation-calendar/utils.js
@@ -98,10 +98,27 @@ function isFirstSelected(slot, selected) {
   return firstSelected.begin === slot.start;
 }
 
+function isHighlighted(slot, selected, hovered) {
+  if (!slot || !selected || !hovered || !selected.length) {
+    return false;
+  }
+  const firstSelected = getBeginOfSelection(selected);
+  const firstSelectedDate = new Date(firstSelected.begin);
+  const slotStartDate = new Date(slot.start);
+  const hoveredDate = new Date(hovered.start);
+  return (
+    slotStartDate > firstSelectedDate &&
+    slotStartDate < hoveredDate &&
+    firstSelectedDate.getDate() === slotStartDate.getDate() &&
+    slotStartDate.getDate() === slotStartDate.getDate()
+  );
+}
+
 export default {
   getNextDayFromDate,
   getNextWeeksDays,
   getSecondDayFromDate,
+  isHighlighted,
   isInsideOpeningHours,
   isSlotAfterSelected,
   isSlotSelectable,

--- a/app/utils/__tests__/timeUtils.spec.js
+++ b/app/utils/__tests__/timeUtils.spec.js
@@ -15,6 +15,7 @@ import {
   getStartTimeString,
   getTimeSlots,
   isPastDate,
+  padLeft,
   prettifyHours,
 } from 'utils/timeUtils';
 
@@ -539,6 +540,26 @@ describe('Utils: timeUtils', () => {
 
       it('returns the number of hours rounded to half an hour', () => {
         expect(prettifyHours(hours)).to.equal('2.5 h');
+      });
+    });
+  });
+
+  describe('padLeft', () => {
+    describe('if number is less than 10', () => {
+      it('returns the number with 0 added to the left as a string', () => {
+        const number = 6;
+        const expected = `0${number}`;
+
+        expect(padLeft(number)).to.equal(expected);
+      });
+    });
+
+    describe('if number is more than 10', () => {
+      const number = 16;
+      const expected = `${number}`;
+
+      it('returns the number as it is as a string', () => {
+        expect(padLeft(number)).to.equal(expected);
       });
     });
   });

--- a/app/utils/timeUtils.js
+++ b/app/utils/timeUtils.js
@@ -161,6 +161,10 @@ function prettifyHours(hours, showMinutes = false) {
   return `${rounded} h`;
 }
 
+function padLeft(number) {
+  return number < 10 ? `0${number}` : String(number);
+}
+
 export {
   addToDate,
   calculateDuration,
@@ -174,4 +178,5 @@ export {
   getTimeSlots,
   isPastDate,
   prettifyHours,
+  padLeft,
 };


### PR DESCRIPTION
In reservation calendar, time slots between last selected and hovered slot are highlighted. The previous logic was based fully on CSS and didn't work in all cases. That is fixed in this branch. Also Timeslot related test was fixed that worked in CI but not locally.