### PR TITLE
VAR-297 | Hide image link from screen reader and keyboard users

### DIFF
--- a/app/pages/user-reservations/reservation-list/ReservationListItem.js
+++ b/app/pages/user-reservations/reservation-list/ReservationListItem.js
@@ -43,7 +43,11 @@ class ReservationListItem extends Component {
     return (
       <li className="reservation">
         <div className="col-md-3 col-lg-2 image-container">
-          <Link to={getResourcePageUrl(resource)}>
+          <Link
+            aria-hidden="true"
+            tabIndex="-1"
+            to={getResourcePageUrl(resource)}
+          >
             {this.renderImage(getMainImage(resource.images))}
           </Link>
         </div>

--- a/app/pages/user-reservations/reservation-list/__tests__/ReservationListItem.test.js
+++ b/app/pages/user-reservations/reservation-list/__tests__/ReservationListItem.test.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import Immutable from 'seamless-immutable';
+import { Link } from 'react-router-dom';
 
 import InfoLabel from '../../../../../src/common/label/InfoLabel';
 import TimeRange from '../../../../shared/time-range/TimeRange';
@@ -43,11 +44,17 @@ describe('pages/user-reservations/reservation-list/ReservationListItem', () => {
       expect(image.props().src).toBe(props.resource.images[0].url);
     });
 
-    test('contains a link to resources page', () => {
+    test('contains two links to resource page with correct props', () => {
       const expectedUrl = getResourcePageUrl(props.resource);
-      const resourceLink = component.find({ to: expectedUrl });
+      const links = component.find(Link);
 
-      expect(resourceLink.length > 0).toBe(true);
+      expect(links.length).toBe(2);
+      // image link
+      expect(links.at(0).prop('aria-hidden')).toBe('true');
+      expect(links.at(0).prop('tabIndex')).toBe('-1');
+      expect(links.at(0).prop('to')).toBe(expectedUrl);
+      // header/name link
+      expect(links.at(1).prop('to')).toBe(expectedUrl);
     });
 
     test('displays the name of the resource', () => {


### PR DESCRIPTION
The link in question would appear as "empty" for screen reader users. This change removes the link from tab index, making it inaccessible with `tab` or screen readers, which should resolve the issue.