### PR TITLE
VAR-40 | My premises date picker is in English on Finnish version

### DIFF
--- a/app/shared/date-picker/DatePicker.js
+++ b/app/shared/date-picker/DatePicker.js
@@ -1,3 +1,5 @@
+import AppConstants from 'constants/AppConstants';
+
 import React from 'react';
 import PropTypes from 'prop-types';
 import DayPickerInput from 'react-day-picker/DayPickerInput';
@@ -5,18 +7,19 @@ import MomentLocaleUtils, {
   formatDate,
   parseDate,
 } from 'react-day-picker/moment';
+import { connect } from 'react-redux';
+import { createStructuredSelector } from 'reselect';
 
-const dateFormat = 'YYYY-MM-DD';
+
+import { currentLanguageSelector } from 'state/selectors/translationSelectors';
+
+const defaultDateFormat = 'YYYY-MM-DD';
 const localizedDateFormat = 'D.M.YYYY';
 
-DatePicker.propTypes = {
-  dateFormat: PropTypes.string,
-  onChange: PropTypes.func.isRequired,
-  value: PropTypes.string.isRequired,
-};
-
-function DatePicker(props) {
-  const pickerDateFormat = props.dateFormat || localizedDateFormat;
+export function UnconnectedDatePicker({
+  dateFormat, onChange, currentLocale, value, rest
+}) {
+  const pickerDateFormat = dateFormat || localizedDateFormat;
 
   return (
     <DayPickerInput
@@ -27,15 +30,33 @@ function DatePicker(props) {
       dayPickerProps={{
         showOutsideDays: true,
         localeUtils: MomentLocaleUtils,
+        locale: currentLocale
       }}
       format={pickerDateFormat}
       formatDate={formatDate}
       keepFocus={false}
-      onDayChange={date => props.onChange(formatDate(date, dateFormat))}
+      onDayChange={date => onChange(formatDate(date, defaultDateFormat))}
       parseDate={parseDate}
-      value={new Date(props.value)}
+      value={new Date(value)}
+      {...rest}
     />
   );
 }
 
-export default DatePicker;
+UnconnectedDatePicker.propTypes = {
+  dateFormat: PropTypes.string,
+  onChange: PropTypes.func.isRequired,
+  value: PropTypes.string.isRequired,
+  currentLocale: PropTypes.string,
+  rest: PropTypes.object
+};
+
+UnconnectedDatePicker.defaultProps = {
+  currentLocale: AppConstants.DEFAULT_LOCALE
+};
+
+const languageSelector = createStructuredSelector({
+  currentLocale: currentLanguageSelector
+});
+
+export default connect(languageSelector)(UnconnectedDatePicker);

--- a/app/shared/date-picker/DatePicker.spec.js
+++ b/app/shared/date-picker/DatePicker.spec.js
@@ -3,7 +3,7 @@ import React from 'react';
 import DayPickerInput from 'react-day-picker/DayPickerInput';
 import simple from 'simple-mock';
 
-import DatePicker from './DatePicker';
+import { UnconnectedDatePicker as DatePicker } from './DatePicker';
 
 function getWrapper(props) {
   const defaults = {
@@ -31,6 +31,20 @@ describe('shared/date-picker/DatePicker', () => {
       dateField.prop('onDayChange')(newDate);
       expect(onChange.callCount).toBe(1);
       expect(onChange.lastCall.arg).toBe(expectedDate);
+    });
+
+    test('have default locale prop', () => {
+      const defaultLocale = 'fi';
+      const dateField = getDateFieldWrapper();
+
+      expect(dateField.prop('dayPickerProps').locale).toEqual(defaultLocale);
+    });
+
+    test('have locale prop passed from redux state', () => {
+      const mockLocale = 'se';
+      const dateField = getDateFieldWrapper({ currentLocale: mockLocale });
+
+      expect(dateField.prop('dayPickerProps').locale).toEqual(mockLocale);
     });
   });
 });


### PR DESCRIPTION
`shared/DatePicker` is missing `locale` props to make localization to work