### PR TITLE
VAR-325 | Change createIsStaffSelector to respect manager role

### DIFF
--- a/app/state/selectors/__tests__/authSelectors.test.js
+++ b/app/state/selectors/__tests__/authSelectors.test.js
@@ -1,9 +1,11 @@
 import User from '../../../utils/fixtures/User';
+import Resource from '../../../utils/fixtures/Resource';
 import { getState } from '../../../utils/testUtils';
 import {
   currentUserSelector,
   isAdminSelector,
   isLoggedInSelector,
+  createIsStaffSelector,
 } from '../authSelectors';
 
 describe('state/selectors/authSelectors', () => {
@@ -80,6 +82,26 @@ describe('state/selectors/authSelectors', () => {
 
     test('returns true if both token and userId are defined', () => {
       expect(getSelected({ token: 'mock-token', userId: 'u-1' })).toBe(true);
+    });
+  });
+
+  describe('createIsStaffSelector', () => {
+    const getMockResource = overrides => ({
+      ...Resource.build(),
+      ...overrides,
+    });
+    const mockResourceSelector = overrides => () => getMockResource(overrides);
+
+    test('returns true when the user has unit admin permission for resource', () => {
+      const selector = createIsStaffSelector(mockResourceSelector({ userPermissions: { isAdmin: true } }));
+
+      expect(selector()).toEqual(true);
+    });
+
+    test('returns true when the user has unit manager permission for resource', () => {
+      const selector = createIsStaffSelector(mockResourceSelector({ userPermissions: { isManager: true } }));
+
+      expect(selector()).toEqual(true);
     });
   });
 });

--- a/app/state/selectors/authSelectors.js
+++ b/app/state/selectors/authSelectors.js
@@ -23,13 +23,43 @@ function isLoggedInSelector(state) {
 }
 
 /**
- * Check if a user has admin permission for a unit.
- * TODO: Find a better name for this.
+ * Check if the user has admin level permissions for the resource. I.e.
+ * if they are a unit admin for the resource in question.
  */
-function createIsStaffSelector(resourceSelector) {
+function createIsUnitAdminSelector(resourceSelector) {
   return createSelector(
     resourceSelector,
     resource => Boolean(get(resource, 'userPermissions.isAdmin', false)),
+  );
+}
+
+/**
+ * Check if the user has manager level permissions for the resource.
+ * I.e. if they are a unit manager for the resource in question.
+ */
+function createIsUnitManagerSelector(resourceSelector) {
+  return createSelector(
+    resourceSelector,
+    resource => Boolean(get(resource, 'userPermissions.isManager', false)),
+  );
+}
+
+/**
+ * Check if a user has admin or manager permission for a unit.
+ * TODO: Find a better name for this.
+ *
+ * 2020/02/07
+ * I added support for the manager role. According to the spec, the
+ * unit manager should have the exact same permissions as the unit admin
+ * has. I couldn't get a good sense of the permission management
+ * architecture, but it seems like this selector is the easiest way to
+ * add support for this role
+ */
+function createIsStaffSelector(resourceSelector) {
+  return createSelector(
+    createIsUnitAdminSelector(resourceSelector),
+    createIsUnitManagerSelector(resourceSelector),
+    (isAdmin, isManager) => isAdmin || isManager,
   );
 }
 


### PR DESCRIPTION
The createIsStaffSelector will now build a selector that will return
true when the user has the unit manager role for the resource given as
a parameter.

The manager and admin roles should, at least for now, have the exact
same permission within this UI. As the permission system is not
centralized anywhere else, this selector is the easiest place in the
code to synchronize these permissions.