### PR TITLE
VAR-25 | Swedish translations changing to react parameter names

### DIFF
--- a/app/i18n/changeLocale.js
+++ b/app/i18n/changeLocale.js
@@ -13,8 +13,9 @@ const messages = {
 };
 
 function changeLocale(language) {
-  savePersistLocale(language);
   const locale = language === 'sv' ? 'se' : language;
+  savePersistLocale(locale);
+
   moment.locale(`varaamo-${locale}`);
   return updateIntl({
     locale,


### PR DESCRIPTION
Persisted locale should be save as `se` instead of `sv`

persistLocale function should save `locale` instead of `language`