### PR TITLE
Add condition to show specific terms only if resource have it

### DIFF
--- a/app/pages/resource/resource-info/ResourceInfo.js
+++ b/app/pages/resource/resource-info/ResourceInfo.js
@@ -25,11 +25,13 @@ function ResourceInfo({
         <Panel defaultExpanded header={t('ResourceInfo.reservationTitle')}>
           <ReservationInfo isLoggedIn={isLoggedIn} resource={resource} />
         </Panel>
-        <Panel defaultExpanded header={t('ResourcePage.specificTerms')}>
-          <Row>
-            <Col xs={12}>{resource.specificTerms}</Col>
-          </Row>
-        </Panel>
+        {resource.specificTerms && (
+          <Panel defaultExpanded header={t('ResourcePage.specificTerms')}>
+            <Row>
+              <Col xs={12}>{resource.specificTerms}</Col>
+            </Row>
+          </Panel>
+        )}
         <Panel defaultExpanded header={t('ResourceInfo.additionalInfoTitle')}>
           <Row>
             <Col className="app-ResourceInfo__address" xs={6}>


### PR DESCRIPTION
This PR is just for minor fix : to show `specific terms` only if it exists in resource page.