### PR TITLE
Render headline and equipment with condition check

### DIFF
--- a/app/pages/resource/resource-info/ResourceInfo.js
+++ b/app/pages/resource/resource-info/ResourceInfo.js
@@ -61,7 +61,7 @@ function ResourceInfo({
         </Row>
       </ResourcePanel>
 
-      { resource.equipment.length > 0 && (<Equipment equipment={resource.equipment} />) }
+      { Array.isArray(resource.equipment) && resource.equipment.length > 0 && (<Equipment equipment={resource.equipment} />) }
     </section>
   );
 }

--- a/app/pages/resource/resource-info/ResourceInfo.js
+++ b/app/pages/resource/resource-info/ResourceInfo.js
@@ -18,9 +18,14 @@ function ResourceInfo({
 
   return (
     <section className="app-ResourceInfo">
-      <div className="app-ResourceInfo__description">
-        {resource.description && <WrappedText openLinksInNewTab text={resource.description} />}
-      </div>
+      {resource.description && (
+        <ResourcePanel header={t('ResourceInfo.descriptionTitle')}>
+          <div className="app-ResourceInfo__description">
+            {resource.description && <WrappedText openLinksInNewTab text={resource.description} />}
+          </div>
+        </ResourcePanel>
+      )}
+
       <ResourcePanel header={t('ResourceInfo.reservationTitle')}>
         <ReservationInfo isLoggedIn={isLoggedIn} resource={resource} />
       </ResourcePanel>
@@ -56,7 +61,7 @@ function ResourceInfo({
         </Row>
       </ResourcePanel>
 
-      <Equipment equipment={resource.equipment} />
+      { resource.equipment.length > 0 && (<Equipment equipment={resource.equipment} />) }
     </section>
   );
 }

--- a/app/pages/resource/resource-info/ResourceInfo.js
+++ b/app/pages/resource/resource-info/ResourceInfo.js
@@ -21,7 +21,7 @@ function ResourceInfo({
       {resource.description && (
         <ResourcePanel header={t('ResourceInfo.descriptionTitle')}>
           <div className="app-ResourceInfo__description">
-            {resource.description && <WrappedText openLinksInNewTab text={resource.description} />}
+            <WrappedText openLinksInNewTab text={resource.description} />
           </div>
         </ResourcePanel>
       )}


### PR DESCRIPTION
What was happening : 
- Headline title was missing in resource page 
- Headline and equipment title was rendered even when there was no any content inside them.

What this PR fixes :
- Adds the headline title in the resource page
-  Makes condition check to render headline and equipment section only if they have some content. 

Test resource link for this : [https://varaamo.test.hel.ninja/resources/awfkojswli4q](https://varaamo.test.hel.ninja/resources/awfkojswli4q)