### PR TITLE
[WIP] - Add fix for reset filter bug and update test

### DIFF
--- a/app/pages/search/controls/SearchControlsContainer.js
+++ b/app/pages/search/controls/SearchControlsContainer.js
@@ -110,6 +110,7 @@ class UnconnectedSearchControlsContainer extends Component {
     }
 
     this.handleFiltersChange(emptyFilters);
+    this.handleSearch(emptyFilters);
   };
 
   hasAdvancedFilters() {

--- a/app/state/reducers/ui/searchReducer.js
+++ b/app/state/reducers/ui/searchReducer.js
@@ -71,7 +71,7 @@ function searchReducer(state = initialState, action) {
     }
 
     case types.UI.ENABLE_TIME_RANGE: {
-      const duration = getDuration(state.filters.duration);
+      const duration = getDuration(Number(state.filters.duration));
       const end = getEndTimeString(state.filters.end);
       const start = getStartTimeString(state.filters.start);
       const useTimeRange = true;

--- a/app/state/selectors/__tests__/urlSearchFiltersSelector.spec.js
+++ b/app/state/selectors/__tests__/urlSearchFiltersSelector.spec.js
@@ -8,7 +8,7 @@ describe('Selector: urlSearchFiltersSelector', () => {
     freeOfCharge: '',
     date: '2015-10-10',
     distance: '',
-    duration: '30',
+    duration: 30,
     end: '23:30',
     page: 1,
     people: '',

--- a/app/state/selectors/uiSearchFiltersSelector.js
+++ b/app/state/selectors/uiSearchFiltersSelector.js
@@ -16,6 +16,7 @@ const uiSearchFiltersSelector = createSelector(
       omit(constants.SUPPORTED_SEARCH_FILTERS, ['lat', 'lon']),
       filters,
       {
+        duration: Number(filters.duration),
         freeOfCharge: textBoolean(filters.freeOfCharge) || '',
         date: getDateString(filters.date),
         page: parseInt(filters.page, 10) || 1,


### PR DESCRIPTION
This PR should fix : Reset filters button should clear filters after it is clicked without needing to click the Search button after the Reset filter is clicked.
