### PR TITLE
Add missing "next" parameter to resource info login redirect

### DIFF
--- a/app/i18n/messages/en.json
+++ b/app/i18n/messages/en.json
@@ -178,7 +178,7 @@
   "ReservationForm.termsAndConditionsError": "You must accept the user regulations of the premises in order to reserve them",
   "ReservationForm.termsAndConditionsHeader": "User regulations of the premises",
   "ReservationForm.termsAndConditionsLabel": "I have read and accepted the user regulations of the premises",
-  "ReservationInfo.loginMessage": "You must <a href=”/login”>log in</a> to reserve these premises.",
+  "ReservationInfo.loginMessage": "You must <a href='/login?next={next}'>log in</a> to reserve these premises.",
   "ReservationInfo.maxNumberOfReservations": "Maximum number of reservations per user:",
   "ReservationInfo.reservationMaxLength": "Maximum duration of the reservation:",
   "ReservationInfoModal.cancelButton": "Cancel event",

--- a/app/i18n/messages/fi.json
+++ b/app/i18n/messages/fi.json
@@ -178,7 +178,7 @@
   "ReservationForm.termsAndConditionsError": "Sinun on hyväksyttävä tilan käyttösäännöt varataksesi tilan",
   "ReservationForm.termsAndConditionsHeader": "Tilan käyttösäännöt",
   "ReservationForm.termsAndConditionsLabel": "Olen lukenut ja hyväksynyt tilan käyttösäännöt",
-  "ReservationInfo.loginMessage": "Sinun täytyy <a href=\"/login\">kirjautua sisään</a>, jotta voit tehdä varauksen tähän tilaan.",
+  "ReservationInfo.loginMessage": "Sinun täytyy <a href='/login?next={next}'>kirjautua sisään</a>, jotta voit tehdä varauksen tähän tilaan.",
   "ReservationInfo.maxNumberOfReservations": "Maksimimäärä varauksia per käyttäjä:",
   "ReservationInfo.reservationMaxLength": "Varauksen maksimipituus:",
   "ReservationInfoModal.cancelButton": "Peru tapahtuma",

--- a/app/i18n/messages/sv.json
+++ b/app/i18n/messages/sv.json
@@ -180,7 +180,7 @@
   "ReservationForm.termsAndConditionsError": "För att kunna boka utrymmet måste du godkänna utrymmets användningsregler.",
   "ReservationForm.termsAndConditionsHeader": "Utrymmets användningsregler",
   "ReservationForm.termsAndConditionsLabel": "Jag har läst och godkänner utrymmets användningsregler",
-  "ReservationInfo.loginMessage": "För att kunna boka detta utrymme måste du <a href=”/login”>logga in</a>.",
+  "ReservationInfo.loginMessage": "För att kunna boka detta utrymme måste du <a href='/login?next={next}'>logga in</a>.",
   "ReservationInfo.maxNumberOfReservations": "Maximalt antal bokningar per användare:",
   "ReservationInfo.reservationMaxLength": "Bokningens maximala längd:",
   "ReservationInfoModal.cancelButton": "Annulera evenmanget",

--- a/app/pages/resource/reservation-info/ReservationInfo.js
+++ b/app/pages/resource/reservation-info/ReservationInfo.js
@@ -11,9 +11,10 @@ function renderLoginText(isLoggedIn, resource) {
   if (isLoggedIn || !resource.reservable) {
     return null;
   }
+  const next = encodeURIComponent(window.location.href);
   return (
     <p className="login-text">
-      <FormattedHTMLMessage id="ReservationInfo.loginMessage" />
+      <FormattedHTMLMessage id="ReservationInfo.loginMessage" values={{ next }} />
     </p>
   );
 }


### PR DESCRIPTION
Fixes the user being redirected to the front page after logging in via the link in reservation info on the resource page.