### PR TITLE
VAR-291 | Fix unnecessary title in rect-toggle

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "react-router-dom": "4.3.1",
     "react-select": "^3.0.4",
     "react-sticky-el": "1.0.20",
-    "react-toggle": "4.0.2",
+    "react-toggle": "4.1.1",
     "redux": "4.0.1",
     "redux-actions": "2.6.5",
     "redux-api-middleware": "3.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7176,9 +7176,10 @@ react-test-renderer@^16.0.0-0, react-test-renderer@^16.8.4:
     react-is "^16.8.4"
     scheduler "^0.13.4"
 
-react-toggle@4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/react-toggle/-/react-toggle-4.0.2.tgz#77f487860efb87fafd197672a2db8c885be1440f"
+react-toggle@4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/react-toggle/-/react-toggle-4.1.1.tgz#2317f67bf918ea3508a96b09dd383efd9da572af"
+  integrity sha512-+wXlMcSpg8SmnIXauMaZiKpR+r2wp2gMUteroejp2UTSqGTVvZLN+m9EhMzFARBKEw7KpQOwzCyfzeHeAndQGw==
   dependencies:
     classnames "^2.2.5"
 


### PR DESCRIPTION
This newer version of react-toggle removes titles from the svg elements
that are used for communicating current state. VoiceOver would read
these titles out loud harming the user experience.