### PR TITLE
VAR-275 | Sync HTML lang attribute with application language

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules
 npm-debug.log
 yarn-error.log
 .idea
+.DS_Store

--- a/app/pages/AppContainer.js
+++ b/app/pages/AppContainer.js
@@ -63,7 +63,7 @@ export class UnconnectedAppContainer extends Component {
     const { isStaff, language } = this.props;
     return (
       <div className={classNames('app', getCustomizationClassName())}>
-        <Helmet>
+        <Helmet htmlAttributes={{ lang: this.props.language }}>
           <title>Varaamo</title>
         </Helmet>
 

--- a/app/pages/__tests__/AppContainer.test.js
+++ b/app/pages/__tests__/AppContainer.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import simple from 'simple-mock';
+import { Helmet } from 'react-helmet';
 
 import Header from '../../../src/domain/header/Header';
 import { getState } from '../../utils/testUtils';
@@ -15,6 +16,7 @@ describe('pages/AppContainer', () => {
       fetchUser: () => null,
       location: {},
       userId: null,
+      language: 'fi',
     };
     return shallow(<AppContainer {...defaults} {...props} />);
   }
@@ -75,6 +77,16 @@ describe('pages/AppContainer', () => {
     test('renders props.children', () => {
       const children = wrapper.find('#child-div');
       expect(children).toHaveLength(1);
+    });
+
+    test('html lang attribute is set correctly for Finnish, Swedish ans English', () => {
+      const languages = ['fi', 'en', 'sv'];
+
+      languages.forEach((code) => {
+        expect(
+          getWrapper({ language: code }).find(Helmet).props().htmlAttributes
+        ).toEqual({ lang: code });
+      });
     });
   });
 


### PR DESCRIPTION
Fixes VAR-275.

This PR is part of a set of accessibility improvements brought over from Turku's version of Varaamo.

Screen readers rely on the lang attribute to know the language the page uses.