### PR TITLE
VAR-173 | Use resource's userPermissions.isAdmin flag to check if user isStaff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
   - Support for payments in Varaamo.
   - Add reusable FullCalendar component.
   - Add option to configure time zone of calendar/resources. Defaults to `Europe/Helsinki`.
+  - Permission checking has been changed: We are now using unit authorizations instead of unit object permissions from respa admin.
 
   **MINOR CHANGES**
   - Replace failure message and add a return button for reservation payment.
@@ -29,6 +30,7 @@
   - [#1028](https://github.com/City-of-Helsinki/varaamo/pull/1028) Always fetch reservations with start and end filters.
   - [#1029](https://github.com/City-of-Helsinki/varaamo/pull/1029) Add option to configure time zone for resources.
   - [#1033](https://github.com/City-of-Helsinki/varaamo/pull/1033) Show errors to staff members if editing of reservations fail.
+  - [#1031](https://github.com/City-of-Helsinki/varaamo/pull/1031) Use resource's userPermissions.isAdmin flag to check if user isStaff
 
 # 0.4.2
   **HOTFIX**

--- a/app/pages/user-reservations/reservation-list/__tests__/reservationListSelector.test.js
+++ b/app/pages/user-reservations/reservation-list/__tests__/reservationListSelector.test.js
@@ -24,10 +24,6 @@ describe('pages/user-reservations/reservation-list/reservationListSelector', () 
     expect(getSelected().resources).toBeDefined();
   });
 
-  test('returns staffUnits', () => {
-    expect(getSelected().staffUnits).toBeDefined();
-  });
-
   test('returns units from the state', () => {
     expect(getSelected().units).toBeDefined();
   });

--- a/app/pages/user-reservations/reservation-list/reservationListSelector.js
+++ b/app/pages/user-reservations/reservation-list/reservationListSelector.js
@@ -1,7 +1,7 @@
 import { createStructuredSelector } from 'reselect';
 
 import ActionTypes from '../../../constants/ActionTypes';
-import { isAdminSelector, staffUnitsSelector } from '../../../state/selectors/authSelectors';
+import { isAdminSelector } from '../../../state/selectors/authSelectors';
 import { resourcesSelector, unitsSelector } from '../../../state/selectors/dataSelectors';
 import requestIsActiveSelectorFactory from '../../../state/selectors/factories/requestIsActiveSelectorFactory';
 import sortedReservationsSelector from '../../../state/selectors/sortedReservationsSelector';
@@ -11,7 +11,6 @@ const reservationListSelector = createStructuredSelector({
   isFetchingReservations: requestIsActiveSelectorFactory(ActionTypes.API.RESERVATIONS_GET_REQUEST),
   reservations: sortedReservationsSelector,
   resources: resourcesSelector,
-  staffUnits: staffUnitsSelector,
   units: unitsSelector,
 });
 

--- a/app/state/selectors/__tests__/authSelectors.test.js
+++ b/app/state/selectors/__tests__/authSelectors.test.js
@@ -4,7 +4,6 @@ import {
   currentUserSelector,
   isAdminSelector,
   isLoggedInSelector,
-  staffUnitsSelector,
 } from '../authSelectors';
 
 describe('state/selectors/authSelectors', () => {
@@ -82,78 +81,5 @@ describe('state/selectors/authSelectors', () => {
     test('returns true if both token and userId are defined', () => {
       expect(getSelected({ token: 'mock-token', userId: 'u-1' })).toBe(true);
     });
-  });
-
-  describe('staffUnitsSelector', () => {
-    function getSelected(user) {
-      const state = {
-        auth: {
-          userId: user.id,
-          token: 'mock-token',
-        },
-        data: {
-          users: { [user.id]: user },
-        },
-      };
-      return staffUnitsSelector(state);
-    }
-
-    test(
-      'returns unit ids where user has can_approve_reservation permission',
-      () => {
-        const user = User.build({
-          staffPerms: {
-            unit: {
-              'unit-1': ['can_approve_reservation'],
-              'unit-2': ['can_approve_reservation'],
-            },
-          },
-        });
-        const selected = getSelected(user);
-        const expected = ['unit-1', 'unit-2'];
-
-        expect(selected).toEqual(expected);
-      }
-    );
-
-    test(
-      'does not return unit ids where user does not have can_approve_reservation permission',
-      () => {
-        const user = User.build({
-          staffPerms: {
-            unit: {
-              'unit-1': ['can_approve_something_else'],
-              'unit-2': ['can_approve_reservation'],
-              'unit-3': [],
-            },
-          },
-        });
-        const selected = getSelected(user);
-        const expected = ['unit-2'];
-
-        expect(selected).toEqual(expected);
-      }
-    );
-
-    test('returns an empty array if user has no staff permissions', () => {
-      const user = User.build();
-      const selected = getSelected(user);
-
-      expect(selected).toEqual([]);
-    });
-
-    test(
-      'returns an empty array if user has no staff permissions for units',
-      () => {
-        const user = User.build({
-          staffPerms: {
-            unit: {},
-          },
-        });
-        const selected = getSelected(user);
-
-        expect(selected).toEqual([]);
-      }
-    );
   });
 });

--- a/app/state/selectors/authSelectors.js
+++ b/app/state/selectors/authSelectors.js
@@ -24,29 +24,6 @@ function isLoggedInSelector(state) {
 }
 
 /**
- * TODO: Find out if this is needed any more, and if isn't: Remove.
- * With our current knowledge, people are given admin permissions for
- * resources through: https://respa.koe.hel.ninja/admin/resources/unitauthorization
- *
- * New staff users won't ever get any "can approve reservation" flags for any units.
- */
-const staffUnitsSelector = createSelector(
-  currentUserSelector,
-  (currentUser) => {
-    if (!currentUser.staffPerms || !currentUser.staffPerms.unit) {
-      return [];
-    }
-    const units = [];
-    forIn(currentUser.staffPerms.unit, (value, key) => {
-      if (includes(value, 'can_approve_reservation')) {
-        units.push(key);
-      }
-    });
-    return units;
-  }
-);
-
-/**
  * Check if a user has admin permission for a unit.
  * TODO: Find a better name for this.
  */
@@ -62,5 +39,4 @@ export {
   currentUserSelector,
   isAdminSelector,
   isLoggedInSelector,
-  staffUnitsSelector,
 };

--- a/app/state/selectors/authSelectors.js
+++ b/app/state/selectors/authSelectors.js
@@ -1,5 +1,3 @@
-import forIn from 'lodash/forIn';
-import includes from 'lodash/includes';
 import { createSelector } from 'reselect';
 
 const userIdSelector = state => state.auth.userId;

--- a/app/state/selectors/authSelectors.js
+++ b/app/state/selectors/authSelectors.js
@@ -1,4 +1,5 @@
 import { createSelector } from 'reselect';
+import { get } from 'lodash';
 
 const userIdSelector = state => state.auth.userId;
 const usersSelector = state => state.data.users;
@@ -28,7 +29,7 @@ function isLoggedInSelector(state) {
 function createIsStaffSelector(resourceSelector) {
   return createSelector(
     resourceSelector,
-    resource => Boolean(resource && resource.userPermissions && resource.userPermissions.isAdmin)
+    resource => Boolean(get(resource, 'userPermissions.isAdmin', false))
   );
 }
 

--- a/app/state/selectors/authSelectors.js
+++ b/app/state/selectors/authSelectors.js
@@ -12,7 +12,7 @@ const currentUserSelector = createSelector(
 );
 
 /**
- * Gotcha warning: Respa API uses isStaff flag for what Varaamo consider admin users.
+ * Check if the user is staff and can see the private route.
  */
 const isAdminSelector = createSelector(
   currentUserSelector,
@@ -23,6 +23,13 @@ function isLoggedInSelector(state) {
   return Boolean(state.auth.userId && state.auth.token);
 }
 
+/**
+ * TODO: Find out if this is needed any more, and if isn't: Remove.
+ * With our current knowledge, people are given admin permissions for
+ * resources through: https://respa.koe.hel.ninja/admin/resources/unitauthorization
+ *
+ * New staff users won't ever get any "can approve reservation" flags for any units.
+ */
 const staffUnitsSelector = createSelector(
   currentUserSelector,
   (currentUser) => {
@@ -40,16 +47,13 @@ const staffUnitsSelector = createSelector(
 );
 
 /**
- * Gotcha warning: Respa API uses isStaff boolean value for admin users.
- *
- * From Varaamo's point of view, a user is staff if they have permissions to
- * approve reservations for a resource.
+ * Check if a user has admin permission for a unit.
+ * TODO: Find a better name for this.
  */
 function createIsStaffSelector(resourceSelector) {
   return createSelector(
     resourceSelector,
-    staffUnitsSelector,
-    (resource, staffUnits) => includes(staffUnits, resource.unit)
+    resource => Boolean(resource && resource.userPermissions && resource.userPermissions.isAdmin)
   );
 }
 

--- a/src/domain/resource/utils.js
+++ b/src/domain/resource/utils.js
@@ -482,7 +482,6 @@ export const isTimeRangeReservable = (resource, start, end, isStaff = false, eve
   return startMoment.isAfter(now);
 };
 
-
 /**
  * isFullCalendarEventDurationEditable();
  * @param resource {object} Resource object.


### PR DESCRIPTION
Turns out that we nowadays should decide if a user is an admin for a resource here: 
https://respa.koe.hel.ninja/admin/resources/unitauthorization/

so we're now updating the selector