### PR TITLE
VAR-292 | Announce changes in search results and search result order

### DIFF
--- a/app/i18n/messages/en.json
+++ b/app/i18n/messages/en.json
@@ -345,6 +345,7 @@
   "SearchSort.typeLabel": "Type",
   "SearchSort.premiseLabel": "Premise",
   "SearchSort.peopleLabel": "People",
+  "SearchSort.sortingStyle": "Search result sorting order is ",
   "TestSiteMessage.text": "This is the test version of Varaamo",
   "TimeRangeControl.timeRangeTitle": "Time range and minimum duration",
   "TimeRangeControl.title": "{date} at {start}-{end} {hours}h booking",

--- a/app/i18n/messages/fi.json
+++ b/app/i18n/messages/fi.json
@@ -354,6 +354,7 @@
   "SearchSort.typeLabel": "Tyyppi",
   "SearchSort.premiseLabel": "Toimipiste",
   "SearchSort.peopleLabel": "Henkilömäärä",
+  "SearchSort.sortingStyle": "Hakutulosten järjestelytapa on ",
   "TimeRangeControl.timeRangeTitle": "Käytä aikaväliä ja varauksen minimipituutta",
   "TimeRangeControl.title": "{date} klo {start}-{end} {hours}h varaus",
   "TestSiteMessage.text": "Tämä on Varaamon testiversio",

--- a/app/i18n/messages/sv.json
+++ b/app/i18n/messages/sv.json
@@ -346,6 +346,7 @@
   "SearchSort.typeLabel": "Typ",
   "SearchSort.premiseLabel": "Lokal",
   "SearchSort.peopleLabel": "Antal personer",
+  "SearchSort.sortingStyle": "Sökresultaten är sorterade enligt ",
   "TestSiteMessage.text": "Detta är Varaamo testversion",
   "TimeRangeControl.timeRangeTitle": "Tidsurval och minsta reserveringstid",
   "TimeRangeControl.title": "{date} kl. {start}-{end} {hours}h bokning",

