### PR TITLE
Navigation links for staff

### DIFF
--- a/app/i18n/messages/en.json
+++ b/app/i18n/messages/en.json
@@ -99,6 +99,7 @@
   "MiniModal.buttonText": "Done",
   "Navbar.aboutLink": "More information",
   "Navbar.adminResources": "My premises",
+  "Navbar.adminMaintenance": "Maintenance",
   "Navbar.userFavorites": "Favorites",
   "Navbar.header": "Welcome",
   "Navbar.homeLink": "Welcome",

--- a/app/i18n/messages/en.json
+++ b/app/i18n/messages/en.json
@@ -100,6 +100,7 @@
   "Navbar.aboutLink": "More information",
   "Navbar.adminResources": "My premises",
   "Navbar.adminMaintenance": "Maintenance",
+  "Navbar.adminGuide": "Guide",
   "Navbar.userFavorites": "Favorites",
   "Navbar.header": "Welcome",
   "Navbar.homeLink": "Welcome",

--- a/app/i18n/messages/fi.json
+++ b/app/i18n/messages/fi.json
@@ -100,6 +100,7 @@
   "Navbar.aboutLink": "Lisää tietoa",
   "Navbar.adminResources": "Omat tilat",
   "Navbar.adminMaintenance": "Ylläpito",
+  "Navbar.adminGuide": "Opas",
   "Navbar.userFavorites": "Suosikit",
   "Navbar.header": "Tervetuloa",
   "Navbar.homeLink": "Tervetuloa",

--- a/app/i18n/messages/fi.json
+++ b/app/i18n/messages/fi.json
@@ -99,6 +99,7 @@
   "MiniModal.buttonText": "Valmis",
   "Navbar.aboutLink": "Lisää tietoa",
   "Navbar.adminResources": "Omat tilat",
+  "Navbar.adminMaintenance": "Ylläpito",
   "Navbar.userFavorites": "Suosikit",
   "Navbar.header": "Tervetuloa",
   "Navbar.homeLink": "Tervetuloa",

--- a/app/i18n/messages/sv.json
+++ b/app/i18n/messages/sv.json
@@ -102,6 +102,7 @@
   "Navbar.aboutLink": "Ytterligare information",
   "Navbar.adminResources": "Egna utrymmen",
   "Navbar.adminMaintenance": "Underhåll",
+  "Navbar.adminGuide": "Guide",
   "Navbar.userFavorites": "Favoriter",
   "Navbar.header": "Välkommen",
   "Navbar.homeLink": "Välkommen",

--- a/app/i18n/messages/sv.json
+++ b/app/i18n/messages/sv.json
@@ -101,6 +101,7 @@
   "MiniModal.buttonText": "Klart",
   "Navbar.aboutLink": "Ytterligare information",
   "Navbar.adminResources": "Egna utrymmen",
+  "Navbar.adminMaintenance": "Underhåll",
   "Navbar.userFavorites": "Favoriter",
   "Navbar.header": "Välkommen",
   "Navbar.homeLink": "Välkommen",

--- a/app/pages/search/controls/PeopleCapacityControl.js
+++ b/app/pages/search/controls/PeopleCapacityControl.js
@@ -5,7 +5,7 @@ import Button from 'react-bootstrap/lib/Button';
 import ListGroup from 'react-bootstrap/lib/ListGroup';
 import ListGroupItem from 'react-bootstrap/lib/ListGroupItem';
 import Overlay from 'react-bootstrap/lib/Overlay';
-import FontAwesome from 'react-fontawesome';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 import { injectT } from 'i18n';
 import SearchControlOverlay from './SearchControlOverlay';
