### PR TITLE
VAR-94 | Add missing specific terms headlines in the reservation form

### DIFF
--- a/app/i18n/messages/en.json
+++ b/app/i18n/messages/en.json
@@ -203,6 +203,7 @@
   "ReservationForm.cancel": "Back",
   "ReservationForm.emailError": "Enter a valid e-mail address",
   "ReservationForm.eventSubjectInfo": "Event name is visible to staff only. Giving a name to the event makes it easier to guide the guests to the right space. Please remember to also tell the name to people arriving to the event.",
+  "ReservationForm.specificTermsTitle": "Specific terms",
   "ReservationForm.maxLengthError": "The maximum length of the field is {maxLength} characters",
   "ReservationForm.requiredError": "Mandatory information",
   "ReservationForm.staffEventHelp": "The Department’s own events are approved automatically and the only mandatory information is the name of the person making the reservation and a description of the event.",

--- a/app/i18n/messages/fi.json
+++ b/app/i18n/messages/fi.json
@@ -203,6 +203,7 @@
   "ReservationForm.cancel": "Takaisin",
   "ReservationForm.emailError": "Syötä kunnollinen sähköpostiosoite",
   "ReservationForm.eventSubjectInfo": "Tilaisuuden nimen näkee ainoastaan henkilökunta. Antamalla tilaisuudelle nimen helpotat saapuvien vieraiden opastamista oikeaan tilaan. Muistathan ilmoittaa nimen myös tilaisuuteen saapuville.",
+  "ReservationForm.specificTermsTitle": "Resurssikohtaiset ehdot",
   "ReservationForm.maxLengthError": "Kentän maksimipituus on {maxLength} merkkiä",
   "ReservationForm.requiredError": "Pakollinen tieto",
   "ReservationForm.staffEventHelp": "Viraston oma tapahtuma hyväksytään automaattisesti ja ainoat pakolliset tiedot ovat varaajan nimi ja tilaisuuden kuvaus.",

--- a/app/i18n/messages/sv.json
+++ b/app/i18n/messages/sv.json
@@ -205,6 +205,7 @@
   "ReservationForm.cancel": "Tillbaka",
   "ReservationForm.emailError": "Mata in en giltig e-postadress",
   "ReservationForm.eventSubjectInfo": "Evenemangets namn är synbar enbart for personalen. Genom att ge evenemanget ett namn så kan vi lotsa besökarna till de rätta utrymmen. Kom ihåg att berätta evenemangets namn även till besökarna.",
+  "ReservationForm.specificTermsTitle": "Specifika villkor",
   "ReservationForm.maxLengthError": "Den maximala längden på fältet är {maxLength} tecken",
   "ReservationForm.requiredError": "Obligatorisk information",
   "ReservationForm.staffEventHelp": "Verkets egna evenemang godkänns automatiskt och de enda obligatoriska uppgifterna är namnet på personen som bokar utrymmet och beskrivningen av evenemanget.",

--- a/app/pages/reservation/reservation-information/ReservationInformationForm.js
+++ b/app/pages/reservation/reservation-information/ReservationInformationForm.js
@@ -357,9 +357,12 @@ class UnconnectedReservationInformationForm extends Component {
           {termsAndConditions
             && this.renderTermsField('termsAndConditions')
           }
-          {resource.specificTerms
-            && <p className="specificTermsContent">{resource.specificTerms}</p>
-          }
+          {resource.specificTerms && (
+            <div>
+              <h2 className="app-ReservationPage__title">{t('ReservationForm.specificTermsTitle')}</h2>
+              <p className="specificTermsContent">{resource.specificTerms}</p>
+            </div>
+          )}
           {includes(fields, 'paymentTermsAndConditions')
             && this.renderPaymentTermsField()
           }


### PR DESCRIPTION
​Specific terms text can be seen on reservation form. But headline is missing. This information should also be seen or hidden depending if resource is using specific terms. This PR should fix it.

Reference latest comment from : VAR-94