--- a/src/domain/search/mapToggle/SearchMapToggle.js
+++ b/src/domain/search/mapToggle/SearchMapToggle.js
@@ -34,7 +34,7 @@ function SearchMapToggle({
       <Grid>
         <Row>
           <Col sm={6}>
-            <div className="app-SearchMapToggle__results-count">
+            <div className="app-SearchMapToggle__results-count" data-testid="result-count" role="status">
               {resultCount ? t('MapToggle.resultsText', { count: resultCount }) : t('MapToggle.noResultsText')}
             </div>
           </Col>

--- a/src/domain/search/mapToggle/__tests__/SearchMapToggle.test.js
+++ b/src/domain/search/mapToggle/__tests__/SearchMapToggle.test.js
@@ -8,32 +8,26 @@ const findListButton = wrapper => wrapper.find({ children: 'MapToggle.showList' 
 const findMapButton = wrapper => wrapper.find({ children: 'MapToggle.showMap' });
 const getButtonClass = modifier => `app-SearchMapToggle__button${modifier && `--${modifier}`}`;
 const findButtons = wrapper => wrapper.find(getButtonClass());
+const findResultCount = wrapper => wrapper.find('[data-testid="result-count"]');
 
 describe('SearchMapToggle', () => {
   const defaultProps = {
     onClick: () => {},
     resultCount: 50,
     active: 'list',
+    t: path => path,
   };
   const getWrapper = props => shallowWithIntl(<SearchMapToggle {...defaultProps} {...props} />);
 
   test('renders correctly', () => {
-    const wrapper = getWrapper({
-      active: 'list',
-      onClick: () => null,
-      resultCount: 53,
-    });
+    const wrapper = getWrapper();
 
     expect(toJSON(wrapper)).toMatchSnapshot();
   });
 
   test('onClick', () => {
     const onClick = jest.fn();
-    const wrapper = getWrapper({
-      active: 'list',
-      onClick,
-      resultCount: 53,
-    });
+    const wrapper = getWrapper({ onClick });
 
     wrapper.find('.app-SearchMapToggle__button-map').simulate('click');
 
@@ -69,5 +63,9 @@ describe('SearchMapToggle', () => {
       expectButtonToBeActive(findMapButton(wrapper));
       expectButtonToBeActive.not(findListButton(wrapper));
     });
+  });
+
+  test('result count should be announced', () => {
+    expect(findResultCount(getWrapper()).prop('role')).toEqual('status');
   });
 });

--- a/src/domain/search/mapToggle/__tests__/__snapshots__/SearchMapToggle.test.js.snap
+++ b/src/domain/search/mapToggle/__tests__/__snapshots__/SearchMapToggle.test.js.snap
@@ -20,6 +20,8 @@ exports[`SearchMapToggle renders correctly 1`] = `
       >
         <div
           className="app-SearchMapToggle__results-count"
+          data-testid="result-count"
+          role="status"
         >
           MapToggle.resultsText
         </div>

--- a/src/domain/search/results/SearchListResults.js
+++ b/src/domain/search/results/SearchListResults.js
@@ -70,7 +70,7 @@ class SearchListResults extends React.Component {
             <Col md={4} mdOffset={8} sm={6}>
               <SearchSort
                 onChange={sort => this.onSortChange(sort)}
-                value={get(filters, 'order_by', '')}
+                value={get(filters, 'orderBy', '')}
               />
             </Col>
           </Row>

--- a/src/domain/search/results/__tests__/SearchListResults.test.js
+++ b/src/domain/search/results/__tests__/SearchListResults.test.js
@@ -6,23 +6,36 @@ import { UnwrappedSearchListResults } from '../SearchListResults';
 import resource from '../../../../common/data/fixtures/resource';
 import unit from '../../../../common/data/fixtures/unit';
 import { globalDateMock } from '../../../../../app/utils/testUtils';
+import SearchSort from '../../sort/SearchSort';
+
+const findSearchSort = wrapper => wrapper.find(SearchSort);
 
 describe('SearchListResults', () => {
   globalDateMock();
-  test('renders correctly', () => {
-    const wrapper = shallow(
-      <UnwrappedSearchListResults
-        history={{}}
-        location={{}}
-        match={{}}
-        onFavoriteClick={() => null}
-        onFiltersChange={() => null}
-        resources={[resource.build()]}
-        units={[unit.build()]}
 
-      />,
-    );
+  const defaultProps = {
+    history: {},
+    location: {},
+    match: {},
+    onFavoriteClick: () => null,
+    onFiltersChange: () => null,
+    resources: [resource.build()],
+    units: [unit.build()],
+  };
+  const getWrapper = props => shallow(
+    <UnwrappedSearchListResults {...defaultProps} {...props} />,
+  );
+  test('renders correctly', () => {
+    const wrapper = getWrapper();
 
     expect(toJSON(wrapper)).toMatchSnapshot();
+  });
+
+  test('correctly passes orderBy to SearchSort', () => {
+    const orderBy = 'value';
+    const location = { search: `?orderBy=${orderBy}` };
+    const wrapper = getWrapper({ location });
+
+    expect(findSearchSort(wrapper).prop('value')).toEqual(orderBy);
   });
 });

--- a/src/domain/search/sort/SearchSort.js
+++ b/src/domain/search/sort/SearchSort.js
@@ -10,19 +10,26 @@ const UntranslatedSearchSort = ({
   onChange,
   value,
 }) => {
+  const sortOptions = [
+    { label: t('SearchSort.nameLabel'), value: `resource_name_${locale}` },
+    { label: t('SearchSort.typeLabel'), value: `type_name_${locale}` },
+    { label: t('SearchSort.premiseLabel'), value: `unit_name_${locale}` },
+    { label: t('SearchSort.peopleLabel'), value: 'people_capacity' },
+  ];
+  const option = sortOptions.find(options => options.value === value);
+  const label = !option ? t('SearchSort.premiseLabel') : option.label;
+
   return (
     <div className="app-SearchSort">
+      <div className="sr-only" data-testid="sort-order-announcer" role="status">
+        {t('SearchSort.sortingStyle') + label}
+      </div>
       <SelectFilter
         id="app-Sort"
         isSearchable={false}
         label={t('SearchSort.label')}
         onChange={item => onChange(item.value)}
-        options={[
-          { label: t('SearchSort.nameLabel'), value: `resource_name_${locale}` },
-          { label: t('SearchSort.typeLabel'), value: `type_name_${locale}` },
-          { label: t('SearchSort.premiseLabel'), value: `unit_name_${locale}` },
-          { label: t('SearchSort.peopleLabel'), value: 'people_capacity' },
-        ]}
+        options={sortOptions}
         value={value}
       />
     </div>

--- a/src/domain/search/sort/__tests__/SearchSort.test.js
+++ b/src/domain/search/sort/__tests__/SearchSort.test.js
@@ -4,12 +4,45 @@ import toJSON from 'enzyme-to-json';
 import { UntranslatedSearchSort as SearchSort } from '../SearchSort';
 import { shallowWithIntl } from '../../../../../app/utils/testUtils';
 
+const findAccessibilitySortOrderAnnouncer = wrapper => wrapper.find('[data-testid="sort-order-announcer"]');
+
 describe('SearchSort', () => {
+  const defaultProps = {
+    locale: 'en',
+    onChange: () => null,
+    t: jest.fn(path => path),
+  };
+  const getWrapper = props => shallowWithIntl(
+    <SearchSort {...defaultProps} {...props} />,
+  );
+
   test('renders correctly', () => {
-    const wrapper = shallowWithIntl(
-      <SearchSort locale="en" onChange={() => null} t={jest.fn()} />,
-    );
+    const wrapper = getWrapper();
 
     expect(toJSON(wrapper)).toMatchSnapshot();
+  });
+
+  describe('accessibility sort order announcer', () => {
+    test('should be rendered', () => {
+      expect(findAccessibilitySortOrderAnnouncer(getWrapper()).length).toEqual(1);
+    });
+
+    test('should be hidden from visual UI', () => {
+      expect(findAccessibilitySortOrderAnnouncer(getWrapper()).hasClass('sr-only')).toEqual(true);
+    });
+
+    test('should be announced', () => {
+      expect(findAccessibilitySortOrderAnnouncer(getWrapper()).prop('role')).toEqual('status');
+    });
+
+    test('should have expected content', () => {
+      const locale = 'en';
+      const value = `unit_name_${locale}`;
+      const accessibilityShortcuts = findAccessibilitySortOrderAnnouncer(getWrapper({ locale, value }));
+
+      expect(accessibilityShortcuts.prop('children'))
+        // eslint-disable-next-line no-useless-concat
+        .toEqual('SearchSort.sortingStyle' + 'SearchSort.premiseLabel');
+    });
   });
 });

--- a/src/domain/search/sort/__tests__/__snapshots__/SearchSort.test.js.snap
+++ b/src/domain/search/sort/__tests__/__snapshots__/SearchSort.test.js.snap
@@ -4,26 +4,34 @@ exports[`SearchSort renders correctly 1`] = `
 <div
   className="app-SearchSort"
 >
+  <div
+    className="sr-only"
+    data-testid="sort-order-announcer"
+    role="status"
+  >
+    SearchSort.sortingStyleSearchSort.premiseLabel
+  </div>
   <InjectT(SelectFilter)
     id="app-Sort"
     isSearchable={false}
+    label="SearchSort.label"
     onChange={[Function]}
     options={
       Array [
         Object {
-          "label": undefined,
+          "label": "SearchSort.nameLabel",
           "value": "resource_name_en",
         },
         Object {
-          "label": undefined,
+          "label": "SearchSort.typeLabel",
           "value": "type_name_en",
         },
         Object {
-          "label": undefined,
+          "label": "SearchSort.premiseLabel",
           "value": "unit_name_en",
         },
         Object {
-          "label": undefined,
+          "label": "SearchSort.peopleLabel",
           "value": "people_capacity",
         },
       ]


### PR DESCRIPTION
Previously when you completed a search the screen reader would not give any input. The screen reader would also not give any input on changes to search result order.

Now the screen reader should read the search result count after the user searches for something (as long as it changes).

And the screen reader should also read out the current sort order after it is changed. It'll take some time for the reader to to describe the current state of the dropdown filter so it takes some patience to hear this announcement.