### PR TITLE
VAR-324 | Wrap generic and specific terms 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
   - Changed search count to be announced when a search is made
   - Changed search results sort order to be announced when sort order is changed
   - Fixed illegible icon names in toggles being read out loud by screen readers
+  - Fixed missing line breaks in generic terms and specific terms
 
   **CHANGELOG**
   - [#1118](https://github.com/City-of-Helsinki/varaamo/pull/1118) Added support for unit manager role; unit managers now have the same permissions as unit admins do

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
 # Unreleased
+  **MINOR CHANGES**
+  - Changed search count to be announced when a search is made
+  - Changed search results sort order to be announced when sort order is changed
+  - Fixed illegible icon names in toggles being read out loud by screen readers
+
+  **CHANGELOG**
+  - [#1118](https://github.com/City-of-Helsinki/varaamo/pull/1118) Added support for unit manager role; unit managers now have the same permissions as unit admins do
 
 # 0.9.0
   **MINOR CHANGES**

--- a/app/pages/reservation/reservation-information/ReservationInformationForm.js
+++ b/app/pages/reservation/reservation-information/ReservationInformationForm.js
@@ -385,7 +385,7 @@ class UnconnectedReservationInformationForm extends Component {
           {resource.specificTerms && (
             <div>
               <h2 className="app-ReservationPage__title">{t('ReservationForm.specificTermsTitle')}</h2>
-              <p className="specificTermsContent">{resource.specificTerms}</p>
+              <WrappedText className="specificTermsContent" text={resource.specificTerms} />
             </div>
           )}
           <div>

--- a/app/pages/resource/resource-info/ResourceInfo.js
+++ b/app/pages/resource/resource-info/ResourceInfo.js
@@ -28,13 +28,13 @@ function ResourceInfo({
 
       {resource.specificTerms && (
         <ResourcePanel header={t('ResourcePage.specificTerms')}>
-          <p>{resource.specificTerms}</p>
+          <WrappedText text={resource.specificTerms} />
         </ResourcePanel>
       )}
 
       {resource.genericTerms && (
         <ResourcePanel defaultExpanded={false} header={t('ResourcePage.genericTermsHeader')}>
-          <p>{resource.genericTerms}</p>
+          <WrappedText text={resource.genericTerms} />
         </ResourcePanel>
       )}
 


### PR DESCRIPTION
The line breaks in terms should be visible, because they make the
content easier to read.