### PR TITLE
VAR-206 | Allow to select timeslot which is already happening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
   - Add `show_only` filter section to filter reservation list. This filter have `can_modify` as its default value.
   - Anonymous users now see a log in button below the calendar on the resource page helping them understand that they need to log in to continue.
   - Errors from respa backend are not swallowed in our ApiClient anymore.
+  - Allow user to select time slot which is already happening.
 
   **HOTFIX**
   - Fix resource information headlines and icon.
@@ -36,6 +37,7 @@
   - [#1031](https://github.com/City-of-Helsinki/varaamo/pull/1031) Use resource's userPermissions.isAdmin flag to check if user isStaff.
   - [#1032](https://github.com/City-of-Helsinki/varaamo/pull/1032) Better max period handling for FullCalendar.
   - [#1035](https://github.com/City-of-Helsinki/varaamo/pull/1035) Daily / weekly view for mobile.
+  - [#1036](https://github.com/City-of-Helsinki/varaamo/pull/1036) Allow to select timeslot which is already happening.
 
 # 0.4.2
   **HOTFIX**

--- a/src/common/calendar/TimePickerCalendar.js
+++ b/src/common/calendar/TimePickerCalendar.js
@@ -341,7 +341,6 @@ class TimePickerCalendar extends Component {
           minTime={resourceUtils.getFullCalendarMinTime(resource, date, viewType)}
           ref={this.calendarRef}
           select={this.onSelect}
-          selectAllow={this.onSelectAllow}
           slotDuration={resourceUtils.getFullCalendarSlotDuration(resource, date, viewType)}
           slotLabelInterval={resourceUtils.getFullCalendarSlotLabelInterval(resource)}
         />

--- a/src/common/calendar/TimePickerCalendar.js
+++ b/src/common/calendar/TimePickerCalendar.js
@@ -166,11 +166,10 @@ class TimePickerCalendar extends Component {
 
       if (eventCallback) {
         eventCallback.revert();
+        createNotification(
+          NOTIFICATION_TYPE.INFO, t('TimePickerCalendar.info.minPeriodText', { duration: minPeriodDuration })
+        );
       }
-
-      createNotification(
-        NOTIFICATION_TYPE.INFO, t('TimePickerCalendar.info.minPeriodText', { duration: minPeriodDuration })
-      );
 
       selectable = calendarUtils.getMinPeriodTimeRange(resource, selected.start, selected.end);
       // Make sure selected time will always bigger than min period

--- a/src/domain/resource/utils.js
+++ b/src/domain/resource/utils.js
@@ -103,6 +103,22 @@ export const isFree = (resource) => {
 };
 
 /**
+ * getSlotSizeInMinutes();
+ * @param resource {object} Resource object.
+ * @returns {number} Slot size in minutes.
+ */
+export const getSlotSizeInMinutes = (resource) => {
+  const slotSize = get(resource, 'slot_size', null);
+
+  if (slotSize) {
+    const slotSizeDuration = moment.duration(slotSize);
+    return slotSizeDuration.hours() * 60 + slotSizeDuration.minutes();
+  }
+
+  return 30;
+};
+
+/**
  * getOpeningHours();
  * @param resource {object} Resource object.
  * @param date Date string that can be parsed as moment object.
@@ -441,8 +457,12 @@ export const isTimeRangeReservable = (resource, start, end, events) => {
     return false;
   }
 
+  const slotSize = getSlotSizeInMinutes(resource);
+  const oneTimeSlotBeforeNow = now.subtract(slotSize, 'minutes');
+
   // Prevent selecting times from past.
-  return startMoment.isAfter(now);
+  // But allow user to select timeslot which is happening.
+  return startMoment.isAfter(oneTimeSlotBeforeNow);
 };
 
 /**
@@ -558,22 +578,6 @@ export const getAvailabilityDataForWholeDay = (resource, date) => {
     bsStyle: 'success',
     values: { hours: rounded },
   };
-};
-
-/**
- * getSlotSizeInMinutes();
- * @param resource {object} Resource object.
- * @returns {number} Slot size in minutes.
- */
-export const getSlotSizeInMinutes = (resource) => {
-  const slotSize = get(resource, 'slot_size', null);
-
-  if (slotSize) {
-    const slotSizeDuration = moment.duration(slotSize);
-    return slotSizeDuration.hours() * 60 + slotSizeDuration.minutes();
-  }
-
-  return 30;
 };
 
 /**


### PR DESCRIPTION
Instead of checking if timerange startTime is AfterNow to prevent user select slot which already happened -> move `now()` to 1 timeSlot to allow that.