### PR TITLE
VAR-295 | Add autofill support into reservation form

### DIFF
--- a/app/pages/reservation/reservation-information/Input.js
+++ b/app/pages/reservation/reservation-information/Input.js
@@ -10,12 +10,13 @@ function Input({
   meta: { error, touched },
   t,
   label,
+  autoComplete,
 }) {
   return (
     <div className="app-ReservationPage__formfield">
       <label>
         {label}
-        <input {...input} />
+        <input {...input} autoComplete={autoComplete} />
       </label>
       {touched && error && <Error error={t(error)} />}
     </div>
@@ -27,6 +28,7 @@ Input.propTypes = {
   meta: PropTypes.object.isRequired,
   t: PropTypes.func.isRequired,
   label: PropTypes.string.isRequired,
+  autoComplete: PropTypes.string,
 };
 
 export default injectT(Input);

--- a/app/pages/reservation/reservation-information/ReservationInformationForm.js
+++ b/app/pages/reservation/reservation-information/ReservationInformationForm.js
@@ -16,6 +16,7 @@ import { hasProducts } from '../../../utils/resourceUtils';
 import WrappedText from '../../../shared/wrapped-text/WrappedText';
 import InternalReservationFields from './InternalReservationFields';
 import { toCamelCase } from '../../../../src/common/data/utils';
+import { INPUT_PURPOSES } from '../../../../src/constants/InputPurposes';
 
 const validators = {
   reserverEmailAddress: (t, { reserverEmailAddress }) => {
@@ -110,7 +111,9 @@ class UnconnectedReservationInformationForm extends Component {
     return t('ReservationForm.reservationFieldsAsteriskNormal');
   };
 
-  renderField(name, type, label, help = null) {
+  renderField(name, type, label, help = null, extraProps = {}) {
+    const { autoComplete, externalName } = extraProps;
+
     if (!includes(this.props.fields, name)) {
       return null;
     }
@@ -122,6 +125,10 @@ class UnconnectedReservationInformationForm extends Component {
         help={help}
         label={`${label}${isRequired ? '*' : ''}`}
         name={name}
+        props={{
+          autoComplete,
+          externalName,
+        }}
         type={type}
       />
     );
@@ -250,6 +257,8 @@ class UnconnectedReservationInformationForm extends Component {
             'reserverName',
             'text',
             t('common.reserverNameLabel'),
+            null,
+            { autoComplete: INPUT_PURPOSES.NAME, externalName: 'name' },
           )}
           {this.renderField(
             'reserverId',
@@ -260,29 +269,39 @@ class UnconnectedReservationInformationForm extends Component {
             'reserverPhoneNumber',
             'text',
             t('common.reserverPhoneNumberLabel'),
+            null,
+            { autoComplete: INPUT_PURPOSES.TEL, externalName: 'phone' },
           )}
           {this.renderField(
             'reserverEmailAddress',
             'email',
             t('common.reserverEmailAddressLabel'),
+            null,
+            { autoComplete: INPUT_PURPOSES.EMAIL, externalName: 'email' },
           )}
           {includes(fields, 'reserverAddressStreet')
             && this.renderField(
               'reserverAddressStreet',
               'text',
               t('common.addressStreetLabel'),
+              null,
+              { autoComplete: INPUT_PURPOSES.STREET_ADDRESS, externalName: 'address' },
             )}
           {includes(fields, 'reserverAddressZip')
             && this.renderField(
               'reserverAddressZip',
               'text',
               t('common.addressZipLabel'),
+              null,
+              { autoComplete: INPUT_PURPOSES.POSTAL_CODE, externalName: 'zip' },
             )}
           {includes(fields, 'reserverAddressCity')
             && this.renderField(
               'reserverAddressCity',
               'text',
               t('common.addressCityLabel'),
+              null,
+              { autoComplete: INPUT_PURPOSES.ADDRESS_LEVEL_2, externalName: 'city' },
             )
           }
           {includes(fields, 'billingAddressStreet')
@@ -293,6 +312,8 @@ class UnconnectedReservationInformationForm extends Component {
               'billingAddressStreet',
               'text',
               t('common.addressStreetLabel'),
+              null,
+              { autoComplete: ['billing', INPUT_PURPOSES.STREET_ADDRESS].join(' '), externalName: 'billing-address' },
             )
           }
           {includes(fields, 'billingAddressZip')
@@ -300,6 +321,8 @@ class UnconnectedReservationInformationForm extends Component {
               'billingAddressZip',
               'text',
               t('common.addressZipLabel'),
+              null,
+              { autoComplete: ['billing', INPUT_PURPOSES.POSTAL_CODE].join(' '), externalName: 'billing-zip' },
             )
           }
           {includes(fields, 'billingAddressCity')
@@ -307,6 +330,8 @@ class UnconnectedReservationInformationForm extends Component {
               'billingAddressCity',
               'text',
               t('common.addressCityLabel'),
+              null,
+              { autoComplete: ['billing', INPUT_PURPOSES.ADDRESS_LEVEL_2].join(' '), externalName: 'billing-city' },
             )
           }
           {includes(fields, 'billingFirstName')
@@ -317,6 +342,8 @@ class UnconnectedReservationInformationForm extends Component {
               'billingFirstName',
               'text',
               t('common.billingFirstNameLabel'),
+              null,
+              { autoComplete: ['billing', INPUT_PURPOSES.GIVEN_NAME].join(' '), externalName: 'billing-fname' },
             )
           }
           {includes(fields, 'billingLastName')
@@ -324,6 +351,8 @@ class UnconnectedReservationInformationForm extends Component {
               'billingLastName',
               'text',
               t('common.billingLastNameLabel'),
+              null,
+              { autoComplete: ['billing', INPUT_PURPOSES.FAMILY_NAME].join(' '), externalName: 'billing-lname' },
             )
           }
           {includes(fields, 'billingPhoneNumber')
@@ -331,6 +360,11 @@ class UnconnectedReservationInformationForm extends Component {
               'billingPhoneNumber',
               'tel',
               t('common.billingPhoneNumberLabel'),
+              null,
+              {
+                autoComplete: ['billing', INPUT_PURPOSES.TEL].join(' '),
+                externalName: ['billing', INPUT_PURPOSES.TEL].join('-'),
+              },
             )
           }
           {includes(fields, 'billingEmailAddress')
@@ -338,6 +372,11 @@ class UnconnectedReservationInformationForm extends Component {
               'billingEmailAddress',
               'email',
               t('common.billingEmailAddressLabel'),
+              null,
+              {
+                autoComplete: ['billing', INPUT_PURPOSES.EMAIL].join(' '),
+                externalName: ['billing', INPUT_PURPOSES.EMAIL].join('-'),
+              },
             )
           }
           <h2 className="app-ReservationPage__title">{t('ReservationInformationForm.eventInformationTitle')}</h2>

--- a/app/pages/reservation/reservation-information/ReservationMetadataField.js
+++ b/app/pages/reservation/reservation-information/ReservationMetadataField.js
@@ -5,18 +5,51 @@ import Input from './Input';
 import Textarea from './Textarea';
 import Terms from './Terms';
 
-function ReservationMetadataField({ type, ...rest }) {
+function ReservationMetadataField({
+  type, input, externalName, ...rest
+}) {
+  const name = externalName || input.name || undefined;
+  const inputWithModifiedName = {
+    ...input,
+    name,
+  };
+
   if (type === 'textarea') {
-    return <Textarea {...rest} />;
+    return <Textarea {...rest} input={inputWithModifiedName} />;
   }
+
   if (type === 'terms') {
-    return <Terms {...rest} />;
+    return <Terms {...rest} input={inputWithModifiedName} />;
   }
-  return <Input type={type} {...rest} />;
+
+  return <Input type={type} {...rest} input={inputWithModifiedName} />;
 }
 
 ReservationMetadataField.propTypes = {
   type: PropTypes.string.isRequired,
+  // Input object passed from redux-form
+  input: PropTypes.object.isRequired,
+  // redux-form uses a name prop that represent the string path of the
+  // value in the form's state. This means that the name prop contains
+  // a value that speaks of the internal data model.
+
+  // Some browsers, for instance Chrome according to its documentation,
+  // don't guarantee auto filling for fields if the name attribute does
+  // not equal some of the values it supports (ref1). It doesn't make
+  // sense for me to refactor how we store form data within the form
+  // state to conform to Chrome's expectations about field names.
+  // Instead, we can replace the name attribute we use to be one that's
+  // "outwards" facing. redux-form does not rely on the name value
+  // within the change event to know what field it should update.
+
+  // Generally speaking, it was difficult to find exact information on
+  // how auto fill works, but ref1 instructs to give specific name and
+  // autoComplete attributes. In practice it did seem like autofill
+  // worked with just name or autoComplete matching the supported
+  // values.
+
+  // ref1: https://developers.google.com/web/updates/2015/06/checkout-faster-with-autofill
+  externalName: PropTypes.string,
 };
 
 export default ReservationMetadataField;

--- a/app/shared/reservation-confirmation/ReservationForm.js
+++ b/app/shared/reservation-confirmation/ReservationForm.js
@@ -16,6 +16,7 @@ import WrappedText from '../wrapped-text/WrappedText';
 import ReduxFormField from '../form-fields/ReduxFormField';
 import injectT from '../../i18n/injectT';
 import TimeControls from './TimeControls';
+import { INPUT_PURPOSES } from '../../../src/constants/InputPurposes';
 
 const validators = {
   reserverEmailAddress: (t, { reserverEmailAddress }) => {
@@ -181,16 +182,19 @@ class UnconnectedReservationForm extends Component {
                 'reserverAddressStreet',
                 'text',
                 t('common.addressStreetLabel'),
+                { name: 'street-address', autoComplete: INPUT_PURPOSES.STREET_ADDRESS },
               )}
               {this.renderField(
                 'reserverAddressZip',
                 'text',
                 t('common.addressZipLabel'),
+                { name: 'zip', autoComplete: INPUT_PURPOSES.POSTAL_CODE },
               )}
               {this.renderField(
                 'reserverAddressCity',
                 'text',
                 t('common.addressCityLabel'),
+                { name: 'city', autoComplete: INPUT_PURPOSES.ADDRESS_LEVEL_2 },
               )}
             </Well>
           )}
@@ -201,16 +205,19 @@ class UnconnectedReservationForm extends Component {
                 'billingAddressStreet',
                 'text',
                 t('common.addressStreetLabel'),
+                { name: 'billing-street-address', autoComplete: ['billing', INPUT_PURPOSES.STREET_ADDRESS].join(' ') },
               )}
               {this.renderField(
                 'billingAddressZip',
                 'text',
                 t('common.addressZipLabel'),
+                { name: 'billing-zip', autoComplete: ['billing', INPUT_PURPOSES.POSTAL_CODE].join(' ') },
               )}
               {this.renderField(
                 'billingAddressCity',
                 'text',
                 t('common.addressCityLabel'),
+                { name: 'billing-city', autoComplete: ['billing', INPUT_PURPOSES.ADDRESS_LEVEL_2].join(' ') },
               )}
             </Well>
           )}

--- a/src/constants/InputPurposes.js
+++ b/src/constants/InputPurposes.js
@@ -1,0 +1,26 @@
+// On this (ref1) page you can find a list of "content purposes" that
+// should be included within the taxonomy of the web page. The actual
+// content of the link is convoluted, but the above mostly just means
+// that assistive and autofill technologies treat these strings as
+// special cases. In this project, they were set up to add support for
+// autofill.
+
+// ref1: https://www.w3.org/TR/WCAG21/#input-purposes
+
+export const INPUT_PURPOSES = Object.freeze({
+  NAME: 'name', // Full name
+  GIVEN_NAME: 'given-name', // Given name (in some Western cultures, also known as the first name)
+  FAMILY_NAME: 'family-name', // Family name (in some Western cultures, also known as the last name or surname)
+  STREET_ADDRESS: 'street-address', // Street address (multiple lines, newlines preserved)
+  // The second administrative level, in addresses with two or more
+  // administrative levels; in the countries with two administrative
+  // levels, this would typically be the city, town, village, or other
+  // locality within which the relevant street address is found
+  ADDRESS_LEVEL_2: 'address-level2',
+  // Postal code, post code, ZIP code, CEDEX code (if CEDEX, append
+  // "CEDEX", and the dissement, if relevant, to the address-level2
+  // field)
+  POSTAL_CODE: 'postal-code',
+  TEL: 'tel', // Full telephone number, including country code
+  EMAIL: 'email', // E-mail address
+});


### PR DESCRIPTION
Users should be able to both autocomplete and autofill common form fields. These include for instance `email`, `phone` and `name`. This PR makes the necessary changes which ensure that this feature works on Chrome.

### Extra Context

This change is being done, because the lack of autofill support was flagged in an accessibility audit completed for Turku's version of Varaamo. The audit change suggestion referenced [input purposes mentioned in WCAG](https://www.w3.org/TR/WCAG21/#input-purposes). I used a [dev guide](https://developers.google.com/web/updates/2015/06/checkout-faster-with-autofill) for Chrome to get extra context. I used [this commit](https://github.com/codepointtku/varaamo/pull/8/commits/bf999fcbf837f4556ab336864e3ae7a64c6b4b9c) from Turku's version as help. Unfortunately I wasn't able to pull it directly because our versions had diverged in that particular file.

I added support for `ReservationForm` even though it looks to be dead code to me.