### PR TITLE
Fix Reset Filters

### DIFF
--- a/app/pages/search/controls/SearchControlsContainer.js
+++ b/app/pages/search/controls/SearchControlsContainer.js
@@ -108,6 +108,7 @@ class UnconnectedSearchControlsContainer extends Component {
     if (this.props.position) {
       this.props.actions.disableGeoposition();
     }
+
     this.handleFiltersChange(emptyFilters);
     this.handleSearch(emptyFilters);
   };

--- a/app/pages/search/controls/SearchControlsContainer.js
+++ b/app/pages/search/controls/SearchControlsContainer.js
@@ -110,6 +110,7 @@ class UnconnectedSearchControlsContainer extends Component {
     }
 
     this.handleFiltersChange(emptyFilters);
+    this.handleSearch(emptyFilters);
   };
 
   hasAdvancedFilters() {

--- a/app/pages/search/controls/SearchControlsContainer.js
+++ b/app/pages/search/controls/SearchControlsContainer.js
@@ -108,7 +108,6 @@ class UnconnectedSearchControlsContainer extends Component {
     if (this.props.position) {
       this.props.actions.disableGeoposition();
     }
-
     this.handleFiltersChange(emptyFilters);
     this.handleSearch(emptyFilters);
   };

--- a/app/pages/search/controls/SearchControlsContainer.spec.js
+++ b/app/pages/search/controls/SearchControlsContainer.spec.js
@@ -445,11 +445,18 @@ describe('pages/search/controls/SearchControlsContainer', () => {
       };
       instance = getWrapper(props).instance();
       instance.handleFiltersChange = simple.mock();
+      instance.handleSearch = simple.mock();
       instance.handleReset();
     });
 
     afterAll(() => {
       simple.restore();
+    });
+
+    test('calls handleSearch with empty filters', () => {
+      const emptyFilters = Object.assign({}, constants.SUPPORTED_SEARCH_FILTERS);
+      expect(instance.handleSearch.callCount).to.equal(1);
+      expect(instance.handleSearch.lastCall.args[0]).to.deep.equal(emptyFilters);
     });
 
     test('calls handleFiltersChange with empty filters', () => {

--- a/app/pages/search/controls/SearchControlsContainer.spec.js
+++ b/app/pages/search/controls/SearchControlsContainer.spec.js
@@ -455,8 +455,8 @@ describe('pages/search/controls/SearchControlsContainer', () => {
 
     test('calls handleSearch with empty filters', () => {
       const emptyFilters = Object.assign({}, constants.SUPPORTED_SEARCH_FILTERS);
-      expect(instance.handleSearch.callCount).to.equal(1);
-      expect(instance.handleSearch.lastCall.args[0]).to.deep.equal(emptyFilters);
+      expect(instance.handleSearch.callCount).toBe(1);
+      expect(instance.handleSearch.lastCall.args[0]).toEqual(emptyFilters);
     });
 
     test('calls handleFiltersChange with empty filters', () => {

--- a/app/pages/search/controls/SelectControl.js
+++ b/app/pages/search/controls/SelectControl.js
@@ -13,6 +13,7 @@ class SelectControl extends React.Component {
     if (isArray(value)) {
       return value.map(item => options.find(option => option.value === item));
     }
+
     return options.find(option => option.value === value);
   };
 

--- a/app/pages/search/controls/SelectControl.js
+++ b/app/pages/search/controls/SelectControl.js
@@ -13,7 +13,6 @@ class SelectControl extends React.Component {
     if (isArray(value)) {
       return value.map(item => options.find(option => option.value === item));
     }
-
     return options.find(option => option.value === value);
   };
 

--- a/app/state/reducers/ui/searchReducer.js
+++ b/app/state/reducers/ui/searchReducer.js
@@ -71,7 +71,7 @@ function searchReducer(state = initialState, action) {
     }
 
     case types.UI.ENABLE_TIME_RANGE: {
-      const duration = getDuration(state.filters.duration);
+      const duration = getDuration(Number(state.filters.duration));
       const end = getEndTimeString(state.filters.end);
       const start = getStartTimeString(state.filters.start);
       const useTimeRange = true;

--- a/app/state/selectors/__tests__/urlSearchFiltersSelector.spec.js
+++ b/app/state/selectors/__tests__/urlSearchFiltersSelector.spec.js
@@ -7,7 +7,7 @@ describe('Selector: urlSearchFiltersSelector', () => {
     freeOfCharge: '',
     date: '2015-10-10',
     distance: '',
-    duration: '30',
+    duration: 30,
     end: '23:30',
     page: 1,
     people: '',

--- a/app/state/selectors/urlSearchFiltersSelector.js
+++ b/app/state/selectors/urlSearchFiltersSelector.js
@@ -17,6 +17,7 @@ const urlSearchFiltersSelector = createSelector(
       omit(constants.SUPPORTED_SEARCH_FILTERS, ['lat', 'lon']),
       filters,
       {
+        duration: Number(filters.duration),
         freeOfCharge: textBoolean(filters.freeOfCharge) || '',
         date: getDateString(filters.date),
         page: parseInt(filters.page, 10) || 1,


### PR DESCRIPTION
This PR should fix : `Reset filters` button should clear filters after it is clicked without needing to click the `Search` button after the `Reset filter` is clicked.