### PR TITLE
VAR-163 | Add new filters to filter reset button, keep filter state when navigate.

### DIFF
--- a/app/i18n/messages/en.json
+++ b/app/i18n/messages/en.json
@@ -334,7 +334,7 @@
   "ManageReservationsList.nameHeader": "Name",
   "ManageReservationsList.emailHeader": "Email",
   "ManageReservationsList.resourceHeader": "Resource",
-  "ManageReservationsList.locationHeader": "Location",
+  "ManageReservationsList.premiseHeader": "Premise",
   "ManageReservationsList.dateAndTimeHeader": "Date and time",
   "ManageReservationsList.statusHeader": "Status",
   "ManageReservationsList.pinHeader": "PIN",

--- a/app/i18n/messages/fi.json
+++ b/app/i18n/messages/fi.json
@@ -343,7 +343,7 @@
   "ManageReservationsList.nameHeader": "Nimi",
   "ManageReservationsList.emailHeader": "Sähköposti",
   "ManageReservationsList.resourceHeader": "Resurssi",
-  "ManageReservationsList.locationHeader": "Sijainti",
+  "ManageReservationsList.premiseHeader": "Toimipiste",
   "ManageReservationsList.dateAndTimeHeader": "Milloin",
   "ManageReservationsList.statusHeader": "Tila",
   "ManageReservationsList.pinHeader": "PIN",

--- a/app/i18n/messages/sv.json
+++ b/app/i18n/messages/sv.json
@@ -335,7 +335,7 @@
   "ManageReservationsList.nameHeader": "Namn",
   "ManageReservationsList.emailHeader": "E-post",
   "ManageReservationsList.resourceHeader": "Resurs",
-  "ManageReservationsList.locationHeader": "Plats",
+  "ManageReservationsList.premiseHeader": "Utrymmet",
   "ManageReservationsList.dateAndTimeHeader": "När",
   "ManageReservationsList.statusHeader": "Status",
   "ManageReservationsList.pinHeader": "PIN",

