### PR TITLE
SearchPage: Fix excess sort field visible on map tab

### DIFF
--- a/app/pages/search/SearchPage.js
+++ b/app/pages/search/SearchPage.js
@@ -99,36 +99,36 @@ class UnconnectedSearchPage extends Component {
         {!isFetchingSearchResults && (
           <MapToggle mapVisible={showMap} onClick={actions.toggleMap} resultCount={resultCount} />
         )}
-        {showMap && (
+        {showMap ? (
           <ResourceMap
             location={location}
             resourceIds={searchResultIds}
             selectedUnitId={selectedUnitId}
             showMap={showMap}
           />
+        ) : (
+          <PageWrapper className="app-SearchPage__wrapper" title={t('SearchPage.title')} transparent>
+            <Row className="app-SearchPage__sortControlRow">
+              <Col className="app-SearchPage__sortControl" md={4} mdOffset={8} sm={6}>
+                <Sort onChange={this.sortResource} sortValue={filters.orderBy} />
+              </Col>
+            </Row>
+            <div className="app-SearchPage__content">
+              {(searchDone || isFetchingSearchResults) && (
+                <SearchResults
+                  history={history}
+                  isFetching={isFetchingSearchResults}
+                  location={location}
+                  ref="searchResults"
+                  resultCount={resultCount}
+                  searchResultIds={searchResultIds}
+                  selectedUnitId={selectedUnitId}
+                  showMap={showMap}
+                />
+              )}
+            </div>
+          </PageWrapper>
         )}
-
-        <PageWrapper className="app-SearchPage__wrapper" title={t('SearchPage.title')} transparent>
-          <Row className="app-SearchPage__sortControlRow">
-            <Col className="app-SearchPage__sortControl" md={4} mdOffset={8} sm={6}>
-              <Sort onChange={this.sortResource} sortValue={filters.orderBy} />
-            </Col>
-          </Row>
-          <div className="app-SearchPage__content">
-            {(searchDone || isFetchingSearchResults) && (
-              <SearchResults
-                history={history}
-                isFetching={isFetchingSearchResults}
-                location={location}
-                ref="searchResults"
-                resultCount={resultCount}
-                searchResultIds={searchResultIds}
-                selectedUnitId={selectedUnitId}
-                showMap={showMap}
-              />
-            )}
-          </div>
-        </PageWrapper>
       </div>
     );
   }


### PR DESCRIPTION
Search resources page has a sort results field which sorts the results
on the list tab. That sort field was visible also on map tab.

Screenshot from [varaamo.hel.fi/search](https://varaamo.hel.fi/search):
![varaamo_order](https://user-images.githubusercontent.com/3500484/56796399-21ae7d80-681b-11e9-97ba-70015cdb08ec.png)

Now the sort field and actually the whole results list is not rendered
at all if map tab is active.