### PR TITLE
[Hotfix] Reduce Varaamo unit, resource fetchAll page_size and timerange

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 # 0.6.1
   **HOTFIX**
   - Resource fetchAll come with empty reservations data, affect resource availability status was determined wrong, which confuse user and display wrong status.
+  - Reduce search `PAGE_SIZE` to 30 instead of 500, time range for 1 week display of reservations to 1 week instead of 4 month long as earlier default.
 
   **CHANGELOG**
   - [#1044](https://github.com/City-of-Helsinki/varaamo/pull/1044) Populate resource fetching with default time range as 1 month.
+  - [#1046](https://github.com/City-of-Helsinki/varaamo/pull/1046) Reduce Varaamo request size.
 
 # 0.6.0
   **MAJOR CHANGES**

--- a/src/domain/search/page/SearchPage.js
+++ b/src/domain/search/page/SearchPage.js
@@ -113,7 +113,7 @@ class SearchPage extends React.Component {
       isLoadingUnits: true,
     });
 
-    client.get('unit', { page_size: 500, unit_has_resource: true })
+    client.get('unit', { page_size: constants.SEARCH_PAGE_SIZE, unit_has_resource: true })
       .then(({ data }) => {
         this.setState({
           isLoadingUnits: false,
@@ -127,7 +127,7 @@ class SearchPage extends React.Component {
       isLoadingPurposes: true,
     });
 
-    client.get('purpose', { page_size: 500 })
+    client.get('purpose', { page_size: constants.SEARCH_PAGE_SIZE })
       .then(({ data }) => {
         this.setState({
           isLoadingPurposes: false,
@@ -154,14 +154,12 @@ class SearchPage extends React.Component {
     });
 
     const start = moment(filters.date)
-      .subtract(2, 'M')
-      .startOf('month')
-      .format();
+      .startOf('week')
+      .toISOString();
     const end = moment(filters.date)
-      .add(2, 'M')
-      .endOf('month')
-      .format();
-    // Fetch resource reservations time range 1 month from filter date.
+      .endOf('week')
+      .toISOString();
+    // Fetch resource reservations time range 1 week from filter date.
 
     const params = {
       ...filters,


### PR DESCRIPTION
There are no need to fetch `500` page_size of data. Making pagination useless.

Reduce default time-range to 1 week of data to reduce payload to Respa.