### PR TITLE
VAR-289 | Make search map toggle more accessible

### DIFF
--- a/src/domain/search/mapToggle/SearchMapToggle.js
+++ b/src/domain/search/mapToggle/SearchMapToggle.js
@@ -41,15 +41,19 @@ function SearchMapToggle({
           <Col sm={6}>
             <div className="pull-right">
               {BUTTONS.map((button) => {
+                const isSelected = active === button.key;
+
                 return (
                   <Button
+                    aria-selected={isSelected}
                     className={classNames(
                       'app-SearchMapToggle__button',
                       `app-SearchMapToggle__button-${button.key}`,
+                      { 'app-SearchMapToggle__button--selected': isSelected },
                     )}
-                    disabled={active === button.key}
                     key={button.key}
                     onClick={() => onClick(button.key)}
+                    role="tab"
                   >
                     {t(button.label)}
                   </Button>

--- a/src/domain/search/mapToggle/__tests__/SearchMapToggle.test.js
+++ b/src/domain/search/mapToggle/__tests__/SearchMapToggle.test.js
@@ -4,31 +4,70 @@ import React from 'react';
 import SearchMapToggle from '../SearchMapToggle';
 import { shallowWithIntl } from '../../../../../app/utils/testUtils';
 
+const findListButton = wrapper => wrapper.find({ children: 'MapToggle.showList' });
+const findMapButton = wrapper => wrapper.find({ children: 'MapToggle.showMap' });
+const getButtonClass = modifier => `app-SearchMapToggle__button${modifier && `--${modifier}`}`;
+const findButtons = wrapper => wrapper.find(getButtonClass());
+
 describe('SearchMapToggle', () => {
+  const defaultProps = {
+    onClick: () => {},
+    resultCount: 50,
+    active: 'list',
+  };
+  const getWrapper = props => shallowWithIntl(<SearchMapToggle {...defaultProps} {...props} />);
+
   test('renders correctly', () => {
-    const wrapper = shallowWithIntl(
-      <SearchMapToggle
-        active="list"
-        onClick={() => null}
-        resultCount={53}
-      />,
-    );
+    const wrapper = getWrapper({
+      active: 'list',
+      onClick: () => null,
+      resultCount: 53,
+    });
 
     expect(toJSON(wrapper)).toMatchSnapshot();
   });
 
   test('onClick', () => {
     const onClick = jest.fn();
-    const wrapper = shallowWithIntl(
-      <SearchMapToggle
-        active="list"
-        onClick={onClick}
-        resultCount={53}
-      />,
-    );
+    const wrapper = getWrapper({
+      active: 'list',
+      onClick,
+      resultCount: 53,
+    });
 
     wrapper.find('.app-SearchMapToggle__button-map').simulate('click');
 
     expect(onClick.mock.calls[0][0]).toBe('map');
+  });
+
+  describe('buttons', () => {
+    const expectButtonToBeActive = (button, not = true) => {
+      expect(button.prop('aria-selected')).toBe(not);
+      expect(button.hasClass(getButtonClass('selected'))).toBe(not);
+    };
+    expectButtonToBeActive.not = button => expectButtonToBeActive(button, false);
+
+    test('buttons have accessibility props', () => {
+      const buttons = findButtons(getWrapper());
+
+      buttons.forEach((button) => {
+        expect(button.prop('role')).toEqual('tab');
+        expect(button.prop('aria-selected')).toBeDefined();
+      });
+    });
+
+    test('only renders list button as selected if list is active', () => {
+      const wrapper = getWrapper({ active: 'list' });
+
+      expectButtonToBeActive(findListButton(wrapper));
+      expectButtonToBeActive.not(findMapButton(wrapper));
+    });
+
+    test('only renders map button as selected if map is active', () => {
+      const wrapper = getWrapper({ active: 'map' });
+
+      expectButtonToBeActive(findMapButton(wrapper));
+      expectButtonToBeActive.not(findListButton(wrapper));
+    });
   });
 });

--- a/src/domain/search/mapToggle/__tests__/__snapshots__/SearchMapToggle.test.js.snap
+++ b/src/domain/search/mapToggle/__tests__/__snapshots__/SearchMapToggle.test.js.snap
@@ -34,18 +34,21 @@ exports[`SearchMapToggle renders correctly 1`] = `
         >
           <Button
             active={false}
+            aria-selected={true}
             block={false}
             bsClass="btn"
             bsStyle="default"
-            className="app-SearchMapToggle__button app-SearchMapToggle__button-list"
-            disabled={true}
+            className="app-SearchMapToggle__button app-SearchMapToggle__button-list app-SearchMapToggle__button--selected"
+            disabled={false}
             key="list"
             onClick={[Function]}
+            role="tab"
           >
             MapToggle.showList
           </Button>
           <Button
             active={false}
+            aria-selected={false}
             block={false}
             bsClass="btn"
             bsStyle="default"
@@ -53,6 +56,7 @@ exports[`SearchMapToggle renders correctly 1`] = `
             disabled={false}
             key="map"
             onClick={[Function]}
+            role="tab"
           >
             MapToggle.showMap
           </Button>

--- a/src/domain/search/mapToggle/_searchMapToggle.scss
+++ b/src/domain/search/mapToggle/_searchMapToggle.scss
@@ -9,31 +9,29 @@
     padding-top: 8px;
   }
 
-  button {
+  &__button {
     background-color: $hel-copper;
     border-color: $hel-copper;
     color: $black;
+
+    &:hover,
+    &:active {
+      background-color: darken($hel-copper, 5);
+      border-color: darken($hel-copper, 5);
+      box-shadow: none;
+    }
   }
 
-  button:hover,
-  button:active {
-    background-color: darken($hel-copper, 5);
-    border-color: darken($hel-copper, 5);
-    box-shadow: none;
-  }
-
-  .btn.disabled,
-  .btn[disabled] {
+  &__button--selected.btn {
     background-color: $hel-silver;
     border-color: $hel-silver;
     opacity: 1;
     cursor: default;
-  }
 
-  .btn.disabled:hover,
-  .btn[disabled]:hover,
-  .btn.disabled:active,
-  .btn[disabled]:active {
-    border-color: $hel-silver;
+    &:hover,
+    &:active {
+      background-color: $hel-silver;
+      border-color: $hel-silver;  
+    }
   }
 }


### PR DESCRIPTION
These buttons were flagged in the accessibility review because you could not for instance access them with the tab key and they were difficult to understand with a screen reader.