@@ -56,7 +56,7 @@ class PeopleCapacityControl extends React.Component {
           onClick={this.showOverlay}
         >
           <div>
-            <FontAwesome name="users" />
+            <FontAwesomeIcon icon="users" />
             {' '}
             {t('PeopleCapacityControl.buttonLabel')}
           </div>

--- a/app/pages/search/controls/PeopleCapacityControl.js
+++ b/app/pages/search/controls/PeopleCapacityControl.js
@@ -5,8 +5,8 @@ import Button from 'react-bootstrap/lib/Button';
 import ListGroup from 'react-bootstrap/lib/ListGroup';
 import ListGroupItem from 'react-bootstrap/lib/ListGroupItem';
 import Overlay from 'react-bootstrap/lib/Overlay';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
+import FAIcon from 'shared/fontawesome-icon';
 import { injectT } from 'i18n';
 import SearchControlOverlay from './SearchControlOverlay';
 
@@ -56,7 +56,7 @@ class PeopleCapacityControl extends React.Component {
           onClick={this.showOverlay}
         >
           <div>
-            <FontAwesomeIcon icon="users" />
+            <FAIcon icon="users" />
             {' '}
             {t('PeopleCapacityControl.buttonLabel')}
           </div>

--- a/app/pages/search/controls/PurposeControl.js
+++ b/app/pages/search/controls/PurposeControl.js
@@ -4,7 +4,7 @@ import Button from 'react-bootstrap/lib/Button';
 import ListGroup from 'react-bootstrap/lib/ListGroup';
 import ListGroupItem from 'react-bootstrap/lib/ListGroupItem';
 import Overlay from 'react-bootstrap/lib/Overlay';
-import FontAwesome from 'react-fontawesome';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 import { injectT } from 'i18n';
 import SearchControlOverlay from './SearchControlOverlay';
@@ -60,7 +60,7 @@ class PurposeControl extends React.Component {
           onClick={this.showOverlay}
         >
           <div>
-            <FontAwesome name="bullseye" />
+            <FontAwesomeIcon icon="bullseye" />
             {' '}
             {t('PurposeControl.buttonLabel')}
           </div>

--- a/app/pages/search/controls/PurposeControl.js
+++ b/app/pages/search/controls/PurposeControl.js
@@ -4,8 +4,8 @@ import Button from 'react-bootstrap/lib/Button';
 import ListGroup from 'react-bootstrap/lib/ListGroup';
 import ListGroupItem from 'react-bootstrap/lib/ListGroupItem';
 import Overlay from 'react-bootstrap/lib/Overlay';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
+import FAIcon from 'shared/fontawesome-icon';
 import { injectT } from 'i18n';
 import SearchControlOverlay from './SearchControlOverlay';
 
@@ -60,7 +60,7 @@ class PurposeControl extends React.Component {
           onClick={this.showOverlay}
         >
           <div>
-            <FontAwesomeIcon icon="bullseye" />
+            <FAIcon icon="bullseye" />
             {' '}
             {t('PurposeControl.buttonLabel')}
           </div>

--- a/app/shared/fontawesome-icon/FontAwesomeIcon.js
+++ b/app/shared/fontawesome-icon/FontAwesomeIcon.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import { FontAwesomeIcon as Icon } from '@fortawesome/react-fontawesome';
+
+function FAIcon({ className, ...rest }) {
+  return (
+    <Icon
+      className={classNames('app-fontAwesome', className)}
+      {...rest}
+    />
+  );
+}
+
+FAIcon.propTypes = {
+  className: PropTypes.string,
+};
+
+export default FAIcon;

--- a/app/shared/fontawesome-icon/FontAwesomeIcon.spec.js
+++ b/app/shared/fontawesome-icon/FontAwesomeIcon.spec.js
@@ -1,0 +1,50 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { FontAwesomeIcon as Icon } from '@fortawesome/react-fontawesome';
+
+import FAIcon from './FontAwesomeIcon';
+
+describe('FontAwesome icon', () => {
+  function getWrapper(props) {
+    return shallow(<FAIcon {...props} />);
+  }
+
+  test('render normally without icon props', () => {
+    const wrapper = getWrapper();
+
+    expect(wrapper).toBeDefined();
+    expect(wrapper.length).toEqual(1);
+  });
+
+  test('render FontAwesomeIcon component', () => {
+    const wrapper = getWrapper({ icon: 'users' });
+    const icon = wrapper.find(Icon);
+
+    expect(icon).toBeDefined();
+    expect(icon.length).toEqual(1);
+    expect(icon.prop('icon')).toEqual('users');
+    expect(icon.find('svg')).toBeDefined();
+  });
+
+  test('have all passed prop down FontAwesome component', () => {
+    const wrapper = getWrapper({ foo: 'bar' });
+
+    expect(wrapper.find(Icon).prop('foo')).toEqual('bar');
+  });
+
+  test('have default className as app-fontAwesome', () => {
+    const wrapper = getWrapper();
+    const expected = 'app-fontAwesome';
+
+    expect(wrapper.prop('className')).toBeDefined();
+    expect(wrapper.prop('className')).toEqual(expected);
+  });
+
+  test('have default className as app-fontAwesome, join with className as props', () => {
+    const wrapper = getWrapper({ className: 'foo' });
+    const expected = 'app-fontAwesome foo';
+
+    expect(wrapper.prop('className')).toBeDefined();
+    expect(wrapper.prop('className')).toEqual(expected);
+  });
+});

--- a/app/shared/fontawesome-icon/index.js
+++ b/app/shared/fontawesome-icon/index.js
@@ -1,0 +1,3 @@
+import FAIcon from './FontAwesomeIcon';
+
+export default FAIcon;

--- a/app/shared/main-navbar/MainNavbar.js
+++ b/app/shared/main-navbar/MainNavbar.js
@@ -1,11 +1,13 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { Fragment } from 'react';
 import { Link } from 'react-router-dom';
 import { LinkContainer } from 'react-router-bootstrap';
 import Navbar from 'react-bootstrap/lib/Navbar';
 import Nav from 'react-bootstrap/lib/Nav';
 import NavItem from 'react-bootstrap/lib/NavItem';
+import { faExternalLinkAlt } from '@fortawesome/free-solid-svg-icons';
 
+import FAIcon from 'shared/fontawesome-icon';
 import { injectT } from 'i18n';
 import { getSearchPageUrl } from 'utils/searchUtils';
 
@@ -72,9 +74,15 @@ class MainNavbar extends React.Component {
             )}
             {isAdmin
               && (
-              <NavItem eventKey="adminMaintenance" href="https://api.hel.fi/respa/ra/">
-                {t('Navbar.adminMaintenance')}
-              </NavItem>
+                <Fragment>
+                  <NavItem eventKey="adminMaintenance" href="https://api.hel.fi/respa/ra/">
+                    {t('Navbar.adminMaintenance')}
+                    <FAIcon icon={faExternalLinkAlt} />
+                  </NavItem>
+                  <NavItem eventKey="adminGuide" href="https://cityofhelsinki.gitbook.io/varaamo">
+                    {t('Navbar.adminGuide')}
+                  </NavItem>
+                </Fragment>
               )
             }
             <LinkContainer to="/about">

--- a/app/shared/main-navbar/MainNavbar.js
+++ b/app/shared/main-navbar/MainNavbar.js
@@ -70,6 +70,13 @@ class MainNavbar extends React.Component {
                 </NavItem>
               </LinkContainer>
             )}
+            {isAdmin
+              && (
+              <NavItem eventKey="adminMaintenance" href="https://api.hel.fi/respa/ra/">
+                {t('Navbar.adminMaintenance')}
+              </NavItem>
+              )
+            }
             <LinkContainer to="/about">
               <NavItem eventKey="about" onClick={() => this.collapseItem()}>
                 {t('Navbar.aboutLink')}

--- a/app/shared/main-navbar/MainNavbar.js
+++ b/app/shared/main-navbar/MainNavbar.js
@@ -79,8 +79,10 @@ class MainNavbar extends React.Component {
                     {t('Navbar.adminMaintenance')}
                     <FAIcon icon={faExternalLinkAlt} />
                   </NavItem>
+
                   <NavItem eventKey="adminGuide" href="https://cityofhelsinki.gitbook.io/varaamo">
                     {t('Navbar.adminGuide')}
+                    <FAIcon icon={faExternalLinkAlt} />
                   </NavItem>
                 </Fragment>
               )

--- a/app/shared/main-navbar/MainNavbar.spec.js
+++ b/app/shared/main-navbar/MainNavbar.spec.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import Nav from 'react-bootstrap/lib/Nav';
 import { LinkContainer } from 'react-router-bootstrap';
+import NavItem from 'react-bootstrap/lib/NavItem';
 
 import { getSearchPageUrl } from 'utils/searchUtils';
 import { shallowWithIntl } from 'utils/testUtils';
@@ -57,6 +58,12 @@ describe('shared/main-navbar/MainNavbar', () => {
         .find(LinkContainer).filter({ to: '/admin-resources' });
       expect(myReservationsLink).toHaveLength(1);
     });
+
+    test('does not renders a link to respa admin UI', () => {
+      const maintenanceLink = getLoggedInNotAdminWrapper()
+        .find(NavItem).filter({ href: 'https://api.hel.fi/respa/ra/' });
+      expect(maintenanceLink).toHaveLength(0);
+    });
   });
 
   describe('if user is logged in and is an admin', () => {
@@ -72,6 +79,12 @@ describe('shared/main-navbar/MainNavbar', () => {
       const myReservationsLink = getLoggedInAdminWrapper()
         .find(LinkContainer).filter({ to: '/admin-resources' });
       expect(myReservationsLink).toHaveLength(1);
+    });
+
+    test('renders a link to respa admin UI', () => {
+      const maintenanceLink = getLoggedInAdminWrapper()
+        .find(NavItem).filter({ href: 'https://api.hel.fi/respa/ra/' });
+      expect(maintenanceLink).toHaveLength(1);
     });
   });
 
