### PR TITLE
VAR-39 | Set varaamo timezone to flexible base on user local timezone

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,12 +18,13 @@ install:
 
 # We are running browser tests
 before_script:
+  - export TZ=Europe/Helsinki
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
 
 script:
   - yarn lint
   - yarn test:ci
-  
+
 after_success:
   - codecov < coverage/lcov.info

--- a/app/i18n/initI18n.js
+++ b/app/i18n/initI18n.js
@@ -1,7 +1,7 @@
 import 'moment/locale/en-gb';
 import 'moment/locale/fi';
 import 'moment/locale/sv';
-import 'moment-timezone';
+import 'moment-timezone/builds/moment-timezone-with-data-10-year-range';
 
 import constants from 'constants/AppConstants';
 
@@ -22,7 +22,6 @@ const messages = {
   fi: fiMessages,
   se: svMessages,
 };
-moment.tz.setDefault('Europe/Helsinki');
 
 moment.defineLocale('varaamo-en', {
   parentLocale: 'en-gb',

--- a/app/utils/__tests__/timeUtils.spec.js
+++ b/app/utils/__tests__/timeUtils.spec.js
@@ -84,6 +84,13 @@ describe('Utils: timeUtils', () => {
       }
     );
 
+    test('default timezone is your local timezone', () => {
+      const timeZoneFromDate = Intl.DateTimeFormat().resolvedOptions().timeZone;
+      const timeZoneFromMoment = moment.tz.guess(true);
+
+      expect(timeZoneFromMoment).toEqual(timeZoneFromDate);
+    });
+
     test(
       'returns an object with availableBetween, end and start in correct form when end is 23:30',
       () => {

--- a/config/jest/setupJest.js
+++ b/config/jest/setupJest.js
@@ -9,8 +9,6 @@ require('isomorphic-fetch');
 
 configure({ adapter: new Adapter(), disableLifecycleMethods: true });
 
-// Adding global locale for all unit test
-moment.tz.setDefault('Europe/Helsinki');
 moment.locale('fi');
 
 // mock window, jsdom intergrated with Jest

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "mobile-detect": "1.4.0",
     "moment": "2.24.0",
     "moment-range": "4.0.1",
-    "moment-timezone": "0.5.23",
+    "moment-timezone": "0.5.25",
     "nocache": "2.0.0",
     "normalizr": "2.2.1",
     "passport": "0.3.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5053,9 +5053,10 @@ moment-range@4.0.1:
   dependencies:
     es6-symbol "^3.1.0"
 
-moment-timezone@0.5.23:
-  version "0.5.23"
-  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.23.tgz#7cbb00db2c14c71b19303cb47b0fb0a6d8651463"
+moment-timezone@0.5.25:
+  version "0.5.25"
+  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.25.tgz#a11bfa2f74e088327f2cd4c08b3e7bdf55957810"
+  integrity sha512-DgEaTyN/z0HFaVcVbSyVCUU6HeFdnNC3vE4c9cgu2dgMTvjBUBdBzWfasTBmAW45u5OIMeCJtU8yNjM22DHucw==
   dependencies:
     moment ">= 2.9.0"
 


### PR DESCRIPTION
- Use smaller subset of `moment-timezone`, reduce application build size.
- Use dynamic timezone for varaamo app.
- Make `Travis` environment stick with Finnish timezone to make sure no old test was hurt because of this change.