### PR TITLE
VAR-181 | Reservation information modal is missing metadata fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   **MINOR CHANGES**
   - Replace failure message and add a return button for reservation payment.
   - Fix manage reservation page only display `can_approve` reservation, now display *all* reservations. Add strict rules for staff to be able to edit/cancel specific reservation.
+  - Fix missing reservation metadata fields data in manage reservation view. Trim empty field row.
 
   **HOTFIX**
   - Fix resource information headlines and icon.
@@ -16,6 +17,7 @@
   - [#999](https://github.com/City-of-Helsinki/varaamo/pull/968) Add reusable FullCalendar component. Used in resource page.
   - [#1002](https://github.com/City-of-Helsinki/varaamo/pull/1002) Replace failure message and add a return button.
   - [#1004](https://github.com/City-of-Helsinki/varaamo/pull/1004) Staff cannot see normal reservations
+  - [#1005](https://github.com/City-of-Helsinki/varaamo/pull/1005) Reservation information modal is missing metadata fields
 
 # 0.4.2
   **HOTFIX**

--- a/src/domain/reservation/constants.js
+++ b/src/domain/reservation/constants.js
@@ -1,0 +1,19 @@
+// Extracted from Respa Admin, under reservation unit metadata fields
+export const RESERVATION_METADATA = [
+  'billing_address_city',
+  'billing_address_street',
+  'billing_address_zip',
+  'company',
+  'event_description',
+  'event_description_guidance',
+  'event_subject',
+  'number_of_participants',
+  'reservation_extra_questions',
+  'reserver_address_city',
+  'reserver_address_street',
+  'reserver_address_zip',
+  'reserver_email_address',
+  'reserver_id',
+  'reserver_name',
+  'reserver_phone_number'
+];

--- a/src/domain/reservation/information/ReservationMetadata.js
+++ b/src/domain/reservation/information/ReservationMetadata.js
@@ -8,9 +8,7 @@ import { RESERVATION_METADATA } from '../constants';
 import injectT from '../../../../app/i18n/injectT';
 
 const ReservationMetadata = ({ t, reservation, customField }) => {
-  const renderMetaDataField = (fieldName) => {
-    const value = get(reservation, fieldName, null);
-
+  const renderDefaultMetaDataField = (fieldName, value) => {
     return (
       value ? (
         <Row
@@ -30,7 +28,12 @@ const ReservationMetadata = ({ t, reservation, customField }) => {
 
   return (
     <div className="app-ReservationMetadata">
-      {RESERVATION_METADATA.map(metadataFieldName => (customField || renderMetaDataField(metadataFieldName)))}
+      {RESERVATION_METADATA.map((metadataFieldName) => {
+        const value = get(reservation, metadataFieldName, null);
+        const fieldGenerator = customField || renderDefaultMetaDataField;
+
+        return fieldGenerator(metadataFieldName, value);
+      })}
     </div>
   );
 };

--- a/src/domain/reservation/information/ReservationMetadata.js
+++ b/src/domain/reservation/information/ReservationMetadata.js
@@ -32,7 +32,7 @@ const ReservationMetadata = ({ t, reservation, customField }) => {
         const value = get(reservation, metadataFieldName, null);
         const fieldGenerator = customField || renderDefaultMetaDataField;
 
-        return fieldGenerator(metadataFieldName, value);
+        return value && fieldGenerator(metadataFieldName, value);
       })}
     </div>
   );

--- a/src/domain/reservation/information/ReservationMetadata.js
+++ b/src/domain/reservation/information/ReservationMetadata.js
@@ -18,7 +18,7 @@ const ReservationMetadata = ({ t, reservation, customField }) => {
           key={`reservation-metadata-field-${fieldName}`}
         >
           <Col xs={6}>
-            <b>{t(`${camelCase(fieldName)}Label`)}</b>
+            <b>{t(`common.${camelCase(fieldName)}Label`)}</b>
           </Col>
           <Col className="app-ReservationConfirmation__field-value" xs={6}>
             {value}

--- a/src/domain/reservation/information/ReservationMetadata.js
+++ b/src/domain/reservation/information/ReservationMetadata.js
@@ -10,19 +10,17 @@ import injectT from '../../../../app/i18n/injectT';
 const ReservationMetadata = ({ t, reservation, customField }) => {
   const renderDefaultMetaDataField = (fieldName, value) => {
     return (
-      value ? (
-        <Row
-          className="app-ReservationMetadata__field"
-          key={`reservation-metadata-field-${fieldName}`}
-        >
-          <Col xs={6}>
-            <b>{t(`common.${camelCase(fieldName)}Label`)}</b>
-          </Col>
-          <Col className="app-ReservationConfirmation__field-value" xs={6}>
-            {value}
-          </Col>
-        </Row>
-      ) : ''
+      <Row
+        className="app-ReservationMetadata__field"
+        key={`reservation-metadata-field-${fieldName}`}
+      >
+        <Col xs={6}>
+          <b>{t(`common.${camelCase(fieldName)}Label`)}</b>
+        </Col>
+        <Col className="app-ReservationConfirmation__field-value" xs={6}>
+          {value}
+        </Col>
+      </Row>
     );
   };
 

--- a/src/domain/reservation/information/ReservationMetadata.js
+++ b/src/domain/reservation/information/ReservationMetadata.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Row, Col } from 'react-bootstrap';
+import camelCase from 'lodash/camelCase';
+import get from 'lodash/get';
+
+import { RESERVATION_METADATA } from '../constants';
+import injectT from '../../../../app/i18n/injectT';
+
+const ReservationMetadata = ({ t, reservation, customField }) => {
+  const renderMetaDataField = (fieldName) => {
+    const value = get(reservation, fieldName, null);
+
+    return (
+      value ? (
+        <Row
+          className="app-ReservationMetadata__field"
+          key={`reservation-metadata-field-${fieldName}`}
+        >
+          <Col xs={6}>
+            <b>{t(`${camelCase(fieldName)}Label`)}</b>
+          </Col>
+          <Col className="app-ReservationConfirmation__field-value" xs={6}>
+            {value}
+          </Col>
+        </Row>
+      ) : ''
+    );
+  };
+
+  return (
+    <div className="app-ReservationMetadata">
+      {RESERVATION_METADATA.map(metadataFieldName => (customField || renderMetaDataField(metadataFieldName)))}
+    </div>
+  );
+};
+
+ReservationMetadata.propTypes = {
+  customField: PropTypes.func,
+  t: PropTypes.func.isRequired,
+  reservation: PropTypes.object.isRequired
+};
+
+export default injectT(ReservationMetadata);

--- a/src/domain/reservation/information/__tests__/ReservationMetadata.test.js
+++ b/src/domain/reservation/information/__tests__/ReservationMetadata.test.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import toJson from 'enzyme-to-json';
+
+import ReservationMetadata from '../ReservationMetadata';
+import { shallowWithIntl } from '../../../../../app/utils/testUtils';
+import reservationCreator from '../../../../common/data/fixtures/reservation';
+
+describe('ReservationMetadata', () => {
+  const reservation = reservationCreator.build();
+
+  test('render normally', () => {
+    const wrapper = shallowWithIntl(<ReservationMetadata reservation={reservation} />);
+
+    expect(toJson(wrapper)).toMatchSnapshot();
+  });
+
+  test('render custom field if specified', () => {
+    const customField = fieldName => <div key={fieldName}>foo</div>;
+
+    const wrapper = shallowWithIntl(<ReservationMetadata customField={customField} reservation={reservation} />);
+
+    expect(wrapper).toBeDefined();
+  });
+});

--- a/src/domain/reservation/information/__tests__/ReservationMetadata.test.js
+++ b/src/domain/reservation/information/__tests__/ReservationMetadata.test.js
@@ -6,6 +6,7 @@ import { shallowWithIntl } from '../../../../../app/utils/testUtils';
 import reservationCreator from '../../../../common/data/fixtures/reservation';
 
 describe('ReservationMetadata', () => {
+  reservationCreator.attr('reserver_name', 'foo');
   const reservation = reservationCreator.build();
 
   test('render normally', () => {

--- a/src/domain/reservation/information/__tests__/__snapshots__/ReservationMetadata.test.js.snap
+++ b/src/domain/reservation/information/__tests__/__snapshots__/ReservationMetadata.test.js.snap
@@ -3,5 +3,30 @@
 exports[`ReservationMetadata render normally 1`] = `
 <div
   className="app-ReservationMetadata"
-/>
+>
+  <Row
+    bsClass="row"
+    className="app-ReservationMetadata__field"
+    componentClass="div"
+    key="reservation-metadata-field-reserver_name"
+  >
+    <Col
+      bsClass="col"
+      componentClass="div"
+      xs={6}
+    >
+      <b>
+        common.reserverNameLabel
+      </b>
+    </Col>
+    <Col
+      bsClass="col"
+      className="app-ReservationConfirmation__field-value"
+      componentClass="div"
+      xs={6}
+    >
+      foo
+    </Col>
+  </Row>
+</div>
 `;

--- a/src/domain/reservation/information/__tests__/__snapshots__/ReservationMetadata.test.js.snap
+++ b/src/domain/reservation/information/__tests__/__snapshots__/ReservationMetadata.test.js.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ReservationMetadata render normally 1`] = `
+<div
+  className="app-ReservationMetadata"
+/>
+`;

--- a/src/domain/reservation/manage/action/ManageReservationsDropdown.js
+++ b/src/domain/reservation/manage/action/ManageReservationsDropdown.js
@@ -14,16 +14,15 @@ const UntranslatedManageReservationsDropdown = ({
 }) => {
   return (
     <div className="app-ManageReservationDropdown">
-      <DropdownButton
-        id="app-ManageReservationDropdown"
-        title={t('ManageReservationsList.actionsHeader')}
-      >
-        <MenuItem onClick={onInfoClick}>
-          {t('ManageReservationsList.actionLabel.information')}
-        </MenuItem>
+      {userCanModify && (
+        <DropdownButton
+          id="app-ManageReservationDropdown"
+          title={t('ManageReservationsList.actionsHeader')}
+        >
+          <MenuItem onClick={onInfoClick}>
+            {t('ManageReservationsList.actionLabel.information')}
+          </MenuItem>
 
-        {userCanModify && (
-        <>
           <MenuItem
             onClick={() => onEditReservation(reservation, RESERVATION_STATE.CONFIRMED)}
           >
@@ -40,17 +39,16 @@ const UntranslatedManageReservationsDropdown = ({
           >
             {t('ManageReservationsList.actionLabel.edit')}
           </MenuItem>
-        </>
-        )}
 
-        {userCanCancel && (
-          <MenuItem
-            onClick={() => onEditReservation(reservation, RESERVATION_STATE.CANCELLED)}
-          >
-            {t('ManageReservationsList.actionLabel.cancel')}
-          </MenuItem>
-        )}
-      </DropdownButton>
+          {userCanCancel && (
+            <MenuItem
+              onClick={() => onEditReservation(reservation, RESERVATION_STATE.CANCELLED)}
+            >
+              {t('ManageReservationsList.actionLabel.cancel')}
+            </MenuItem>
+          )}
+        </DropdownButton>
+      )}
     </div>
   );
 };

--- a/src/domain/reservation/manage/action/__tests__/ManageReservationsDropdown.test.js
+++ b/src/domain/reservation/manage/action/__tests__/ManageReservationsDropdown.test.js
@@ -8,7 +8,7 @@ import reservation from '../../../../../common/data/fixtures/reservation';
 describe('ManageReservationsDropdown', () => {
   test('renders correctly', () => {
     const wrapper = shallowWithIntl(
-      <ManageReservationsDropdown reservation={reservation.build()} t={() => 'foo'} />
+      <ManageReservationsDropdown reservation={reservation.build()} t={() => 'foo'} userCanModify />
     );
     expect(toJSON(wrapper)).toMatchSnapshot();
   });

--- a/src/domain/reservation/manage/action/__tests__/__snapshots__/ManageReservationsDropdown.test.js.snap
+++ b/src/domain/reservation/manage/action/__tests__/__snapshots__/ManageReservationsDropdown.test.js.snap
@@ -16,6 +16,32 @@ exports[`ManageReservationsDropdown renders correctly 1`] = `
     >
       foo
     </MenuItem>
+    <MenuItem
+      bsClass="dropdown"
+      disabled={false}
+      divider={false}
+      header={false}
+      onClick={[Function]}
+    >
+      foo
+    </MenuItem>
+    <MenuItem
+      bsClass="dropdown"
+      disabled={false}
+      divider={false}
+      header={false}
+      onClick={[Function]}
+    >
+      foo
+    </MenuItem>
+    <MenuItem
+      bsClass="dropdown"
+      disabled={false}
+      divider={false}
+      header={false}
+    >
+      foo
+    </MenuItem>
   </DropdownButton>
 </div>
 `;

--- a/src/domain/reservation/modal/ReservationInformationModal.js
+++ b/src/domain/reservation/modal/ReservationInformationModal.js
@@ -4,30 +4,37 @@ import {
 } from 'react-bootstrap';
 import PropTypes from 'prop-types';
 import get from 'lodash/get';
+import camelCase from 'lodash/camelCase';
 
 import ManageReservationsStatus from '../manage/status/ManageReservationsStatus';
 import injectT from '../../../../app/i18n/injectT';
 import { getDateAndTime } from '../manage/list/ManageReservationsList';
 import { RESERVATION_STATE } from '../../../constants/ReservationState';
-import * as reservationUtils from '../utils';
+import ReservationMetadata from '../information/ReservationMetadata';
 
 const ReservationInformationModal = ({
   t, reservation, onHide, isOpen, onEditClick, onEditReservation, onSaveComment
 }) => {
-  const canUserModify = reservationUtils.canUserModifyReservation(reservation);
-  const canUserCancel = reservationUtils.canUserCancelReservation(reservation);
-
   const [comment, setComment] = useState(get(reservation, 'comments') || '');
   const saveComment = () => onSaveComment(reservation, comment);
 
   const renderField = (label, value) => {
     return (
-      <div className="app-ReservationInformationModal__field">
-        <Row>
-          <Col className="app-ReservationInformationModal__field__label" xs={5}><span>{t(label)}</span></Col>
-          <Col className="app-ReservationInformationModal__field__value" xs={7}><span>{value}</span></Col>
-        </Row>
-      </div>
+      value ? (
+        <div className="app-ReservationInformationModal__field">
+          <Row>
+            <Col className="app-ReservationInformationModal__field__label" xs={5}>
+              <span>{t(`common.${(camelCase(label))}Label`)}</span>
+            </Col>
+
+            <Col className="app-ReservationInformationModal__field__value" xs={7}>
+              <span>
+                {value}
+              </span>
+            </Col>
+          </Row>
+        </div>
+      ) : ''
     );
   };
   return (
@@ -42,20 +49,25 @@ const ReservationInformationModal = ({
       <Modal.Body>
         <ManageReservationsStatus reservation={reservation} />
         <div className="app-ReservationInformationModal__information">
+
+          {/* Render default basic information fields */}
           <div className="app-ReservationInformationModal__information__account">
-            {renderField('common.userNameLabel', get(reservation, 'user.display_name', ''))}
-            {renderField('common.userEmailLabel', get(reservation, 'user.email', ''))}
+            {renderField('user_name', get(reservation, 'user.display_name', ''))}
+            {renderField('user_email', get(reservation, 'user.email', ''))}
           </div>
-          {renderField('common.reserverNameLabel', get(reservation, 'reserver_name', ''))}
-          {renderField('common.eventDescriptionLabel', get(reservation, 'event_description', ''))}
-          {renderField('common.reservationTimeLabel', getDateAndTime(reservation))}
-          {renderField('common.resourceLabel', get(reservation, 'resource.name.fi', ''))}
-          {renderField('common.reserverPhoneNumberLabel', get(reservation, 'reserver_phone_number', ''))}
+          {renderField('reservation_time', getDateAndTime(reservation))}
+          {renderField('resource', get(reservation, 'resource.name.fi', ''))}
+
+          {/* Render reservation metadata (extra) fields */}
+          <ReservationMetadata
+            customField={renderField}
+            reservation={reservation}
+          />
+
         </div>
         <div className="app-ReservationInformationModal__edit-reservation-btn">
           <Button
             bsStyle="primary"
-            disabled={!canUserModify}
             onClick={() => onEditClick(reservation)}
           >
             {t('ReservationEditForm.startEdit')}
@@ -68,7 +80,7 @@ const ReservationInformationModal = ({
           <FormControl
             className="app-ReservationInformationModal__comments-field"
             componentClass="textarea"
-            onChange={e => canUserModify && setComment(e.target.value)}
+            onChange={e => setComment(e.target.value)}
             placeholder={t('common.commentsPlaceholder')}
             rows={5}
             value={comment}
@@ -76,7 +88,6 @@ const ReservationInformationModal = ({
           <div className="app-ReservationInformationModal__save-comment">
             <Button
               bsStyle="primary"
-              disabled={!canUserModify}
               onClick={saveComment}
             >
               {t('ReservationInfoModal.saveComment')}
@@ -94,7 +105,6 @@ const ReservationInformationModal = ({
 
         <Button
           bsStyle="default"
-          disabled={!canUserCancel}
           onClick={() => onEditReservation(reservation, RESERVATION_STATE.CANCELLED)}
         >
           {t('ReservationInfoModal.cancelButton')}
@@ -102,7 +112,6 @@ const ReservationInformationModal = ({
 
         <Button
           bsStyle="danger"
-          disabled={!canUserModify}
           onClick={() => onEditReservation(reservation, RESERVATION_STATE.DENIED)}
         >
           {t('ReservationInfoModal.denyButton')}
@@ -110,7 +119,6 @@ const ReservationInformationModal = ({
 
         <Button
           bsStyle="success"
-          disabled={!canUserModify}
           onClick={() => onEditReservation(reservation, RESERVATION_STATE.CONFIRMED)}
         >
           {t('ReservationInfoModal.confirmButton')}

--- a/src/domain/reservation/modal/ReservationInformationModal.js
+++ b/src/domain/reservation/modal/ReservationInformationModal.js
@@ -20,21 +20,19 @@ const ReservationInformationModal = ({
 
   const renderField = (label, value) => {
     return (
-      value ? (
-        <div className="app-ReservationInformationModal__field">
-          <Row>
-            <Col className="app-ReservationInformationModal__field__label" xs={5}>
-              <span>{t(`common.${(camelCase(label))}Label`)}</span>
-            </Col>
+      <div className="app-ReservationInformationModal__field">
+        <Row>
+          <Col className="app-ReservationInformationModal__field__label" xs={5}>
+            <span>{t(`common.${(camelCase(label))}Label`)}</span>
+          </Col>
 
-            <Col className="app-ReservationInformationModal__field__value" xs={7}>
-              <span>
-                {value}
-              </span>
-            </Col>
-          </Row>
-        </div>
-      ) : ''
+          <Col className="app-ReservationInformationModal__field__value" xs={7}>
+            <span>
+              {value}
+            </span>
+          </Col>
+        </Row>
+      </div>
     );
   };
   return (

--- a/src/domain/reservation/modal/ReservationInformationModal.js
+++ b/src/domain/reservation/modal/ReservationInformationModal.js
@@ -55,6 +55,7 @@ const ReservationInformationModal = ({
         <div className="app-ReservationInformationModal__edit-reservation-btn">
           <Button
             bsStyle="primary"
+            disabled={!canUserModify}
             onClick={() => onEditClick(reservation)}
           >
             {t('ReservationEditForm.startEdit')}

--- a/src/domain/reservation/modal/__tests__/__snapshots__/ReservationInfomationModal.test.js.snap
+++ b/src/domain/reservation/modal/__tests__/__snapshots__/ReservationInfomationModal.test.js.snap
@@ -68,7 +68,62 @@ exports[`ReservationInformationModal renders correctly 1`] = `
     >
       <div
         className="app-ReservationInformationModal__information__account"
-      />
+      >
+        <div
+          className="app-ReservationInformationModal__field"
+        >
+          <Row
+            bsClass="row"
+            componentClass="div"
+          >
+            <Col
+              bsClass="col"
+              className="app-ReservationInformationModal__field__label"
+              componentClass="div"
+              xs={5}
+            >
+              <span>
+                common.userNameLabel
+              </span>
+            </Col>
+            <Col
+              bsClass="col"
+              className="app-ReservationInformationModal__field__value"
+              componentClass="div"
+              xs={7}
+            >
+              <span />
+            </Col>
+          </Row>
+        </div>
+        <div
+          className="app-ReservationInformationModal__field"
+        >
+          <Row
+            bsClass="row"
+            componentClass="div"
+          >
+            <Col
+              bsClass="col"
+              className="app-ReservationInformationModal__field__label"
+              componentClass="div"
+              xs={5}
+            >
+              <span>
+                common.userEmailLabel
+              </span>
+            </Col>
+            <Col
+              bsClass="col"
+              className="app-ReservationInformationModal__field__value"
+              componentClass="div"
+              xs={7}
+            >
+              <span />
+            </Col>
+          </Row>
+        </div>
+      </div>
       <div
         className="app-ReservationInformationModal__field"
       >
@@ -95,6 +150,33 @@ exports[`ReservationInformationModal renders correctly 1`] = `
             <span>
               ke 14.08.2019 14:00 - 15:00
             </span>
+          </Col>
+        </Row>
+      </div>
+      <div
+        className="app-ReservationInformationModal__field"
+      >
+        <Row
+          bsClass="row"
+          componentClass="div"
+        >
+          <Col
+            bsClass="col"
+            className="app-ReservationInformationModal__field__label"
+            componentClass="div"
+            xs={5}
+          >
+            <span>
+              common.resourceLabel
+            </span>
+          </Col>
+          <Col
+            bsClass="col"
+            className="app-ReservationInformationModal__field__value"
+            componentClass="div"
+            xs={7}
+          >
+            <span />
           </Col>
         </Row>
       </div>

--- a/src/domain/reservation/modal/__tests__/__snapshots__/ReservationInfomationModal.test.js.snap
+++ b/src/domain/reservation/modal/__tests__/__snapshots__/ReservationInfomationModal.test.js.snap
@@ -68,116 +68,7 @@ exports[`ReservationInformationModal renders correctly 1`] = `
     >
       <div
         className="app-ReservationInformationModal__information__account"
-      >
-        <div
-          className="app-ReservationInformationModal__field"
-        >
-          <Row
-            bsClass="row"
-            componentClass="div"
-          >
-            <Col
-              bsClass="col"
-              className="app-ReservationInformationModal__field__label"
-              componentClass="div"
-              xs={5}
-            >
-              <span>
-                common.userNameLabel
-              </span>
-            </Col>
-            <Col
-              bsClass="col"
-              className="app-ReservationInformationModal__field__value"
-              componentClass="div"
-              xs={7}
-            >
-              <span />
-            </Col>
-          </Row>
-        </div>
-        <div
-          className="app-ReservationInformationModal__field"
-        >
-          <Row
-            bsClass="row"
-            componentClass="div"
-          >
-            <Col
-              bsClass="col"
-              className="app-ReservationInformationModal__field__label"
-              componentClass="div"
-              xs={5}
-            >
-              <span>
-                common.userEmailLabel
-              </span>
-            </Col>
-            <Col
-              bsClass="col"
-              className="app-ReservationInformationModal__field__value"
-              componentClass="div"
-              xs={7}
-            >
-              <span />
-            </Col>
-          </Row>
-        </div>
-      </div>
-      <div
-        className="app-ReservationInformationModal__field"
-      >
-        <Row
-          bsClass="row"
-          componentClass="div"
-        >
-          <Col
-            bsClass="col"
-            className="app-ReservationInformationModal__field__label"
-            componentClass="div"
-            xs={5}
-          >
-            <span>
-              common.reserverNameLabel
-            </span>
-          </Col>
-          <Col
-            bsClass="col"
-            className="app-ReservationInformationModal__field__value"
-            componentClass="div"
-            xs={7}
-          >
-            <span />
-          </Col>
-        </Row>
-      </div>
-      <div
-        className="app-ReservationInformationModal__field"
-      >
-        <Row
-          bsClass="row"
-          componentClass="div"
-        >
-          <Col
-            bsClass="col"
-            className="app-ReservationInformationModal__field__label"
-            componentClass="div"
-            xs={5}
-          >
-            <span>
-              common.eventDescriptionLabel
-            </span>
-          </Col>
-          <Col
-            bsClass="col"
-            className="app-ReservationInformationModal__field__value"
-            componentClass="div"
-            xs={7}
-          >
-            <span />
-          </Col>
-        </Row>
-      </div>
+      />
       <div
         className="app-ReservationInformationModal__field"
       >
@@ -207,60 +98,27 @@ exports[`ReservationInformationModal renders correctly 1`] = `
           </Col>
         </Row>
       </div>
-      <div
-        className="app-ReservationInformationModal__field"
-      >
-        <Row
-          bsClass="row"
-          componentClass="div"
-        >
-          <Col
-            bsClass="col"
-            className="app-ReservationInformationModal__field__label"
-            componentClass="div"
-            xs={5}
-          >
-            <span>
-              common.resourceLabel
-            </span>
-          </Col>
-          <Col
-            bsClass="col"
-            className="app-ReservationInformationModal__field__value"
-            componentClass="div"
-            xs={7}
-          >
-            <span />
-          </Col>
-        </Row>
-      </div>
-      <div
-        className="app-ReservationInformationModal__field"
-      >
-        <Row
-          bsClass="row"
-          componentClass="div"
-        >
-          <Col
-            bsClass="col"
-            className="app-ReservationInformationModal__field__label"
-            componentClass="div"
-            xs={5}
-          >
-            <span>
-              common.reserverPhoneNumberLabel
-            </span>
-          </Col>
-          <Col
-            bsClass="col"
-            className="app-ReservationInformationModal__field__value"
-            componentClass="div"
-            xs={7}
-          >
-            <span />
-          </Col>
-        </Row>
-      </div>
+      <InjectT(ReservationMetadata)
+        customField={[Function]}
+        reservation={
+          Object {
+            "begin": "2019-08-14T14:00:00+03:00",
+            "comments": "",
+            "end": "2019-08-14T15:00:00+03:00",
+            "event_description": "",
+            "event_subject": "",
+            "has_catering_order": false,
+            "id": 1,
+            "its_own": false,
+            "resource": 1,
+            "staff_event": false,
+            "state": "requested",
+            "url": "https://respa.koe.hel.ninja/v1/reservation/192388/",
+            "user": Object {},
+            "user_permissions": null,
+          }
+        }
+      />
     </div>
     <div
       className="app-ReservationInformationModal__edit-reservation-btn"
@@ -302,7 +160,7 @@ exports[`ReservationInformationModal renders correctly 1`] = `
           block={false}
           bsClass="btn"
           bsStyle="primary"
-          disabled={true}
+          disabled={false}
           onClick={[Function]}
         >
           ReservationInfoModal.saveComment
@@ -329,7 +187,7 @@ exports[`ReservationInformationModal renders correctly 1`] = `
       block={false}
       bsClass="btn"
       bsStyle="default"
-      disabled={true}
+      disabled={false}
       onClick={[Function]}
     >
       ReservationInfoModal.cancelButton
@@ -339,7 +197,7 @@ exports[`ReservationInformationModal renders correctly 1`] = `
       block={false}
       bsClass="btn"
       bsStyle="danger"
-      disabled={true}
+      disabled={false}
       onClick={[Function]}
     >
       ReservationInfoModal.denyButton
@@ -349,7 +207,7 @@ exports[`ReservationInformationModal renders correctly 1`] = `
       block={false}
       bsClass="btn"
       bsStyle="success"
-      disabled={true}
+      disabled={false}
       onClick={[Function]}
     >
       ReservationInfoModal.confirmButton


### PR DESCRIPTION
- Dynamically render reservation metadata fields.
- Add custom function to render custom metadata rows.
- Add supported fields (extract from Respa)
- Trim empty field value, hide those field from rendering.
- Hide reservation action button from user without permissions in manage reservation.