@@ -94,6 +107,12 @@ describe('shared/main-navbar/MainNavbar', () => {
       const myReservationsLink = getNotLoggedInWrapper()
         .find(LinkContainer).filter({ to: '/admin-resources' });
       expect(myReservationsLink).toHaveLength(0);
+    });
+
+    test('does not render a link to respa admin UI', () => {
+      const maintenanceLink = getNotLoggedInWrapper()
+        .find(NavItem).filter({ href: 'https://api.hel.fi/respa/ra/' });
+      expect(maintenanceLink).toHaveLength(0);
     });
   });
 });

--- a/app/shared/main-navbar/MainNavbar.spec.js
+++ b/app/shared/main-navbar/MainNavbar.spec.js
@@ -59,10 +59,16 @@ describe('shared/main-navbar/MainNavbar', () => {
       expect(myReservationsLink).toHaveLength(1);
     });
 
-    test('does not renders a link to respa admin UI', () => {
+    test('does not render a link to respa admin UI', () => {
       const maintenanceLink = getLoggedInNotAdminWrapper()
         .find(NavItem).filter({ href: 'https://api.hel.fi/respa/ra/' });
       expect(maintenanceLink).toHaveLength(0);
+    });
+
+    test('does not render a link to varaamo gitbook', () => {
+      const gitbookLink = getLoggedInNotAdminWrapper()
+        .find(NavItem).filter({ href: 'https://cityofhelsinki.gitbook.io/varaamo' });
+      expect(gitbookLink).toHaveLength(0);
     });
   });
 
