### PR TITLE
[Hotfix] VAR-149 | Populate resource fetching with default time range as 1 month.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.6.1
+  **HOTFIX**
+  - Resource fetchAll come with empty reservations data, affect resource availability status was determined wrong, which confuse user and display wrong status.
+
+  **CHANGELOG**
+  - [#1044](https://github.com/City-of-Helsinki/varaamo/pull/1044) Populate resource fetching with default time range as 1 month.
+
 # 0.6.0
   **MAJOR CHANGES**
   - Support for payments in Varaamo.

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "nocache": "2.0.0",
     "normalizr": "2.2.1",
     "passport": "0.3.2",
-    "passport-helsinki": "git://github.com/City-of-Helsinki/passport-helsinki.git",
+    "passport-helsinki": "git+https://github.com/City-of-Helsinki/passport-helsinki.git",
     "query-string": "4.2.3",
     "rc-slider": "8.3.1",
     "react": "16.8.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "varaamo",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/City-of-Helsinki/varaamo"

--- a/src/common/api/client.js
+++ b/src/common/api/client.js
@@ -21,9 +21,11 @@ axios.interceptors.response.use((response) => {
   } else if (error.request) {
     // The request was made but no response was received.
     // `error.request` is an instance of XMLHttpRequest in the browser.
+    // eslint-disable-next-line no-console
     console.error(error.request);
   } else {
     // Something happened in setting up the request that triggered an Error.
+    // eslint-disable-next-line no-console
     console.error(error.message);
   }
   return Promise.reject(error);

--- a/src/domain/footer/__tests__/__snapshots__/Footer.test.js.snap
+++ b/src/domain/footer/__tests__/__snapshots__/Footer.test.js.snap
@@ -56,7 +56,7 @@ exports[`domain/footer/Footer When there is no customization in use renders corr
           <span
             className="app-varaamo-version"
           >
-            v0.6.0
+            v0.6.1
           </span>
         </div>
       </Col>
@@ -121,7 +121,7 @@ exports[`domain/footer/Footer renders correctly 1`] = `
           <span
             className="app-varaamo-version"
           >
-            v0.6.0
+            v0.6.1
           </span>
         </div>
       </Col>

--- a/src/domain/reservation/manage/page/__tests__/ManageReservationsPage.test.js
+++ b/src/domain/reservation/manage/page/__tests__/ManageReservationsPage.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import toJSON from 'enzyme-to-json';
 
-import { shallowWithIntl } from '../../../../../../app/utils/testUtils';
+import { shallowWithIntl, globalDateMock } from '../../../../../../app/utils/testUtils';
 import { UnwrappedManageReservationsPage } from '../ManageReservationsPage';
 import resourceCreator from '../../../../../common/data/fixtures/resource';
 import reservationCreator from '../../../../../common/data/fixtures/reservation';
@@ -9,6 +9,8 @@ import { RESERVATION_SHOWONLY_FILTERS } from '../../../constants';
 import { RESERVATION_STATE } from '../../../../../constants/ReservationState';
 
 describe('ManageReservationsPage', () => {
+  globalDateMock();
+
   const defaultProps = {
     location: { search: '' }
   };

--- a/src/domain/reservation/manage/page/__tests__/__snapshots__/ManageReservationsPage.test.js.snap
+++ b/src/domain/reservation/manage/page/__tests__/__snapshots__/ManageReservationsPage.test.js.snap
@@ -28,7 +28,11 @@ exports[`ManageReservationsPage renders correctly 1`] = `
       </Row>
     </Grid>
     <InjectIntl(InjectT(ManageReservationsFilters))
-      filters={Object {}}
+      filters={
+        Object {
+          "date": "2019-10-14",
+        }
+      }
       onSearchChange={[Function]}
       onShowOnlyFiltersChange={[Function]}
       showOnlyFilters={

--- a/src/domain/reservation/manage/page/__tests__/__snapshots__/ManageReservationsPage.test.js.snap
+++ b/src/domain/reservation/manage/page/__tests__/__snapshots__/ManageReservationsPage.test.js.snap
@@ -30,7 +30,7 @@ exports[`ManageReservationsPage renders correctly 1`] = `
     <InjectIntl(InjectT(ManageReservationsFilters))
       filters={
         Object {
-          "date": "2019-10-14",
+          "date": "2017-12-10",
         }
       }
       onSearchChange={[Function]}

--- a/src/domain/search/__tests__/utils.test.js
+++ b/src/domain/search/__tests__/utils.test.js
@@ -3,12 +3,13 @@ import constants from '../../../../app/constants/AppConstants';
 
 describe('src/domain/search/utils.js', () => {
   // eslint-disable-next-line max-len
-  const expectedSearch = 'municipality=helsinki%2Cvantaa%2Cespoo&search=Foo&purpose=events&availableBetween=2019-07-31T14%3A30%2B03%3A00%2C2019-07-31T23%3A30%2B03%3A00%2C30';
+  const expectedSearch = 'municipality=helsinki%2Cvantaa%2Cespoo&search=Foo&purpose=events&availableBetween=2019-07-31T14%3A30%2B03%3A00%2C2019-07-31T23%3A30%2B03%3A00%2C30&date=2019-07-31';
   const expectedFilters = {
     municipality: 'helsinki,vantaa,espoo',
     search: 'Foo',
     purpose: 'events',
     availableBetween: '2019-07-31T14:30+03:00,2019-07-31T23:30+03:00,30',
+    date: '2019-07-31',
   };
 
   test('getFiltersFromUrl', () => {

--- a/src/domain/search/page/SearchPage.js
+++ b/src/domain/search/page/SearchPage.js
@@ -9,6 +9,7 @@ import {
   Redirect,
 } from 'react-router-dom';
 import { Row, Col } from 'react-bootstrap';
+import moment from 'moment';
 
 import constants from '../../../../app/constants/AppConstants';
 import injectT from '../../../../app/i18n/injectT';
@@ -152,9 +153,21 @@ class SearchPage extends React.Component {
       isLoading: true,
     });
 
+    const start = moment(filters.date)
+      .subtract(2, 'M')
+      .startOf('month')
+      .format();
+    const end = moment(filters.date)
+      .add(2, 'M')
+      .endOf('month')
+      .format();
+    // Fetch resource reservations time range 1 month from filter date.
+
     const params = {
       ...filters,
       page_size: constants.SEARCH_PAGE_SIZE,
+      start,
+      end
     };
 
     // Only include positional params if user has toggled the position filter on.

--- a/src/domain/search/page/__tests__/SearchPage.test.js
+++ b/src/domain/search/page/__tests__/SearchPage.test.js
@@ -2,15 +2,18 @@ import React from 'react';
 import toJSON from 'enzyme-to-json';
 
 import { UnWrappedSearchPage } from '../SearchPage';
-import { shallowWithIntl } from '../../../../../app/utils/testUtils';
+import { shallowWithIntl, globalDateMock } from '../../../../../app/utils/testUtils';
 
 describe('SearchPage', () => {
+  globalDateMock();
+
   test('renders correctly', () => {
     const props = {
       location: {},
       history: {},
-      match: { path: 'foo' }
+      match: { path: 'foo' },
     };
+
     const wrapper = shallowWithIntl(
       <UnWrappedSearchPage {...props} />
     );

--- a/src/domain/search/page/__tests__/__snapshots__/SearchPage.test.js.snap
+++ b/src/domain/search/page/__tests__/__snapshots__/SearchPage.test.js.snap
@@ -7,7 +7,7 @@ exports[`SearchPage renders correctly 1`] = `
   <InjectIntl(InjectT(SearchFilters))
     filters={
       Object {
-        "date": "2019-10-14",
+        "date": "2017-12-10",
       }
     }
     isGeolocationEnabled={false}

--- a/src/domain/search/page/__tests__/__snapshots__/SearchPage.test.js.snap
+++ b/src/domain/search/page/__tests__/__snapshots__/SearchPage.test.js.snap
@@ -5,7 +5,11 @@ exports[`SearchPage renders correctly 1`] = `
   className="app-SearchPage"
 >
   <InjectIntl(InjectT(SearchFilters))
-    filters={Object {}}
+    filters={
+      Object {
+        "date": "2019-10-14",
+      }
+    }
     isGeolocationEnabled={false}
     isLoadingPurposes={false}
     isLoadingUnits={false}

--- a/src/domain/search/utils.js
+++ b/src/domain/search/utils.js
@@ -4,13 +4,19 @@ import capitalize from 'lodash/capitalize';
 import sortBy from 'lodash/sortBy';
 import snakeCase from 'lodash/snakeCase';
 import forEach from 'lodash/forEach';
+import moment from 'moment';
 
 import constants from '../../../app/constants/AppConstants';
 import * as urlUtils from '../../common/url/utils';
 
 export const getFiltersFromUrl = (location, supportedFilters = constants.SUPPORTED_SEARCH_FILTERS) => {
   const query = new URLSearchParams(location.search);
-  const filters = {};
+  const defaultDate = moment().format(constants.DATE_FORMAT);
+
+  // Give default date to populate start/end time as default when fetching resources,
+  // Otherwise, reservations property under resource data will be empty.
+
+  const filters = { date: defaultDate };
 
   query.forEach((value, key) => {
     if (!supportedFilters || supportedFilters[key] !== undefined) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5911,9 +5911,9 @@ pascalcase@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/pascalcase/-/pascalcase-0.1.1.tgz#b363e55e8006ca6fe21784d2db22bd15d7917f14"
 
-"passport-helsinki@git://github.com/City-of-Helsinki/passport-helsinki.git":
+"passport-helsinki@git+https://github.com/City-of-Helsinki/passport-helsinki.git":
   version "0.1.0"
-  resolved "git://github.com/City-of-Helsinki/passport-helsinki.git#fec48d78e0258aa1472369014ffc01cd98c7cdc6"
+  resolved "git+https://github.com/City-of-Helsinki/passport-helsinki.git#fec48d78e0258aa1472369014ffc01cd98c7cdc6"
   dependencies:
     passport-oauth2 "^1.1.2"
 


### PR DESCRIPTION
Otherwise reservations data under resource will be empty. This is required from respa.

Extra:

Change `passport-helsinki` dependency to install either from `git/https`. People who didnt come from Hki org can fetch and use varaamo (for open-source).