### PR TITLE
VAR-34 | Staff comment section is not working

### DIFF
--- a/app/shared/comment-form/CommentForm.js
+++ b/app/shared/comment-form/CommentForm.js
@@ -17,7 +17,7 @@ class CommentForm extends Component {
 
   handleSave(event) {
     event.preventDefault();
-    const comments = this.commentsInput.current.value;
+    const comments = this.commentsInput.value;
     this.props.onSave(comments);
   }
 
@@ -33,8 +33,9 @@ class CommentForm extends Component {
           <FormControl
             componentClass="textarea"
             defaultValue={defaultValue}
+            // eslint-disable-next-line no-return-assign
+            inputRef={ref => this.commentsInput = ref}
             placeholder={t('CommentForm.placeholder')}
-            ref={this.commentsInput}
             rows={5}
           />
         </FormGroup>

--- a/app/shared/comment-form/CommentForm.spec.js
+++ b/app/shared/comment-form/CommentForm.spec.js
@@ -27,12 +27,16 @@ describe('shared/comment-form/CommentForm', () => {
 
     describe('comments textarea', () => {
       test('renders a FormControl with correct props', () => {
-        const formControl = getWrapper().find(FormControl);
+        const wrapper = getWrapper();
+        const formControl = wrapper.find(FormControl);
+        formControl.prop('inputRef')('foo');
+        // change input
 
         expect(formControl.length).toBe(1);
         expect(formControl.prop('componentClass')).toBe('textarea');
         expect(formControl.prop('defaultValue')).toBe(defaultProps.defaultValue);
         expect(typeof formControl.prop('inputRef')).toBe('function');
+        expect(wrapper.instance().commentsInput).toEqual('foo');
       });
     });
 

--- a/app/shared/comment-form/CommentForm.spec.js
+++ b/app/shared/comment-form/CommentForm.spec.js
@@ -29,14 +29,16 @@ describe('shared/comment-form/CommentForm', () => {
       test('renders a FormControl with correct props', () => {
         const wrapper = getWrapper();
         const formControl = wrapper.find(FormControl);
-        formControl.prop('inputRef')('foo');
+        const mockRef = { value: 'foo' };
+
+        formControl.prop('inputRef')(mockRef);
         // change input
 
         expect(formControl.length).toBe(1);
         expect(formControl.prop('componentClass')).toBe('textarea');
         expect(formControl.prop('defaultValue')).toBe(defaultProps.defaultValue);
         expect(typeof formControl.prop('inputRef')).toBe('function');
-        expect(wrapper.instance().commentsInput).toEqual('foo');
+        expect(wrapper.instance().commentsInput).toEqual(mockRef);
       });
     });
 

--- a/app/shared/comment-form/CommentForm.spec.js
+++ b/app/shared/comment-form/CommentForm.spec.js
@@ -32,6 +32,7 @@ describe('shared/comment-form/CommentForm', () => {
         expect(formControl.length).toBe(1);
         expect(formControl.prop('componentClass')).toBe('textarea');
         expect(formControl.prop('defaultValue')).toBe(defaultProps.defaultValue);
+        expect(typeof formControl.prop('inputRef')).toBe('function');
       });
     });
 

--- a/app/shared/comment-form/CommentForm.spec.js
+++ b/app/shared/comment-form/CommentForm.spec.js
@@ -75,7 +75,7 @@ describe('shared/comment-form/CommentForm', () => {
     beforeAll(() => {
       const instance = getWrapper().instance();
       // override ref value to mock
-      instance.commentsInput.current = { value: comments };
+      instance.commentsInput = { value: comments };
 
       defaultProps.onSave.reset();
       instance.handleSave(mockEvent);

--- a/app/shared/modals/reservation-info/ReservationInfoModal.js
+++ b/app/shared/modals/reservation-info/ReservationInfoModal.js
@@ -29,7 +29,7 @@ class ReservationInfoModal extends Component {
   }
 
   handleSaveCommentsClick() {
-    const comments = this.commentsInput.current.value;
+    const comments = this.commentsInput.value;
     this.props.onSaveCommentsClick(comments);
   }
 
@@ -98,8 +98,9 @@ class ReservationInfoModal extends Component {
                     componentClass="textarea"
                     defaultValue={reservation.comments}
                     disabled={disabled}
+                    // eslint-disable-next-line no-return-assign
+                    inputRef={ref => this.commentsInput = ref}
                     placeholder={t('common.commentsPlaceholder')}
-                    ref={this.commentsInput}
                     rows={5}
                   />
                 </FormGroup>

--- a/app/shared/modals/reservation-info/ReservationInfoModal.spec.js
+++ b/app/shared/modals/reservation-info/ReservationInfoModal.spec.js
@@ -121,11 +121,17 @@ describe('shared/modals/reservation-info/ReservationInfoModal', () => {
           });
 
           test('renders textarea FormControl for comments with correct props', () => {
-            const formControl = getCommentsForm(props).find(FormControl);
+            const wrapper = getWrapper(props);
+            const formControl = wrapper.find('.comments-form').find(FormControl);
+
+            formControl.prop('inputRef')('foo');
+            // change input value
+
             expect(formControl).toHaveLength(1);
             expect(formControl.prop('componentClass')).toBe('textarea');
             expect(formControl.prop('defaultValue')).toBe(reservation.comments);
             expect(typeof formControl.prop('inputRef')).toBe('function');
+            expect(wrapper.instance().commentsInput).toEqual('foo');
           });
 
           test('renders a save button with correct onClick prop', () => {

--- a/app/shared/modals/reservation-info/ReservationInfoModal.spec.js
+++ b/app/shared/modals/reservation-info/ReservationInfoModal.spec.js
@@ -123,15 +123,16 @@ describe('shared/modals/reservation-info/ReservationInfoModal', () => {
           test('renders textarea FormControl for comments with correct props', () => {
             const wrapper = getWrapper(props);
             const formControl = wrapper.find('.comments-form').find(FormControl);
+            const mockRef = { value: 'foo' };
 
-            formControl.prop('inputRef')('foo');
+            formControl.prop('inputRef')(mockRef);
             // change input value
 
             expect(formControl).toHaveLength(1);
             expect(formControl.prop('componentClass')).toBe('textarea');
             expect(formControl.prop('defaultValue')).toBe(reservation.comments);
             expect(typeof formControl.prop('inputRef')).toBe('function');
-            expect(wrapper.instance().commentsInput).toEqual('foo');
+            expect(wrapper.instance().commentsInput).toEqual(mockRef);
           });
 
           test('renders a save button with correct onClick prop', () => {

--- a/app/shared/modals/reservation-info/ReservationInfoModal.spec.js
+++ b/app/shared/modals/reservation-info/ReservationInfoModal.spec.js
@@ -125,6 +125,7 @@ describe('shared/modals/reservation-info/ReservationInfoModal', () => {
             expect(formControl).toHaveLength(1);
             expect(formControl.prop('componentClass')).toBe('textarea');
             expect(formControl.prop('defaultValue')).toBe(reservation.comments);
+            expect(typeof formControl.prop('inputRef')).toBe('function');
           });
 
           test('renders a save button with correct onClick prop', () => {

--- a/app/shared/modals/reservation-info/ReservationInfoModal.spec.js
+++ b/app/shared/modals/reservation-info/ReservationInfoModal.spec.js
@@ -363,7 +363,7 @@ describe('shared/modals/reservation-info/ReservationInfoModal', () => {
     beforeAll(() => {
       const instance = getWrapper({ onSaveCommentsClick }).instance();
       // override ref value to mock
-      instance.commentsInput.current = { value: comments };
+      instance.commentsInput = { value: comments };
       instance.handleSaveCommentsClick();
     });
 


### PR DESCRIPTION
**Hotfix**

React-bootstrap `ref` prop is deprecated and replace with `inputProps`
This issue is causing the comment value undefined, causing the edit issue.