@@ -85,6 +91,12 @@ describe('shared/main-navbar/MainNavbar', () => {
       const maintenanceLink = getLoggedInAdminWrapper()
         .find(NavItem).filter({ href: 'https://api.hel.fi/respa/ra/' });
       expect(maintenanceLink).toHaveLength(1);
+    });
+
+    test('renders a link to varaamo gitbook', () => {
+      const gitbookLink = getLoggedInAdminWrapper()
+        .find(NavItem).filter({ href: 'https://cityofhelsinki.gitbook.io/varaamo' });
+      expect(gitbookLink).toHaveLength(1);
     });
   });
 
@@ -113,6 +125,12 @@ describe('shared/main-navbar/MainNavbar', () => {
       const maintenanceLink = getNotLoggedInWrapper()
         .find(NavItem).filter({ href: 'https://api.hel.fi/respa/ra/' });
       expect(maintenanceLink).toHaveLength(0);
+    });
+
+    test('does not render a link to varaamo gitbook', () => {
+      const gitbookLink = getNotLoggedInWrapper()
+        .find(NavItem).filter({ href: 'https://cityofhelsinki.gitbook.io/varaamo' });
+      expect(gitbookLink).toHaveLength(0);
     });
   });
 });

--- a/app/shared/main-navbar/MainNavbar.spec.js
+++ b/app/shared/main-navbar/MainNavbar.spec.js
@@ -6,9 +6,13 @@ import NavItem from 'react-bootstrap/lib/NavItem';
 import { getSearchPageUrl } from 'utils/searchUtils';
 import { shallowWithIntl } from 'utils/testUtils';
 import MainNavbar from './MainNavbar';
