### PR TITLE
[Hotfix] Prepend missing prefix on className, remove deprecated options

### DIFF
--- a/app/pages/search/controls/SelectControl.js
+++ b/app/pages/search/controls/SelectControl.js
@@ -4,6 +4,7 @@ import ControlLabel from 'react-bootstrap/lib/ControlLabel';
 import FormGroup from 'react-bootstrap/lib/FormGroup';
 import Select from 'react-select';
 import isArray from 'lodash/isArray';
+import classNames from 'classnames';
 
 import { injectT } from 'i18n';
 
@@ -19,7 +20,7 @@ class SelectControl extends React.Component {
   render() {
     const {
       id,
-      className = 'app-Select',
+      className,
       isLoading = false,
       isClearable = true,
       isSearchable = true,
@@ -30,7 +31,6 @@ class SelectControl extends React.Component {
       t,
       value,
       ...rest } = this.props;
-
     return (
       <div className="app-SelectControl">
         <FormGroup controlId={id}>
@@ -38,7 +38,7 @@ class SelectControl extends React.Component {
           {!isLoading &&
             <Select
               {...rest}
-              className={className}
+              className={classNames('app-Select', className)}
               classNamePrefix="app-Select"
               id={id}
               isClearable={isClearable}

--- a/app/pages/search/controls/SelectControl.spec.js
+++ b/app/pages/search/controls/SelectControl.spec.js
@@ -69,6 +69,16 @@ describe('pages/search/controls/SelectControl', () => {
     expect(select.prop('value')).to.equal(defaults.options[0]);
   });
 
+  it('renders a Select with props className contain app-Select, so the styling will work', () => {
+    const select = getWrapper({ className: 'foo' }).find(Select);
+    const defaultSelect = getWrapper().find(Select);
+
+    expect(select).to.have.length(1);
+    expect(select.prop('className')).to.include('app-Select');
+    expect(select.prop('className')).to.include('foo');
+    expect(defaultSelect.prop('className')).to.include('app-Select');
+  });
+
   it('Select onChange calls prop onChange', () => {
     const onChange = simple.mock();
     const select = getWrapper({ onChange }).find(Select);

--- a/app/pages/search/controls/TimeRangeControl.js
+++ b/app/pages/search/controls/TimeRangeControl.js
@@ -2,7 +2,6 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import map from 'lodash/map';
 import Moment from 'moment';
-import classNames from 'classnames';
 import { extendMoment } from 'moment-range';
 
 import { injectT } from 'i18n';
@@ -141,7 +140,7 @@ class TimeRangeControl extends React.Component {
         />
         <div className="app-TimeRangeControl__range">
           <SelectControl
-            className={classNames('app-Select', 'app-TimeRangeControl__range-start')}
+            className="app-TimeRangeControl__range-start"
             id="time-filter-start-select"
             isClearable={false}
             isDisabled={!useTimeRange}
@@ -153,7 +152,7 @@ class TimeRangeControl extends React.Component {
           />
           <div className="app-TimeRangeControl__range-separator">-</div>
           <SelectControl
-            className={classNames('app-Select', 'app-TimeRangeControl__range-end')}
+            className="app-TimeRangeControl__range-end"
             id="time-filter-end-select"
             isClearable={false}
             isDisabled={!useTimeRange}
@@ -165,7 +164,7 @@ class TimeRangeControl extends React.Component {
             value={end}
           />
           <SelectControl
-            className={classNames('app-Select', 'app-TimeRangeControl__range-duration')}
+            className="app-TimeRangeControl__range-duration"
             id="time-filter-duration-select"
             isClearable={false}
             isDisabled={!useTimeRange}

--- a/app/pages/user-reservations/reservation-filters/AdminReservationFilters.js
+++ b/app/pages/user-reservations/reservation-filters/AdminReservationFilters.js
@@ -2,7 +2,6 @@ import map from 'lodash/map';
 import sortBy from 'lodash/sortBy';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import classNames from 'classnames';
 
 import SelectControl from 'pages/search/controls/SelectControl';
 import constants from 'constants/AppConstants';
@@ -43,7 +42,7 @@ class AdminReservationFilters extends Component {
       <div className="reservation-filters">
         <h4>{t('UserReservationsPage.preliminaryReservationsHeader')}</h4>
         <SelectControl
-          className={classNames('app-Select', 'reservation-state-select')}
+          className="reservation-state-select"
           id="reservation"
           isClearable={false}
           isSearchable={false}

--- a/app/shared/recurring-reservation-controls/RecurringReservationControls.js
+++ b/app/shared/recurring-reservation-controls/RecurringReservationControls.js
@@ -10,14 +10,6 @@ import { injectT } from 'i18n';
 import DatePicker from 'shared/date-picker';
 import SelectControl from 'pages/search/controls/SelectControl';
 
-function createOptionRenderer(t) {
-  return option => t(option.label);
-}
-
-function createValueRenderer(t) {
-  return option => t(option.label);
-}
-
 function RecurringReservationControls({
   changeFrequency,
   changeLastTime,
@@ -42,14 +34,13 @@ function RecurringReservationControls({
             </label>
             <SelectControl
               className="recurrence-frequency-select"
-              inputProps={{ id: 'recurrence-frequency-select' }}
+              getOptionLabel={({ label }) => t(label)}
+              id="recurrence-frequency-select"
               isClearable={false}
               name="recurrence-frequency-select"
               onChange={changeFrequency}
-              optionRenderer={createOptionRenderer(t)}
               options={frequencyOptions}
               value={frequency}
-              valueRenderer={createValueRenderer(t)}
             />
           </div>
         </Col>

--- a/app/shared/recurring-reservation-controls/RecurringReservationControls.spec.js
+++ b/app/shared/recurring-reservation-controls/RecurringReservationControls.spec.js
@@ -84,11 +84,10 @@ describe('shared/RecurringReservationControls/RecurringReservationControls', () 
     });
   });
 
-  describe.only('has recurring select option', () => {
+  describe('has recurring select option', () => {
     it('translated', () => {
       const arg = 'foo';
       const tMock = simple.mock();
-
 
       const wrapper = getWrapper({ frequency: '' });
       wrapper.setProps({ t: tMock });

--- a/app/shared/recurring-reservation-controls/RecurringReservationControls.spec.js
+++ b/app/shared/recurring-reservation-controls/RecurringReservationControls.spec.js
@@ -83,4 +83,19 @@ describe('shared/RecurringReservationControls/RecurringReservationControls', () 
       expect(wrapper.find(DatePicker)).to.have.length(0);
     });
   });
+
+  describe.only('has recurring select option', () => {
+    it('translated', () => {
+      const arg = 'foo';
+      const tMock = simple.mock();
+
+
+      const wrapper = getWrapper({ frequency: '' });
+      wrapper.setProps({ t: tMock });
+      const getOptionLabel = wrapper.find(SelectControl).prop('getOptionLabel');
+      getOptionLabel({ label: arg });
+
+      expect(tMock.lastCall.arg).to.equal(arg);
+    });
+  });
 });


### PR DESCRIPTION
- Add `app-Select` as default className prefix on `SelectControl` component
- Fix deprecated prop on SelectControl on `RecurringReservation`
- Remove `classnames` import when using `SelectControl` component