### PR TITLE
[Fix] Fix dateRanges return unconsistent data

### DIFF
--- a/app/pages/resource/reservation-calendar/reservationCalendarSelector.js
+++ b/app/pages/resource/reservation-calendar/reservationCalendarSelector.js
@@ -17,7 +17,6 @@ import timeSelector from 'state/selectors/timeSelector';
 import requestIsActiveSelectorFactory from 'state/selectors/factories/requestIsActiveSelectorFactory';
 import { getOpeningHours, getOpenReservations } from 'utils/resourceUtils';
 import { getTimeSlots } from 'utils/timeUtils';
-import utils from './utils';
 
 const moment = extendMoment(Moment);
 
@@ -35,9 +34,8 @@ const isEditingSelector = createSelector(
 const dateRangeSelector = createSelector(
   dateSelector,
   (selectedDate) => {
-    const nextWeekDays = utils.getNextWeeksDays(selectedDate);
-    const startDate = moment(selectedDate).startOf('week').format('YYYY-MM-DD');
-    const endDate = moment(selectedDate).endOf('week').add(nextWeekDays, 'days').format('YYYY-MM-DD');
+    const startDate = moment(selectedDate).startOf('isoWeek').format('YYYY-MM-DD');
+    const endDate = moment(selectedDate).endOf('isoWeek').format('YYYY-MM-DD');
     const range = moment.range(moment(startDate), moment(endDate));
     const rangeDates = map(Array.from(range.by('days')), date => date.format('YYYY-MM-DD'));
 

--- a/app/pages/resource/reservation-calendar/reservationCalendarSelector.spec.js
+++ b/app/pages/resource/reservation-calendar/reservationCalendarSelector.spec.js
@@ -150,7 +150,6 @@ describe('pages/resource/reservation-calendar/reservationCalendarSelector', () =
         mockSlots,
         mockSlots,
         mockSlots,
-        mockSlots,
       ];
       simple.mock(timeUtils, 'getTimeSlots').returnWith(mockSlots);
 
@@ -158,7 +157,7 @@ describe('pages/resource/reservation-calendar/reservationCalendarSelector', () =
       const props = getProps(resource.id);
       const selected = reservationCalendarSelector(state, props);
 
-      expect(timeUtils.getTimeSlots.callCount).to.equal(8);
+      expect(timeUtils.getTimeSlots.callCount).to.equal(7);
       const actualArgs = timeUtils.getTimeSlots.calls[5].args;
       expect(actualArgs[0]).to.equal('2015-10-10T12:00:00+03:00');
       expect(actualArgs[1]).to.equal('2015-10-10T18:00:00+03:00');
@@ -177,7 +176,6 @@ describe('pages/resource/reservation-calendar/reservationCalendarSelector', () =
         [],
         [{ start: '2015-10-10' }],
         [{ start: '2015-10-11' }],
-        [],
       ];
       simple.mock(timeUtils, 'getTimeSlots').returnWith([]);
 
@@ -185,7 +183,7 @@ describe('pages/resource/reservation-calendar/reservationCalendarSelector', () =
       const props = getProps(resource.id);
       const selected = reservationCalendarSelector(state, props);
 
-      expect(timeUtils.getTimeSlots.callCount).to.equal(8);
+      expect(timeUtils.getTimeSlots.callCount).to.equal(7);
       const actualArgs = timeUtils.getTimeSlots.calls[5].args;
       expect(actualArgs[0]).to.equal('2015-10-10T12:00:00+03:00');
       expect(actualArgs[1]).to.equal('2015-10-10T18:00:00+03:00');

--- a/app/pages/resource/reservation-calendar/utils.js
+++ b/app/pages/resource/reservation-calendar/utils.js
@@ -22,16 +22,6 @@ function getNextDayFromDate(date) {
     : null;
 }
 
-function getNextWeeksDays(date) {
-  const selectedWeekDay = moment(date).day();
-  if (selectedWeekDay === 0) {
-    return 2;
-  } else if (selectedWeekDay === 6) {
-    return 1;
-  }
-  return 0;
-}
-
 function getSecondDayFromDate(date) {
   return date
     ? moment(date)
@@ -119,7 +109,6 @@ function isHighlighted(slot, selected, hovered) {
 
 export default {
   getNextDayFromDate,
-  getNextWeeksDays,
   getSecondDayFromDate,
   isHighlighted,
   isInsideOpeningHours,

--- a/app/pages/resource/reservation-calendar/utils.spec.js
+++ b/app/pages/resource/reservation-calendar/utils.spec.js
@@ -31,23 +31,6 @@ describe('pages/resource/reservation-calendar/utils', () => {
     });
   });
 
-  describe('getNextWeeksDays', () => {
-    it('0 if date is Monday', () => {
-      const actual = utils.getNextWeeksDays('2018-05-21');
-      expect(actual).to.equal(0);
-    });
-
-    it('1 if date is Saturday', () => {
-      const actual = utils.getNextWeeksDays('2018-05-26');
-      expect(actual).to.equal(1);
-    });
-
-    it('2 if date is Sunday', () => {
-      const actual = utils.getNextWeeksDays('2018-05-27');
-      expect(actual).to.equal(2);
-    });
-  });
-
   describe('getSecondDayFromDate', () => {
     it('returns null if no date', () => {
       const actual = utils.getSecondDayFromDate();


### PR DESCRIPTION
Reservation timeslot UI only show time in current week, from start as Monday and end by Sunday. Current implementation return a day range which somehow start on Monday, end by next Monday (8 days). Sometime return 7