### PR TITLE
VAR-277 | Fix date filter breaking on any other date than today

### DIFF
--- a/app/constants/AppConstants.js
+++ b/app/constants/AppConstants.js
@@ -9,6 +9,7 @@ export default {
     'varaamotest-vantaa.hel.ninja': 'VANTAA',
   },
   DATE_FORMAT: 'YYYY-MM-DD',
+  DATETIME_FORMAT: 'YYYY-MM-DD[T]HH:mm',
   DEFAULT_LOCALE: 'fi',
   FEEDBACK_URL: 'https://app.helmet-kirjasto.fi/forms/?site=varaamopalaute',
   FILTER: {

--- a/app/constants/AppConstants.js
+++ b/app/constants/AppConstants.js
@@ -9,7 +9,7 @@ export default {
     'varaamotest-vantaa.hel.ninja': 'VANTAA',
   },
   DATE_FORMAT: 'YYYY-MM-DD',
-  DATETIME_FORMAT: 'YYYY-MM-DD[T]HH:mm',
+  DATETIME_FORMAT: 'YYYY-MM-DD[T]HH:mmZZ',
   DEFAULT_LOCALE: 'fi',
   FEEDBACK_URL: 'https://app.helmet-kirjasto.fi/forms/?site=varaamopalaute',
   FILTER: {

--- a/src/domain/search/filters/SearchFilters.js
+++ b/src/domain/search/filters/SearchFilters.js
@@ -26,8 +26,7 @@ import iconTimes from './images/times.svg';
 function timeToDatetime(time, date) {
   const [hours, minutes] = time.split(':');
 
-  // ignore timezone by using utc time
-  return moment.utc(date).startOf('day').hours(hours).minutes(minutes)
+  return moment(date).startOf('day').hours(hours).minutes(minutes)
     .format(constants.DATETIME_FORMAT);
 }
 

--- a/src/domain/search/filters/__tests__/SearchFilters.test.js
+++ b/src/domain/search/filters/__tests__/SearchFilters.test.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import toJSON from 'enzyme-to-json';
+import moment from 'moment';
 
 import { ISearchFilters } from '../SearchFilters';
 import { shallowWithIntl } from '../../../../../app/utils/testUtils';
@@ -20,7 +21,8 @@ const findDateFilter = wrapper => wrapper.find(DateFilter);
 const findTimeRangeFilter = wrapper => wrapper.find(TimeRangeFilter);
 // This selector breaks easily
 const findSubmitButton = wrapper => wrapper.find({ children: 'SearchFilters.searchButton' });
-const makeDatetime = (dateVal, timeVal) => `${dateVal}T${timeVal}`;
+const makeDatetime = (dateVal, timeVal) => moment(`${dateVal} ${timeVal}`, 'YYYY-MM-DD HH:mm')
+  .format('YYYY-MM-DD[T]HH:mmZZ');
 const availableBetweenFilter = value => value.availableBetween;
 
 const startTime = '11:00';
@@ -62,7 +64,7 @@ describe('ResourceMap', () => {
     expect(wrapper.state().filters.availableBetween).toEqual([startTime, endTime, duration].join(','));
   });
 
-  test('makes searches with an availableBetween value that includes current selected date', () => {
+  test('makes searches with an availableBetween value that includes current selected date and timezone offset', () => {
     const date = '2017-07-07';
     const timeRange = ['12:00', '14:00', 30];
     const onChange = jest.fn(availableBetweenFilter);

--- a/src/domain/search/filters/__tests__/SearchFilters.test.js
+++ b/src/domain/search/filters/__tests__/SearchFilters.test.js
@@ -2,26 +2,128 @@ import React from 'react';
 import toJSON from 'enzyme-to-json';
 
 import { ISearchFilters } from '../SearchFilters';
-import { shallowWithIntl, globalDateMock } from '../../../../../app/utils/testUtils';
+import { shallowWithIntl } from '../../../../../app/utils/testUtils';
 import unit from '../../../../common/data/fixtures/unit';
 import purpose from '../../../../common/data/fixtures/purpose';
+import DateFilter from '../filter/DateFilter';
+import TimeRangeFilter from '../filter/TimeRangeFilter';
+
+const defaultProps = {
+  onChange: jest.fn(),
+  onGeolocationToggle: jest.fn(),
+  units: [unit.build()],
+  purposes: [purpose.build()],
+  filters: {},
+  t: value => value,
+};
+const findDateFilter = wrapper => wrapper.find(DateFilter);
+const findTimeRangeFilter = wrapper => wrapper.find(TimeRangeFilter);
+// This selector breaks easily
+const findSubmitButton = wrapper => wrapper.find({ children: 'SearchFilters.searchButton' });
+const makeDatetime = (dateVal, timeVal) => `${dateVal}T${timeVal}`;
+const availableBetweenFilter = value => value.availableBetween;
+
+const startTime = '11:00';
+const endTime = '13:00';
+const duration = 30;
+const datetimeRange = (date0, date1) => [`${date0}T${startTime}`, `${date1 || date0}T${endTime}`, 30];
 
 describe('ResourceMap', () => {
-  globalDateMock();
+  const getWrapper = props => shallowWithIntl(
+    <ISearchFilters {...defaultProps} {...props} />,
+  );
 
   test('renders correctly', () => {
-    const props = {
-      onChange: jest.fn(),
-      onGeolocationToggle: jest.fn(),
-      units: [unit.build()],
-      purposes: [purpose.build()],
-      filters: {},
-    };
+    const originalDate = Date;
+    const mockDate = new Date(2017, 12 - 1, 10);
+    global.Date = () => mockDate;
 
-    const wrapper = shallowWithIntl(
-      <ISearchFilters {...props} />,
-    );
+    const wrapper = getWrapper();
 
     expect(toJSON(wrapper)).toMatchSnapshot();
+
+    global.Date = originalDate;
+  });
+
+  // A bit of an ugly test, but I want to guard this internal
+  // representation from being changed by accident.
+  test('parses availableBetween before adding into state', () => {
+    const date0 = '2017-07-07';
+    const date1 = '2017-08-08';
+    const filters = {
+      availableBetween: datetimeRange(date0).join(','),
+    };
+    const wrapper = getWrapper({ filters });
+
+    expect(wrapper.state().filters.availableBetween).toEqual([startTime, endTime, duration].join(','));
+
+    wrapper.setProps({ filters: { availableBetween: datetimeRange(date1).join(',') } });
+
+    expect(wrapper.state().filters.availableBetween).toEqual([startTime, endTime, duration].join(','));
+  });
+
+  test('makes searches with an availableBetween value that includes current selected date', () => {
+    const date = '2017-07-07';
+    const timeRange = ['12:00', '14:00', 30];
+    const onChange = jest.fn(availableBetweenFilter);
+    const wrapper = getWrapper({ onChange });
+
+    findDateFilter(wrapper).prop('onChange')(date);
+    findTimeRangeFilter(wrapper).prop('onChange')(timeRange.join(','));
+    findSubmitButton(wrapper).prop('onClick')();
+
+    expect(onChange).toHaveLastReturnedWith([
+      makeDatetime(date, timeRange[0]),
+      makeDatetime(date, timeRange[1]),
+      timeRange[2],
+    ].join(','));
+  });
+
+  test('does not inject date when availableBetween is undefined', () => {
+    const date = '2017-07-07';
+    const onChange = jest.fn(availableBetweenFilter);
+    const wrapper = getWrapper({ onChange });
+
+    findDateFilter(wrapper).prop('onChange')(date);
+    findSubmitButton(wrapper).prop('onClick')();
+
+    expect(onChange).toHaveLastReturnedWith(undefined);
+  });
+
+  test('injects current date into availableBetween when date changes and availableBetween has been set', () => {
+    const date = '2017-07-07';
+    const timeRange = ['11:00', '14:00', 30];
+    const [startTime0, endTime0, duration0] = timeRange;
+    const onChange = jest.fn(availableBetweenFilter);
+    const wrapper = getWrapper({ onChange });
+
+    findTimeRangeFilter(wrapper).prop('onChange')(timeRange.join(','));
+    findDateFilter(wrapper).prop('onChange')(date);
+    findSubmitButton(wrapper).prop('onClick')();
+
+    expect(onChange).toHaveLastReturnedWith([
+      makeDatetime(date, startTime0),
+      makeDatetime(date, endTime0),
+      duration0,
+    ].join(','));
+  });
+
+  test('ignores availableBetween spanning multiple dates and always uses date instead', () => {
+    const date0 = '2017-07-07';
+    const date1 = '2017-08-08';
+    const filters = {
+      date: date0,
+      availableBetween: datetimeRange(date0, date1).join(','),
+    };
+    const onChange = jest.fn(availableBetweenFilter);
+    const wrapper = getWrapper({ filters, onChange });
+
+    findSubmitButton(wrapper).prop('onClick')();
+
+    expect(onChange).toHaveLastReturnedWith([
+      makeDatetime(date0, startTime),
+      makeDatetime(date0, endTime),
+      duration,
+    ].join(','));
   });
 });

--- a/src/domain/search/filters/__tests__/__snapshots__/SearchFilters.test.js.snap
+++ b/src/domain/search/filters/__tests__/__snapshots__/SearchFilters.test.js.snap
@@ -280,7 +280,6 @@ exports[`ResourceMap renders correctly 1`] = `
             sm={6}
           >
             <TimeRangeFilter
-              date="2017-12-10"
               label="TimeRangeControl.timeRangeTitle"
               onChange={[Function]}
               value=""

--- a/src/domain/search/filters/filter/TimeRangeFilter.js
+++ b/src/domain/search/filters/filter/TimeRangeFilter.js
@@ -21,7 +21,6 @@ class TimeRangeFilter extends React.Component {
     label: PropTypes.string.isRequired,
     onChange: PropTypes.func.isRequired,
     value: PropTypes.string,
-    date: PropTypes.string.isRequired,
   };
 
   constructor(props) {
@@ -44,12 +43,12 @@ class TimeRangeFilter extends React.Component {
   }
 
   splitValueString = (value) => {
-    const valueParts = value.split(',');
+    const [startTime, endTime, duration] = value.split(',');
 
     return {
-      startTime: valueParts[0] ? moment(valueParts[0]).format('HH:mm') : this.getDefaultValue('startTime'),
-      endTime: valueParts[1] ? moment(valueParts[1]).format('HH:mm') : this.getDefaultValue('endTime'),
-      duration: valueParts[2] ? Number(valueParts[2]) : this.getDefaultValue('duration'),
+      startTime: startTime || this.getDefaultValue('startTime'),
+      endTime: endTime || this.getDefaultValue('endTime'),
+      duration: duration ? Number(duration) : this.getDefaultValue('duration'),
     };
   };
 
@@ -80,26 +79,13 @@ class TimeRangeFilter extends React.Component {
   };
 
   getValueString = () => {
-    const { date } = this.props;
     const {
       startTime,
       endTime,
       duration,
     } = this.state;
 
-    const format = 'YYYY-MM-DD[T]HH:mmZ';
-
-    const startTimeParts = startTime.split(':');
-    const start = moment(date)
-      .hours(startTimeParts[0])
-      .minutes(startTimeParts[1]);
-
-    const endTimeParts = endTime.split(':');
-    const end = moment(date)
-      .hours(endTimeParts[0])
-      .minutes(endTimeParts[1]);
-
-    return `${start.format(format)},${end.format(format)},${duration}`;
+    return `${startTime},${endTime},${duration}`;
   };
 
   /**

--- a/src/domain/search/filters/filter/TimeRangeFilter.js
+++ b/src/domain/search/filters/filter/TimeRangeFilter.js
@@ -21,6 +21,7 @@ class TimeRangeFilter extends React.Component {
     label: PropTypes.string.isRequired,
     onChange: PropTypes.func.isRequired,
     value: PropTypes.string,
+    date: PropTypes.string.isRequired,
   };
 
   constructor(props) {
@@ -79,6 +80,7 @@ class TimeRangeFilter extends React.Component {
   };
 
   getValueString = () => {
+    const { date } = this.props;
     const {
       startTime,
       endTime,
@@ -88,12 +90,12 @@ class TimeRangeFilter extends React.Component {
     const format = 'YYYY-MM-DD[T]HH:mmZ';
 
     const startTimeParts = startTime.split(':');
-    const start = moment()
+    const start = moment(date)
       .hours(startTimeParts[0])
       .minutes(startTimeParts[1]);
 
     const endTimeParts = endTime.split(':');
-    const end = moment()
+    const end = moment(date)
       .hours(endTimeParts[0])
       .minutes(endTimeParts[1]);
 

--- a/src/domain/search/filters/filter/__tests__/TimeRangeFilter.test.js
+++ b/src/domain/search/filters/filter/__tests__/TimeRangeFilter.test.js
@@ -1,21 +1,46 @@
 import React from 'react';
 import toJSON from 'enzyme-to-json';
+import moment from 'moment';
 
 import TimeRangeFilter from '../TimeRangeFilter';
 import { shallowWithIntl } from '../../../../../../app/utils/testUtils';
 
+const defaultProps = {
+  label: 'foo',
+  onChange: jest.fn(),
+  value: '2011-10-05T14:48:00.000Z,2011-10-05T14:48:00.000Z',
+  date: '2011-10-05',
+};
+
+const findStartSelect = wrapper => wrapper.find('#time-filter-start-select');
 
 describe('TimeRangeFilter', () => {
+  const getWrapper = props => shallowWithIntl(<TimeRangeFilter {...defaultProps} {...props} />);
+
   test('render normally', () => {
-    const props = {
-      label: 'foo',
-      onChange: jest.fn(),
-      value: '2011-10-05T14:48:00.000Z,2011-10-05T14:48:00.000Z',
-    };
-    const wrapper = shallowWithIntl(
-      <TimeRangeFilter {...props} />,
-    );
+    const wrapper = getWrapper();
 
     expect(toJSON(wrapper)).toMatchSnapshot();
+  });
+
+  test('should use date when building duration parameter', () => {
+    const date = '2017-07-07';
+    // To simplify the expect row, we are doing a bit of "filtering" the
+    // actual return to ignore time parameters.
+    const onChange = jest.fn((string) => {
+      const [firstDate, secondDate] = string.split(',').slice(0, 2);
+      const genericFirstDate = moment(firstDate).startOf('day').toISOString();
+      const genericSecondDate = moment(secondDate).startOf('day').toISOString();
+
+      return [genericFirstDate, genericSecondDate];
+    });
+    const wrapper = getWrapper({ date, onChange });
+
+    findStartSelect(wrapper).prop('onChange')({ value: '12:00' });
+
+    expect(onChange).toHaveReturnedWith([
+      moment(date).startOf('day').toISOString(),
+      moment(date).startOf('day').toISOString(),
+    ]);
   });
 });

--- a/src/domain/search/filters/filter/__tests__/__snapshots__/TimeRangeFilter.test.js.snap
+++ b/src/domain/search/filters/filter/__tests__/__snapshots__/TimeRangeFilter.test.js.snap
@@ -212,7 +212,7 @@ exports[`TimeRangeFilter render normally 1`] = `
           },
         ]
       }
-      value="17:48"
+      value="12:48"
     />
     <div
       className="app-TimeRangeFilter__range-separator"
@@ -228,6 +228,46 @@ exports[`TimeRangeFilter render normally 1`] = `
       onChange={[Function]}
       options={
         Array [
+          Object {
+            "label": "13:18",
+            "value": "13:18",
+          },
+          Object {
+            "label": "13:48",
+            "value": "13:48",
+          },
+          Object {
+            "label": "14:18",
+            "value": "14:18",
+          },
+          Object {
+            "label": "14:48",
+            "value": "14:48",
+          },
+          Object {
+            "label": "15:18",
+            "value": "15:18",
+          },
+          Object {
+            "label": "15:48",
+            "value": "15:48",
+          },
+          Object {
+            "label": "16:18",
+            "value": "16:18",
+          },
+          Object {
+            "label": "16:48",
+            "value": "16:48",
+          },
+          Object {
+            "label": "17:18",
+            "value": "17:18",
+          },
+          Object {
+            "label": "17:48",
+            "value": "17:48",
+          },
           Object {
             "label": "18:18",
             "value": "18:18",
@@ -275,7 +315,7 @@ exports[`TimeRangeFilter render normally 1`] = `
         ]
       }
       searchable={false}
-      value="17:48"
+      value="14:48"
     />
     <InjectT(SelectFilter)
       className="app-TimeRangeFilter__range-duration"
@@ -284,7 +324,26 @@ exports[`TimeRangeFilter render normally 1`] = `
       isClearable={false}
       isSearchable={false}
       onChange={[Function]}
-      options={Array []}
+      options={
+        Array [
+          Object {
+            "label": "0.5 h",
+            "value": 30,
+          },
+          Object {
+            "label": "1 h",
+            "value": 60,
+          },
+          Object {
+            "label": "1.5 h",
+            "value": 90,
+          },
+          Object {
+            "label": "2 h",
+            "value": 120,
+          },
+        ]
+      }
       value={30}
     />
   </div>


### PR DESCRIPTION
I have two commits here of which both fix a similar bug in the search page of Varaamo.

--- 

**Reproducing the bug**
1) Go to search page in Varaamo
2) Refine your search by giving a time range
3) Change your searched date into some other day than today
4) Notice that the results are still shown from today

The test data looks to be quite empty at the moment, so it may be easier to reproduce the bug in the test environment (if you want to reproduce it).

You can select a popular location like Oodi, do a norma search, open the details for something that's reservable and then see when it's booked from its calendar. Then you can use this booked date + time combination to search--you should notice that the reservable item is still being returned in the list.

You can also just look at the values saved into query parameters in the url--you can make out it well enough to see that the `availableBetween` parameter always uses the current date, no matter what the value of `date` is.

---

The first commit implements the `date` prop that's already passed in `SearchFilters` onto `TimeRangeFilter`. I suspect that the original design meant for this prop to be used as the mechanism that would sync the selected date with the date(s) in availableBetween.

Previously `availableBetween` would just naively use the current date.

---

However, the first fix isn't enough because the filter values are only updated when the user interacts with the filters. This means that the `availableBetween` filter will have the old date value as long as the user doesn't change it.

In other words, if the user selects a time range and then selects another date, the results would still be shown from the first date (because that date is still saved in the `availableBetween` filter).

To fix this I added scaffolding that changes the data content of `availableBetween` within the `SearchFilters` component. When it is read into the component, I am discarding the date part from its datetime values. After this process `availableBetween` only contains time values.

`2017-07-07T13:00,2017-07-07T16:00,60`
->
`13:00,16:00,60`

Just before `SearchFilter` sends its values to be searched with, I inject the currently selected date into `availableBetween` in order to make its data representation complete.

With this approach the date is only managed in a single place and the requests made to the server are left unaltered.
