### PR TITLE
VAR-76 | Fix the bug of getting one slot extra in timediff.

### DIFF
--- a/app/pages/resource/reservation-calendar/time-slots/TimeSlot.js
+++ b/app/pages/resource/reservation-calendar/time-slots/TimeSlot.js
@@ -97,9 +97,7 @@ class TimeSlot extends PureComponent {
       onClick({
         begin: slot.start,
         end: slot.end,
-        resource: resource.id,
-        minPeriod: resource.minPeriod === resource.slotSize ? null : resource.minPeriod
-        // Ignore minPeriod if minPeriod is equal slotSize
+        resource,
       });
     }
   };

--- a/app/pages/resource/reservation-calendar/time-slots/TimeSlot.spec.js
+++ b/app/pages/resource/reservation-calendar/time-slots/TimeSlot.spec.js
@@ -242,7 +242,7 @@ describe('pages/resource/reservation-calendar/time-slots/TimeSlot', () => {
       {
         begin: defaultProps.slot.start,
         end: defaultProps.slot.end,
-        resource: defaultProps.resource.id,
+        resource: defaultProps.resource,
       },
     ]);
   });

--- a/app/state/reducers/ui/reservationsReducer.js
+++ b/app/state/reducers/ui/reservationsReducer.js
@@ -163,7 +163,7 @@ function reservationsReducer(state = initialState, action) {
       // startSlot > minPeriodSlot => payload slot is larger than minPeriod
       // startSlot === minPeriodSlot => make one of them as end timeslot
       // startSlot < minPeriodSlot => keep minPeriod as selected.
-      minPeriodSlot = getEndTimeSlotWithMinPeriod(state.selected[0], minPeriod);
+      minPeriodSlot = getEndTimeSlotWithMinPeriod(state.selected[0], minPeriod, slotSize);
       const timeDiff = getTimeDiff(startSlot.begin, minPeriodSlot.begin);
 
       return state.merge({

--- a/app/state/reducers/ui/reservationsReducer.js
+++ b/app/state/reducers/ui/reservationsReducer.js
@@ -1,7 +1,6 @@
 import types from 'constants/ActionTypes';
 import ModalTypes from 'constants/ModalTypes';
 
-import omit from 'lodash/omit';
 import isEmpty from 'lodash/isEmpty';
 import first from 'lodash/first';
 import last from 'lodash/last';
@@ -134,10 +133,15 @@ function reservationsReducer(state = initialState, action) {
     }
 
     case types.UI.TOGGLE_TIME_SLOT: {
-      const minPeriod = action.payload.minPeriod;
+      const { minPeriod, slotSize, id } = action.payload.resource;
+
       let minPeriodSlot;
 
-      const startSlot = omit(action.payload, 'minPeriod');
+      const startSlot = {
+        begin: action.payload.begin,
+        end: action.payload.end,
+        resource: id
+      };
       // Remove minPeriod of slot information from payload.
       // startSlot is known as input slot from payload.
 
@@ -145,7 +149,7 @@ function reservationsReducer(state = initialState, action) {
         // No time slot have been selected.
         // auto append minPeriodSlot to selected state to make sure minPeriod time is selected.
         // If minPeriod exist
-        minPeriodSlot = minPeriod && getEndTimeSlotWithMinPeriod(startSlot, minPeriod);
+        minPeriodSlot = minPeriod && getEndTimeSlotWithMinPeriod(startSlot, minPeriod, slotSize);
 
         return state.merge({ selected: minPeriod ? [startSlot, minPeriodSlot] : [startSlot] });
       }

--- a/app/state/reducers/ui/reservationsReducer.spec.js
+++ b/app/state/reducers/ui/reservationsReducer.spec.js
@@ -447,14 +447,24 @@ describe('state/reducers/ui/reservationsReducer', () => {
           const initialState = Immutable({
             selected: [],
           });
-          const slot = {
+
+          const payload = {
             begin: '2015-10-11T10:00:00Z',
             end: '2015-10-11T11:00:00Z',
-            resource: 'some-resource',
+            resource: {
+              id: 'some-resource'
+            },
           };
-          const action = toggleTimeSlot(slot);
+
+          const expected = Immutable([{
+            begin: '2015-10-11T10:00:00Z',
+            end: '2015-10-11T11:00:00Z',
+            resource: 'some-resource'
+          }
+
+          ]);
+          const action = toggleTimeSlot(payload);
           const nextState = reservationsReducer(initialState, action);
-          const expected = Immutable([slot]);
 
           expect(nextState.selected).toEqual(expected);
           expect(expected).not.toHaveProperty('minPeriod');
@@ -464,15 +474,22 @@ describe('state/reducers/ui/reservationsReducer', () => {
           const initialState = Immutable({
             selected: []
           });
-          const minPeriod = '01:00:00';
+          const minPeriod = '02:00:00';
+
+          const payload = {
+            begin: '2019-05-09T05:00:00.000Z',
+            end: '2019-05-09T06:00:00.000Z',
+            resource: {
+              id: 'some-resource',
+              minPeriod,
+              slotSize: '01:00:00'
+            },
+          };
+
           const startTimeSlot = {
             begin: '2019-05-09T05:00:00.000Z',
             end: '2019-05-09T06:00:00.000Z',
-            resource: 'some-resource',
-          };
-          const payload = {
-            ...startTimeSlot,
-            minPeriod
+            resource: 'some-resource'
           };
 
           const expectedEndSlot = {
@@ -499,6 +516,7 @@ describe('state/reducers/ui/reservationsReducer', () => {
             end: '2019-05-09T06:00:00.000Z',
             resource: 'some-resource',
           };
+
           const initialState = Immutable({
             selected: [
               originalStartTimeSlot,
@@ -513,7 +531,10 @@ describe('state/reducers/ui/reservationsReducer', () => {
 
           const payload = {
             ...newEndTimeSlot,
-            minPeriod
+            resource: {
+              id: 'some-resource',
+              minPeriod
+            }
           };
 
           const action = toggleTimeSlot(payload);
@@ -524,6 +545,8 @@ describe('state/reducers/ui/reservationsReducer', () => {
         });
 
         test('in case new end time is less than minPeriod, keep end time slot to minPeriod', () => {
+          const minPeriod = '03:00:00';
+
           const newEndTimeSlot = {
             begin: '2019-05-09T06:00:00.000Z',
             end: '2019-05-09T07:00:00.000Z',
@@ -536,22 +559,27 @@ describe('state/reducers/ui/reservationsReducer', () => {
             end: '2019-05-09T06:00:00.000Z',
             resource: 'some-resource',
           };
+
           const generatedEndTimeSlot = {
             begin: '2019-05-09T07:00:00.000Z',
             end: '2019-05-09T08:00:00.000Z',
             resource: 'some-resource',
           };
+
           const initialState = Immutable({
             selected: [
               originalStartTimeSlot,
               generatedEndTimeSlot,
             ]
           });
-          const minPeriod = '02:00:00';
 
           const payload = {
             ...newEndTimeSlot,
-            minPeriod
+            resource: {
+              id: 'some-resource',
+              minPeriod,
+              slotSize: '01:00:00'
+            }
           };
 
           const action = toggleTimeSlot(payload);
@@ -571,7 +599,10 @@ describe('state/reducers/ui/reservationsReducer', () => {
             end: '2015-10-11T11:00:00Z',
             resource: 'some-resource',
           };
-          const action = toggleTimeSlot(slot);
+
+          const payload = { ...slot, resource: { id: 'some-resource' } };
+
+          const action = toggleTimeSlot(payload);
           const nextState = reservationsReducer(initialState, action);
           const expected = Immutable([slot]);
 
@@ -593,7 +624,10 @@ describe('state/reducers/ui/reservationsReducer', () => {
             end: '2015-10-11T11:00:00ZZ',
             resource: 'some-resource',
           };
-          const action = toggleTimeSlot(slot);
+
+          const payload = { ...slot, resource: { id: 'some-resource' } };
+
+          const action = toggleTimeSlot(payload);
           const nextState = reservationsReducer(initialState, action);
           const expected = Immutable([...initialState.selected, slot]);
 
@@ -623,7 +657,10 @@ describe('state/reducers/ui/reservationsReducer', () => {
               resource: 'some-resource',
             };
 
-            const action = toggleTimeSlot(slot);
+            const payload = { ...slot, resource: { id: 'some-resource' } };
+
+
+            const action = toggleTimeSlot(payload);
             const nextState = reservationsReducer(initialState, action);
             const expected = Immutable([initialState.selected[0], slot]);
 
@@ -652,7 +689,10 @@ describe('state/reducers/ui/reservationsReducer', () => {
             resource: 'some-resource',
           };
 
-          const action = toggleTimeSlot(slot);
+          const payload = { ...slot, resource: { id: 'some-resource' } };
+
+
+          const action = toggleTimeSlot(payload);
           const nextState = reservationsReducer(initialState, action);
           const expected = Immutable([initialState.selected[0], slot]);
 
@@ -672,7 +712,10 @@ describe('state/reducers/ui/reservationsReducer', () => {
             end: '2015-10-11T11:00:00Z',
             resource: 'some-resource',
           };
-          const action = toggleTimeSlot(slot2);
+
+          const payload = { ...slot2, resource: { id: 'some-resource' } };
+
+          const action = toggleTimeSlot(payload);
           const initialState = Immutable({
             selected: [slot1, slot2],
           });

--- a/app/utils/timeUtils.js
+++ b/app/utils/timeUtils.js
@@ -201,8 +201,10 @@ function periodToMinute(period) {
  * @param {string} minPeriod
  * @return {object} endSlot
  */
-function getEndTimeSlotWithMinPeriod(startSlot, minPeriod) {
-  const minPeriodInMinutes = periodToMinute(minPeriod);
+function getEndTimeSlotWithMinPeriod(startSlot, minPeriod, slotSize) {
+  const minPeriodInMinutes = periodToMinute(minPeriod) - periodToMinute(slotSize);
+  // minPeriod always >= slotSize
+  // minus 1 timeSlot here so the timediff between start slot and end slot is equal with minPeriod.
 
   return {
     resource: startSlot.resource,


### PR DESCRIPTION
Populated endSlot was equal startSlot + minPeriod, timediff was increased minPeriod + slotSize instead of minPeriod only (due to last slot)