+import FAIcon from 'shared/fontawesome-icon';
 
 describe('shared/main-navbar/MainNavbar', () => {
   const pathname = 'somepath';
+  const gitbookURL = 'https://cityofhelsinki.gitbook.io/varaamo';
+  const respaURL = 'https://api.hel.fi/respa/ra/';
+
   function getWrapper(props) {
     const defaults = {
       activeLink: pathname,
@@ -61,13 +65,13 @@ describe('shared/main-navbar/MainNavbar', () => {
 
     test('does not render a link to respa admin UI', () => {
       const maintenanceLink = getLoggedInNotAdminWrapper()
-        .find(NavItem).filter({ href: 'https://api.hel.fi/respa/ra/' });
+        .find(NavItem).filter({ href: respaURL });
       expect(maintenanceLink).toHaveLength(0);
     });
 
     test('does not render a link to varaamo gitbook', () => {
       const gitbookLink = getLoggedInNotAdminWrapper()
-        .find(NavItem).filter({ href: 'https://cityofhelsinki.gitbook.io/varaamo' });
+        .find(NavItem).filter({ href: gitbookURL });
       expect(gitbookLink).toHaveLength(0);
     });
   });
@@ -77,6 +81,7 @@ describe('shared/main-navbar/MainNavbar', () => {
       isAdmin: true,
       isLoggedIn: true,
     };
+
     function getLoggedInAdminWrapper(extraProps) {
       return getWrapper({ ...props, ...extraProps });
     }
@@ -89,14 +94,30 @@ describe('shared/main-navbar/MainNavbar', () => {
 
     test('renders a link to respa admin UI', () => {
       const maintenanceLink = getLoggedInAdminWrapper()
-        .find(NavItem).filter({ href: 'https://api.hel.fi/respa/ra/' });
+        .find(NavItem).filter({ href: respaURL });
       expect(maintenanceLink).toHaveLength(1);
     });
 
     test('renders a link to varaamo gitbook', () => {
       const gitbookLink = getLoggedInAdminWrapper()
-        .find(NavItem).filter({ href: 'https://cityofhelsinki.gitbook.io/varaamo' });
+        .find(NavItem).filter({ href: gitbookURL });
       expect(gitbookLink).toHaveLength(1);
+    });
+
+    test('renders a external link icon to next to respa admin UI text', () => {
+      const maintenanceLink = getLoggedInAdminWrapper()
+        .find(NavItem).filter({ href: respaURL });
+      const icon = maintenanceLink.find(FAIcon);
+
+      expect(icon).toHaveLength(1);
+    });
+
+    test('renders an icon next to varaamo gitbook text', () => {
+      const gitbookLink = getLoggedInAdminWrapper()
+        .find(NavItem).filter({ href: gitbookURL });
+
+      const icon = gitbookLink.find(FAIcon);
+      expect(icon).toHaveLength(1);
     });
   });
 
@@ -123,13 +144,13 @@ describe('shared/main-navbar/MainNavbar', () => {
 
     test('does not render a link to respa admin UI', () => {
       const maintenanceLink = getNotLoggedInWrapper()
-        .find(NavItem).filter({ href: 'https://api.hel.fi/respa/ra/' });
+        .find(NavItem).filter({ href: respaURL });
       expect(maintenanceLink).toHaveLength(0);
     });
 
     test('does not render a link to varaamo gitbook', () => {
       const gitbookLink = getNotLoggedInWrapper()
-        .find(NavItem).filter({ href: 'https://cityofhelsinki.gitbook.io/varaamo' });
+        .find(NavItem).filter({ href: gitbookURL });
       expect(gitbookLink).toHaveLength(0);
     });
   });

--- a/app/shared/main-navbar/_main-navbar.scss
+++ b/app/shared/main-navbar/_main-navbar.scss
@@ -21,4 +21,13 @@
   .navbar-toggle .icon-bar {
     color: $white;
   }
+
+  .navbar-nav {
+    li {
+      a {
+        display: flex;
+        align-items: center;
+      }
+    }
+  }
 }

--- a/app/shared/main-navbar/_main-navbar.scss
+++ b/app/shared/main-navbar/_main-navbar.scss
@@ -1,3 +1,5 @@
+$externalIconMarginLeft: 5px;
+
 .app-MainNavbar {
   background-color: $theme-primary-dark;
   margin-bottom: 0;
@@ -29,5 +31,9 @@
         align-items: center;
       }
     }
+  }
+
+  .app-fontAwesome {
+    margin-left: $externalIconMarginLeft;
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,9 @@
   "description": "Varaamo is the user interface for the City of Helsinki varaamo.hel.fi resource reservation service.",
   "license": "MIT",
   "dependencies": {
+    "@fortawesome/fontawesome-svg-core": "^1.2.16",
+    "@fortawesome/free-solid-svg-icons": "^5.8.0",
+    "@fortawesome/react-fontawesome": "^0.1.4",
     "bootstrap-sass": "3.4.1",
     "classnames": "2.2.5",
     "dotenv": "7.0.0",
@@ -41,7 +44,6 @@
     "react-bootstrap": "0.32.3",
     "react-day-picker": "7.3.0",
     "react-dom": "16.8.4",
-    "react-fontawesome": "1.6.1",
     "react-helmet": "5.2.0",
     "react-intl": "2.8.0",
     "react-intl-redux": "2.1.0",

--- a/server/Html.js
+++ b/server/Html.js
@@ -65,7 +65,6 @@ class Html extends Component {
           <meta charSet="utf-8" />
           <meta content="IE=edge" httpEquiv="X-UA-Compatible" />
           <meta content="width=device-width, initial-scale=1" name="viewport" />
-          <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet" />
           <link href="https://overpass-30e2.kxcdn.com/overpass.css" rel="stylesheet" />
           {this.renderStylesLink(appCssSrc, isProduction)}
           <title>Varaamo</title>

--- a/yarn.lock
+++ b/yarn.lock
@@ -694,6 +694,33 @@
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/@emotion/utils/-/utils-0.8.2.tgz#576ff7fb1230185b619a75d258cbc98f0867a8dc"
 
+"@fortawesome/fontawesome-common-types@^0.2.16":
+  version "0.2.16"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.16.tgz#7428620cd5ac9b148f40b45413b5de7205954d5e"
+  integrity sha512-KVV0xwBM+JWwPlijCghjeQKBHziuvdWRF6kGQlaHKdUcJQ095YVcSjoXg90p6V91XL7RYoUEhYKu/t/f6HIS6g==
+
+"@fortawesome/fontawesome-svg-core@^1.2.16":
+  version "1.2.16"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.16.tgz#f0a4f9dd410f3d2888665d48de95b1b69f238d9d"
+  integrity sha512-5PzC5M/XKHkCU8zWeCNhMRpoyKhSu7FgkC/wxsucs8P2SngcmcZIeY5HM/xrr7SF2sZN7np3bxD/L3vOHb2guQ==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "^0.2.16"
+
+"@fortawesome/free-solid-svg-icons@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.8.0.tgz#5bfc94dd0aebf569c834a83e0649b8ed2a39da50"
+  integrity sha512-2UkbBDOHjnZJDtc9ePkdQosLa7tDtm29HsI9d8RUkL/ZXQ37hvQ7H5ymseSvmsOJXBF5PUszbF/nq3e2wY9mMA==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "^0.2.16"
+
+"@fortawesome/react-fontawesome@^0.1.4":
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/@fortawesome/react-fontawesome/-/react-fontawesome-0.1.4.tgz#18d61d9b583ca289a61aa7dccc05bd164d6bc9ad"
+  integrity sha512-GwmxQ+TK7PEdfSwvxtGnMCqrfEm0/HbRHArbUudsYiy9KzVCwndxa2KMcfyTQ8El0vROrq8gOOff09RF1oQe8g==
+  dependencies:
+    humps "^2.0.1"
+    prop-types "^15.5.10"
+
 "@jest/console@^24.3.0":
   version "24.3.0"
   resolved "https://registry.yarnpkg.com/@jest/console/-/console-24.3.0.tgz#7bd920d250988ba0bf1352c4493a48e1cb97671e"
@@ -3619,7 +3646,7 @@ https-proxy-agent@^2.2.1:
     agent-base "^4.1.0"
     debug "^3.1.0"
 
-humps@2.0.1:
+humps@2.0.1, humps@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/humps/-/humps-2.0.1.tgz#dd02ea6081bd0568dc5d073184463957ba9ef9aa"
   integrity sha1-3QLqYIG9BWjcXQcxhEY5V7qe+ao=
@@ -6168,12 +6195,6 @@ react-dom@16.8.4:
     object-assign "^4.1.1"
     prop-types "^15.6.2"
     scheduler "^0.13.4"
-
-react-fontawesome@1.6.1:
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/react-fontawesome/-/react-fontawesome-1.6.1.tgz#eddce17e7dc731aa09fd4a186688a61793a16c5c"
-  dependencies:
-    prop-types "^15.5.6"
 
 react-helmet@5.2.0:
   version "5.2.0"


### PR DESCRIPTION
Add new `Maintenance` tab, `Guide` tab in navbar, for admin only, one redirect to respa admin UI, one  point to gitbook.

Maintenance work: 
- Replace all `react-fontawesome` with `react-fontawesome` from `FontAwesome` author.
- Replace all `react-fontawesome` import with single component.
- Add bold theme for react-fontawesome as request from @SamuelSaarentola 
