### PR TITLE
Fix getTimeDiff behavior

### DIFF
--- a/app/state/reducers/ui/reservationsReducer.js
+++ b/app/state/reducers/ui/reservationsReducer.js
@@ -162,7 +162,7 @@ function reservationsReducer(state = initialState, action) {
       // startSlot === minPeriodSlot => make one of them as end timeslot
       // startSlot < minPeriodSlot => keep minPeriod as selected.
       minPeriodSlot = getEndTimeSlotWithMinPeriod(state.selected[0], minPeriod, slotSize);
-      const timeDiff = getTimeDiff(startSlot.begin, minPeriodSlot.begin);
+      const timeDiff = getTimeDiff(minPeriodSlot.begin, startSlot.begin);
 
       return state.merge({
         selected: [state.selected[0],

--- a/app/utils/__tests__/timeUtils.test.js
+++ b/app/utils/__tests__/timeUtils.test.js
@@ -672,8 +672,8 @@ describe('Utils: timeUtils', () => {
       const minPeriod = '01:00:00';
       const result = getEndTimeSlotWithMinPeriod(slot, minPeriod);
 
-      expect(getTimeDiff(result.begin, slot.begin, 'minutes')).toEqual(periodToMinute(minPeriod));
-      expect(getTimeDiff(result.end, slot.end, 'minutes')).toEqual(periodToMinute(minPeriod));
+      expect(getTimeDiff(slot.begin, result.begin, 'minutes')).toEqual(periodToMinute(minPeriod));
+      expect(getTimeDiff(slot.end, result.end, 'minutes')).toEqual(periodToMinute(minPeriod));
       expect(result.resource).toEqual(slot.resource);
     });
   });

--- a/app/utils/__tests__/timeUtils.test.js
+++ b/app/utils/__tests__/timeUtils.test.js
@@ -641,7 +641,6 @@ describe('Utils: timeUtils', () => {
       const startDate = '2019-05-09T05:30:00.000Z';
       const endDate = '2019-05-09T05:00:00.000Z';
 
-      // > 0 => startTime > endTime
       expect(getTimeDiff(startDate, endDate) > 0).toBeFalsy();
     });
 

--- a/app/utils/__tests__/timeUtils.test.js
+++ b/app/utils/__tests__/timeUtils.test.js
@@ -623,7 +623,7 @@ describe('Utils: timeUtils', () => {
       const startDate = '2019-05-09T05:00:01.000Z';
       const endDate = '2019-05-09T05:00:00.000Z';
 
-      const expected = 1000;
+      const expected = -1000;
 
       expect(getTimeDiff(startDate, endDate)).toEqual(expected);
     });
@@ -632,7 +632,7 @@ describe('Utils: timeUtils', () => {
       const startDate = '2019-05-09T05:30:01.000Z';
       const endDate = '2019-05-09T05:00:00.000Z';
       const unit = 'minutes';
-      const expected = 30;
+      const expected = -30;
 
       expect(getTimeDiff(startDate, endDate, unit)).toEqual(expected);
     });
@@ -642,14 +642,22 @@ describe('Utils: timeUtils', () => {
       const endDate = '2019-05-09T05:00:00.000Z';
 
       // > 0 => startTime > endTime
-      expect(getTimeDiff(startDate, endDate) > 0).toBeTruthy();
+      expect(getTimeDiff(startDate, endDate) > 0).toBeFalsy();
     });
 
     test('can return float value instead of round number', () => {
       const startDate = '2019-05-09T05:42:00.000Z';
       const endDate = '2019-05-09T05:30:00.000Z';
       const result = parseFloat(getTimeDiff(startDate, endDate, 'hours', true));
-      expect(result).toEqual(0.2);
+      expect(result).toEqual(-0.2);
+    });
+
+    test('given startDate < endDate the difference should be positive', () => {
+      const startTime = '2019-06-20T12:30:00.000Z';
+      const endTime = '2019-06-20T12:45:00.000Z';
+      const unit = 'minutes';
+      const expected = 15;
+      expect(getTimeDiff(startTime, endTime, unit)).toEqual(expected);
     });
   });
 

--- a/app/utils/reservationUtils.js
+++ b/app/utils/reservationUtils.js
@@ -95,7 +95,7 @@ function getReservationPrice(begin, end, products) {
   }
 
   const currentProduct = products && products[0];
-  const timeDiff = getTimeDiff(end, begin, 'hours', true);
+  const timeDiff = getTimeDiff(begin, end, 'hours', true);
   // TODO: Replace those getter with generic data when price
   // not only by hours and product is more than 1.
 

--- a/app/utils/timeUtils.js
+++ b/app/utils/timeUtils.js
@@ -222,7 +222,7 @@ function getEndTimeSlotWithMinPeriod(startSlot, minPeriod, slotSize) {
  * @returns {int | float} timediff
  */
 function getTimeDiff(startTime, endTime, unit, isFloat = false) {
-  return moment(startTime).diff(moment(endTime), unit, isFloat);
+  return moment(endTime).diff(moment(startTime), unit, isFloat);
 }
 
 export {


### PR DESCRIPTION
The old behavior returned an negative number when calling the function with sane arguments (i.e. startTime is before endTime). This fixes the behavior so that the result is a positive number when startTime is before endTime.