--- a/src/common/form/fields/_buttonGroupField.scss
+++ b/src/common/form/fields/_buttonGroupField.scss
@@ -1,7 +1,4 @@
 .app-ButtonGroupField {
-  &__label {
-  }
-
   &__buttons {
     display: block;
     overflow: hidden;
@@ -9,7 +6,7 @@
   }
 
   &__button {
-    margin: 0 2px !important;
+    margin: 0 5px 5px 0 !important;
     font-size: 14px;
     font-weight: 500;
 

--- a/src/domain/reservation/manage/filters/ManageReservationsFilters.js
+++ b/src/domain/reservation/manage/filters/ManageReservationsFilters.js
@@ -144,7 +144,7 @@ class ManageReservationsFilters extends React.Component {
                 </Col>
               </Row>
               <Row>
-                <Col md={3}>
+                <Col md={5}>
                   <SelectField
                     id="unitField"
                     label={t('ManageReservationsFilters.unitLabel')}

--- a/src/domain/reservation/manage/filters/ManageReservationsFilters.js
+++ b/src/domain/reservation/manage/filters/ManageReservationsFilters.js
@@ -29,7 +29,8 @@ class ManageReservationsFilters extends React.Component {
     filters: PropTypes.object,
     units: PropTypes.array,
     onSearchChange: PropTypes.func.isRequired,
-    onListFilterChange: PropTypes.func.isRequired,
+    onShowOnlyFiltersChange: PropTypes.func.isRequired,
+    showOnlyFilters: PropTypes.array,
     intl: intlShape,
   };
 
@@ -51,14 +52,18 @@ class ManageReservationsFilters extends React.Component {
   };
 
   onReset = () => {
-    const { onSearchChange } = this.props;
+    const { onSearchChange, onShowOnlyFiltersChange } = this.props;
+
+    onShowOnlyFiltersChange();
+    // Reset show only filters by giving empty selection
+
     onSearchChange({});
   };
 
   hasFilters = () => {
-    const { filters } = this.props;
+    const { filters, showOnlyFilters } = this.props;
 
-    return !isEmpty(omit(filters, 'page'));
+    return !isEmpty(omit(filters, 'page')) || !isEmpty(showOnlyFilters);
   };
 
   getStatusOptions = () => {
@@ -95,7 +100,7 @@ class ManageReservationsFilters extends React.Component {
       filters,
       units,
       intl,
-      onListFilterChange
+      onShowOnlyFiltersChange
     } = this.props;
 
     const state = get(filters, 'state', null);
@@ -107,67 +112,40 @@ class ManageReservationsFilters extends React.Component {
       <div className="app-ManageReservationsFilters">
         <Grid>
           <Row>
-            <Col md={9}>
-              <Row>
-                <Col md={5}>
-                  <ButtonGroupField
-                    id="stateField"
-                    label={t('ManageReservationsFilters.statusLabel')}
-                    onChange={value => this.onFilterChange('state', value)}
-                    options={this.getStatusOptions()}
-                    type="checkbox"
-                    value={state ? state.split(',') : null}
-                  />
-                </Col>
-                <Col md={7}>
-                  <div className="app-ManageReservationsFilters__datePickers">
-                    <DateField
-                      id="startDateField"
-                      label={t('ManageReservationsFilters.startDateLabel')}
-                      onChange={(value) => {
-                        this.onFilterChange('start', moment(value).format(constants.DATE_FORMAT));
-                      }}
-                      placeholder={t('ManageReservationsFilters.startDatePlaceholder')}
-                      value={startDate ? moment(startDate).toDate() : null}
-                    />
-                    <div className="separator">-</div>
-                    <DateField
-                      id="EndDateField"
-                      label={t('ManageReservationsFilters.endDateLabel')}
-                      onChange={(value) => {
-                        this.onFilterChange('end', moment(value).format(constants.DATE_FORMAT));
-                      }}
-                      placeholder={t('ManageReservationsFilters.endDatePlaceholder')}
-                      value={endDate ? moment(endDate).toDate() : null}
-                    />
-                  </div>
-                </Col>
-              </Row>
-              <Row>
-                <Col md={5}>
-                  <SelectField
-                    id="unitField"
-                    label={t('ManageReservationsFilters.unitLabel')}
-                    onChange={item => this.onFilterChange('unit', item.value)}
-                    options={units.map(unit => ({
-                      value: unit.id,
-                      label: dataUtils.getLocalizedFieldValue(unit.name, locale)
-                    }))}
-                    value={get(filters, 'unit', null)}
-                  />
-                </Col>
-                <Col md={3}>
-                  <ButtonGroupField
-                    id="showOnlyField"
-                    label={t('ManageReservationsFilters.showOnly.title')}
-                    onChange={value => onListFilterChange(value)}
-                    options={this.getShowOnlyOptions()}
-                    type="checkbox"
-                  />
-                </Col>
-              </Row>
-            </Col>
             <Col md={3}>
+              <ButtonGroupField
+                id="stateField"
+                label={t('ManageReservationsFilters.statusLabel')}
+                onChange={value => this.onFilterChange('state', value)}
+                options={this.getStatusOptions()}
+                type="checkbox"
+                value={state ? state.split(',') : null}
+              />
+            </Col>
+            <Col md={5}>
+              <div className="app-ManageReservationsFilters__datePickers">
+                <DateField
+                  id="startDateField"
+                  label={t('ManageReservationsFilters.startDateLabel')}
+                  onChange={(value) => {
+                    this.onFilterChange('start', moment(value).format(constants.DATE_FORMAT));
+                  }}
+                  placeholder={t('ManageReservationsFilters.startDatePlaceholder')}
+                  value={startDate ? moment(startDate).toDate() : null}
+                />
+                <div className="separator">-</div>
+                <DateField
+                  id="EndDateField"
+                  label={t('ManageReservationsFilters.endDateLabel')}
+                  onChange={(value) => {
+                    this.onFilterChange('end', moment(value).format(constants.DATE_FORMAT));
+                  }}
+                  placeholder={t('ManageReservationsFilters.endDatePlaceholder')}
+                  value={endDate ? moment(endDate).toDate() : null}
+                />
+              </div>
+            </Col>
+            <Col md={4}>
               <TextField
                 id="searchField"
                 label={t('ManageReservationsFilters.searchLabel')}
@@ -175,7 +153,32 @@ class ManageReservationsFilters extends React.Component {
                 placeholder={t('ManageReservationsFilters.searchPlaceholder')}
                 value={get(filters, 'reserver_info_search', '')}
               />
+            </Col>
+          </Row>
 
+          <Row>
+            <Col md={3}>
+              <SelectField
+                id="unitField"
+                label={t('ManageReservationsFilters.unitLabel')}
+                onChange={item => this.onFilterChange('unit', item.value)}
+                options={units.map(unit => ({
+                  value: unit.id,
+                  label: dataUtils.getLocalizedFieldValue(unit.name, locale)
+                }))}
+                value={get(filters, 'unit', null)}
+              />
+            </Col>
+            <Col md={5}>
+              <ButtonGroupField
+                id="showOnlyField"
+                label={t('ManageReservationsFilters.showOnly.title')}
+                onChange={value => onShowOnlyFiltersChange(value)}
+                options={this.getShowOnlyOptions()}
+                type="checkbox"
+              />
+            </Col>
+            <Col md={4}>
               {this.hasFilters() && (
                 <Button
                   bsStyle="link"

--- a/src/domain/reservation/manage/filters/__tests__/__snapshots__/ManageReservationsFilters.test.js.snap
+++ b/src/domain/reservation/manage/filters/__tests__/__snapshots__/ManageReservationsFilters.test.js.snap
@@ -16,129 +16,69 @@ exports[`ManageReservationsFilters renders correctly 1`] = `
       <Col
         bsClass="col"
         componentClass="div"
-        md={9}
+        md={3}
       >
-        <Row
-          bsClass="row"
-          componentClass="div"
-        >
-          <Col
-            bsClass="col"
-            componentClass="div"
-            md={5}
-          >
-            <ButtonGroupField
-              id="stateField"
-              label="ManageReservationsFilters.statusLabel"
-              onChange={[Function]}
-              options={
-                Array [
-                  Object {
-                    "label": "Reservation.stateLabelConfirmed",
-                    "value": "confirmed",
-                  },
-                  Object {
-                    "label": "Reservation.stateLabelCancelled",
-                    "value": "cancelled",
-                  },
-                  Object {
-                    "label": "Reservation.stateLabelDenied",
-                    "value": "denied",
-                  },
-                  Object {
-                    "label": "Reservation.stateLabelRequested",
-                    "value": "requested",
-                  },
-                ]
-              }
-              type="checkbox"
-              value={null}
-            />
-          </Col>
-          <Col
-            bsClass="col"
-            componentClass="div"
-            md={7}
-          >
-            <div
-              className="app-ManageReservationsFilters__datePickers"
-            >
-              <InjectT(UntranslatedDateField)
-                id="startDateField"
-                label="ManageReservationsFilters.startDateLabel"
-                onChange={[Function]}
-                placeholder="ManageReservationsFilters.startDatePlaceholder"
-                value={null}
-              />
-              <div
-                className="separator"
-              >
-                -
-              </div>
-              <InjectT(UntranslatedDateField)
-                id="EndDateField"
-                label="ManageReservationsFilters.endDateLabel"
-                onChange={[Function]}
-                placeholder="ManageReservationsFilters.endDatePlaceholder"
-                value={null}
-              />
-            </div>
-          </Col>
-        </Row>
-        <Row
-          bsClass="row"
-          componentClass="div"
-        >
-          <Col
-            bsClass="col"
-            componentClass="div"
-            md={3}
-          >
-            <InjectT(SelectField)
-              id="unitField"
-              label="ManageReservationsFilters.unitLabel"
-              onChange={[Function]}
-              options={
-                Array [
-                  Object {
-                    "label": "Unit (en) - 1",
-                    "value": 1,
-                  },
-                ]
-              }
-              value={null}
-            />
-          </Col>
-          <Col
-            bsClass="col"
-            componentClass="div"
-            md={3}
-          >
-            <ButtonGroupField
-              id="showOnlyField"
-              label="ManageReservationsFilters.showOnly.title"
-              onChange={[Function]}
-              options={
-                Array [
-                  Object {
-                    "label": "ManageReservationsFilters.showOnly.favoriteButtonLabel",
-                    "value": "favorite",
-                  },
-                  Object {
-                    "label": "ManageReservationsFilters.showOnly.canModifyButtonLabel",
-                    "value": "can_modify",
-                  },
-                ]
-              }
-              type="checkbox"
-            />
-          </Col>
-        </Row>
+        <ButtonGroupField
+          id="stateField"
+          label="ManageReservationsFilters.statusLabel"
+          onChange={[Function]}
+          options={
+            Array [
+              Object {
+                "label": "Reservation.stateLabelConfirmed",
+                "value": "confirmed",
+              },
+              Object {
+                "label": "Reservation.stateLabelCancelled",
+                "value": "cancelled",
+              },
+              Object {
+                "label": "Reservation.stateLabelDenied",
+                "value": "denied",
+              },
+              Object {
+                "label": "Reservation.stateLabelRequested",
+                "value": "requested",
+              },
+            ]
+          }
+          type="checkbox"
+          value={null}
+        />
       </Col>
       <Col
         bsClass="col"
         componentClass="div"
-        md={3}
+        md={5}
+      >
+        <div
+          className="app-ManageReservationsFilters__datePickers"
+        >
+          <InjectT(UntranslatedDateField)
+            id="startDateField"
+            label="ManageReservationsFilters.startDateLabel"
+            onChange={[Function]}
+            placeholder="ManageReservationsFilters.startDatePlaceholder"
+            value={null}
+          />
+          <div
+            className="separator"
+          >
+            -
+          </div>
+          <InjectT(UntranslatedDateField)
+            id="EndDateField"
+            label="ManageReservationsFilters.endDateLabel"
+            onChange={[Function]}
+            placeholder="ManageReservationsFilters.endDatePlaceholder"
+            value={null}
+          />
+        </div>
+      </Col>
+      <Col
+        bsClass="col"
+        componentClass="div"
+        md={4}
       >
         <TextField
           id="searchField"
@@ -148,6 +88,60 @@ exports[`ManageReservationsFilters renders correctly 1`] = `
           value=""
         />
       </Col>
+    </Row>
+    <Row
+      bsClass="row"
+      componentClass="div"
+    >
+      <Col
+        bsClass="col"
+        componentClass="div"
+        md={3}
+      >
+        <InjectT(SelectField)
+          id="unitField"
+          label="ManageReservationsFilters.unitLabel"
+          onChange={[Function]}
+          options={
+            Array [
+              Object {
+                "label": "Unit (en) - 1",
+                "value": 1,
+              },
+            ]
+          }
+          value={null}
+        />
+      </Col>
+      <Col
+        bsClass="col"
+        componentClass="div"
+        md={5}
+      >
+        <ButtonGroupField
+          id="showOnlyField"
+          label="ManageReservationsFilters.showOnly.title"
+          onChange={[Function]}
+          options={
+            Array [
+              Object {
+                "label": "ManageReservationsFilters.showOnly.favoriteButtonLabel",
+                "value": "favorite",
+              },
+              Object {
+                "label": "ManageReservationsFilters.showOnly.canModifyButtonLabel",
+                "value": "can_modify",
+              },
+            ]
+          }
+          type="checkbox"
+        />
+      </Col>
+      <Col
+        bsClass="col"
+        componentClass="div"
+        md={4}
+      />
     </Row>
   </Grid>
 </div>

--- a/src/domain/reservation/manage/list/ManageReservationsList.js
+++ b/src/domain/reservation/manage/list/ManageReservationsList.js
@@ -37,7 +37,7 @@ const ManageReservationsList = ({
             <th>{t('ManageReservationsList.nameHeader')}</th>
             <th>{t('ManageReservationsList.emailHeader')}</th>
             <th>{t('ManageReservationsList.resourceHeader')}</th>
-            <th>{t('ManageReservationsList.locationHeader')}</th>
+            <th>{t('ManageReservationsList.premiseHeader')}</th>
             <th>{t('ManageReservationsList.dateAndTimeHeader')}</th>
             <th />
             <th>{t('ManageReservationsList.pinHeader')}</th>

--- a/src/domain/reservation/manage/list/__tests__/__snapshots__/ManageReservationsList.test.js.snap
+++ b/src/domain/reservation/manage/list/__tests__/__snapshots__/ManageReservationsList.test.js.snap
@@ -28,7 +28,7 @@ exports[`ManageReservationsList renders correctly 1`] = `
           ManageReservationsList.resourceHeader
         </th>
         <th>
-          ManageReservationsList.locationHeader
+          ManageReservationsList.premiseHeader
         </th>
         <th>
           ManageReservationsList.dateAndTimeHeader

--- a/src/domain/reservation/manage/page/ManageReservationsPage.js
+++ b/src/domain/reservation/manage/page/ManageReservationsPage.js
@@ -44,7 +44,7 @@ class ManageReservationsPage extends React.Component {
       totalCount: 0,
       isModalOpen: false,
       selectedReservation: {},
-      filteredReservations: []
+      showOnlyFilters: []
     };
   }
 
@@ -84,7 +84,6 @@ class ManageReservationsPage extends React.Component {
         this.setState({
           isLoading: false,
           reservations: get(data, 'results', []),
-          filteredReservations: get(data, 'results', []),
           totalCount: get(data, 'count', 0),
         });
       });
@@ -114,7 +113,7 @@ class ManageReservationsPage extends React.Component {
 
   onListFilterChange = (filters) => {
     this.setState({
-      filteredReservations: this.getFilteredReservations(filters)
+      showOnlyFilters: filters
     });
   }
 
@@ -195,11 +194,11 @@ class ManageReservationsPage extends React.Component {
     const {
       isLoading,
       isLoadingUnits,
-      filteredReservations,
       units,
       totalCount,
       isModalOpen,
-      selectedReservation
+      selectedReservation,
+      showOnlyFilters
     } = this.state;
     const filters = searchUtils.getFiltersFromUrl(location, false);
     const title = t('ManageReservationsPage.title');
@@ -230,7 +229,7 @@ class ManageReservationsPage extends React.Component {
                     onEditClick={this.onEditClick}
                     onEditReservation={this.onEditReservation}
                     onInfoClick={this.onInfoClick}
-                    reservations={filteredReservations}
+                    reservations={this.getFilteredReservations(showOnlyFilters)}
                   />
                 </Loader>
                 <Pagination

--- a/src/domain/reservation/manage/page/ManageReservationsPage.js
+++ b/src/domain/reservation/manage/page/ManageReservationsPage.js
@@ -4,6 +4,7 @@ import get from 'lodash/get';
 import Loader from 'react-loader';
 import { withRouter } from 'react-router-dom';
 import { Grid, Row, Col } from 'react-bootstrap';
+import isEmpty from 'lodash/isEmpty';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { createStructuredSelector } from 'reselect';
@@ -111,7 +112,7 @@ class ManageReservationsPage extends React.Component {
     });
   };
 
-  onListFilterChange = (filters) => {
+  onShowOnlyFiltersChange = (filters) => {
     this.setState({
       showOnlyFilters: filters
     });
@@ -168,6 +169,10 @@ class ManageReservationsPage extends React.Component {
 
     const canModifyFilter = reservation => reservationUtils.canUserModifyReservation(reservation);
 
+    if (isEmpty(filters) || !Array.isArray(filters)) {
+      return reservations;
+    }
+
     // Both options selected
     if (filters.length > 1) {
       return reservations.filter(reservation => canModifyFilter(reservation) && favoriteResourceFilter(reservation));
@@ -215,8 +220,9 @@ class ManageReservationsPage extends React.Component {
           </Grid>
           <ManageReservationsFilters
             filters={filters}
-            onListFilterChange={this.onListFilterChange}
             onSearchChange={this.onSearchFiltersChange}
+            onShowOnlyFiltersChange={this.onShowOnlyFiltersChange}
+            showOnlyFilters={showOnlyFilters}
             units={units}
           />
         </div>

--- a/src/domain/reservation/manage/page/__tests__/ManageReservationsPage.test.js
+++ b/src/domain/reservation/manage/page/__tests__/ManageReservationsPage.test.js
@@ -3,16 +3,83 @@ import toJSON from 'enzyme-to-json';
 
 import { shallowWithIntl } from '../../../../../../app/utils/testUtils';
 import { UnwrappedManageReservationsPage } from '../ManageReservationsPage';
+import resourceCreator from '../../../../../common/data/fixtures/resource';
+import reservationCreator from '../../../../../common/data/fixtures/reservation';
+import { RESERVATION_SHOWONLY_FILTERS } from '../../../constants';
+import { RESERVATION_STATE } from '../../../../../constants/ReservationState';
 
 describe('ManageReservationsPage', () => {
-  test('renders correctly', () => {
-    const props = {
-      location: { search: '' },
-    };
-    const wrapper = shallowWithIntl(
-      <UnwrappedManageReservationsPage {...props} />
-    );
+  const defaultProps = {
+    location: { search: '' }
+  };
+  const wrapper = props => shallowWithIntl(
+    <UnwrappedManageReservationsPage {...defaultProps} {...props} />
+  );
 
-    expect(toJSON(wrapper)).toMatchSnapshot();
+  test('renders correctly', () => {
+    const page = wrapper();
+    expect(toJSON(page)).toMatchSnapshot();
+  });
+
+  describe('Reservation show_only filters', () => {
+    const unFavResource = resourceCreator.build({ id: 'unfav' });
+    const favResource = resourceCreator.build({ id: 'fav' });
+
+    const unFavReservation = reservationCreator.build({
+      resource: unFavResource,
+      user_permissions: { can_modify: false },
+      state: RESERVATION_STATE.REQUESTED
+    });
+
+    const favReservation = reservationCreator.build({
+      resource: favResource,
+      user_permissions: { can_modify: true },
+      state: RESERVATION_STATE.CANCELLED
+    });
+
+    const canModifyFav = reservationCreator.build({
+      resource: favResource,
+      user_permissions: { can_modify: true },
+      state: RESERVATION_STATE.REQUESTED
+    });
+
+    const mockReservations = [
+      unFavReservation,
+      favReservation,
+      canModifyFav
+    ];
+
+    const page = wrapper({ userFavoriteResources: ['fav'] });
+
+    beforeAll(() => {
+      page.setState({ reservations: mockReservations });
+      page.update();
+    });
+
+    test('return unfiltered reservations by default if no selected filter', () => {
+      const filtered = page.instance().getFilteredReservations([]);
+      const empty = page.instance().getFilteredReservations();
+
+      expect(filtered).toEqual(mockReservations);
+      expect(empty).toEqual(mockReservations);
+    });
+
+    test('return unfiltered reservations by default if arguments is not supported', () => {
+      const filtered = page.instance().getFilteredReservations('foo');
+
+      expect(filtered).toEqual(mockReservations);
+    });
+
+    test('return favorite reservations if show_only: favorite selected', () => {
+      const filtered = page.instance().getFilteredReservations([RESERVATION_SHOWONLY_FILTERS.FAVORITE]);
+
+      expect(filtered).toEqual([favReservation, canModifyFav]);
+    });
+
+    test('return can_modify reservations if show_only: can_modify selected', () => {
+      const filtered = page.instance().getFilteredReservations([RESERVATION_SHOWONLY_FILTERS.CAN_MODIFY]);
+
+      expect(filtered).toEqual([canModifyFav]);
+    });
   });
 });

--- a/src/domain/reservation/manage/page/__tests__/__snapshots__/ManageReservationsPage.test.js.snap
+++ b/src/domain/reservation/manage/page/__tests__/__snapshots__/ManageReservationsPage.test.js.snap
@@ -29,8 +29,9 @@ exports[`ManageReservationsPage renders correctly 1`] = `
     </Grid>
     <InjectIntl(InjectT(ManageReservationsFilters))
       filters={Object {}}
-      onListFilterChange={[Function]}
       onSearchChange={[Function]}
+      onShowOnlyFiltersChange={[Function]}
+      showOnlyFilters={Array []}
       units={Array []}
     />
   </div>


### PR DESCRIPTION
- When new filters button selected, show reset filters button.
- Keep button state as internal state, so it will persist as long as user not refresh / unmount page.

Extra:
- Rename `location` to `premise` as request from PO.
- Add extra margin between buttons as request from PO.