### PR TITLE
VAR-284 | Fix tab behaviour for mobile navigation

### DIFF
--- a/src/domain/header/MainNavbar.js
+++ b/src/domain/header/MainNavbar.js
@@ -40,10 +40,10 @@ class MainNavbar extends React.Component {
         onToggle={() => this.toggleCollapse()}
       >
         <Navbar.Header>
-          <Navbar.Toggle />
           <Navbar.Brand>
             <Link to="/">Varaamo</Link>
           </Navbar.Brand>
+          <Navbar.Toggle />
         </Navbar.Header>
         <Navbar.Collapse>
           <Nav activeKey={activeLink}>

--- a/src/domain/header/_main-navbar.scss
+++ b/src/domain/header/_main-navbar.scss
@@ -36,4 +36,13 @@ $externalIconMarginLeft: 5px;
   .app-fontAwesome {
     margin-left: $externalIconMarginLeft;
   }
+
+  // These styles set the active and focus state for MainNavbar's child
+  // links and buttons.
+  a:focus,
+  a:active,
+  button:focus,
+  button:active {
+    outline: 2px solid $theme-primary-light;
+  }
 }


### PR DESCRIPTION
Ensures that links and buttons within the main navigation have an
outline when focused.

The home menu link is now focused before the mobile menu toggle button.
Previously this was the other way around which made for a confusing
user experience.

Resolves VAR-284
Relevant commit from Turku's repo
https://github.com/codepointtku/varaamo/commit/b2f7edf619845a2c425537b19d34f167d1e3dbae