### PR TITLE
VAR-331, VAR-332 | Improve performance for my reservations page

### DIFF
--- a/app/pages/user-reservations/UserReservationsPage.js
+++ b/app/pages/user-reservations/UserReservationsPage.js
@@ -15,6 +15,7 @@ import userReservationsPageSelector from './userReservationsPageSelector';
 import ReservationList from './reservation-list/ReservationListContainer';
 import * as searchUtils from '../../../src/domain/search/utils';
 import client from '../../../src/common/api/client';
+import constants from '../../constants/AppConstants';
 
 const PAGE_SIZE = 10;
 // We request past reservations from the API by using the start and end
@@ -172,7 +173,7 @@ class UnconnectedUserReservationsPage extends Component {
 
   loadPastReservations = (getFilters) => {
     const getFilterWithDefaults = (defaultFilters) => {
-      const now = moment().format('YYYY-MM-DD[T]HH:mmZZ');
+      const now = moment().format(constants.DATETIME_FORMAT);
       const filters = {
         ...defaultFilters,
         all: true,
@@ -182,7 +183,7 @@ class UnconnectedUserReservationsPage extends Component {
         // common heuristics these should not be considered to be in the
         // past, but I could not find a more efficient way to find past
         // reservations.
-        start: moment(ARBITRARY_START_DATETIME, 'YYYY-MM-DD[T]HH:mm').format('YYYY-MM-DD[T]HH:mmZZ'),
+        start: moment(ARBITRARY_START_DATETIME, 'YYYY-MM-DD[T]HH:mm').format(constants.DATETIME_FORMAT),
         end: now,
       };
 

--- a/app/pages/user-reservations/UserReservationsPage.js
+++ b/app/pages/user-reservations/UserReservationsPage.js
@@ -2,43 +2,265 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import Loader from 'react-loader';
 import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
+import get from 'lodash/get';
+import classNames from 'classnames';
+import moment from 'moment';
+import pick from 'lodash/pick';
 
-import { fetchReservations } from '../../actions/reservationActions';
-import { fetchResources } from '../../actions/resourceActions';
-import { fetchUnits } from '../../actions/unitActions';
 import ReservationInfoModal from '../../shared/modals/reservation-info/ReservationInfoModalContainer';
 import PageWrapper from '../PageWrapper';
 import ReservationCancelModal from '../../shared/modals/reservation-cancel/ReservationCancelModalContainer';
 import injectT from '../../i18n/injectT';
 import userReservationsPageSelector from './userReservationsPageSelector';
 import ReservationList from './reservation-list/ReservationListContainer';
-import { getFiltersFromUrl } from '../../../src/domain/search/utils';
+import * as searchUtils from '../../../src/domain/search/utils';
+import client from '../../../src/common/api/client';
 
 const PAGE_SIZE = 10;
+// We request past reservations from the API by using the start and end
+// parameters. When using one of these parameters, you also have to use
+// the other. To get past reservations we are using the below value for
+// the start parameter, and current datetime for the end parameter.
+const ARBITRARY_START_DATETIME = '2000-01-01T00:00';
+const UPCOMING_PARAMETERS = ['ordering'];
+const PAST_PARAMETERS = ['all', 'ordering', 'start', 'end'];
+const initialModelState = Object.freeze({
+  data: [],
+  loading: false,
+  error: null,
+});
+const TABS = Object.freeze({
+  UPCOMING: 'upcoming',
+  PAST: 'past',
+});
 
 class UnconnectedUserReservationsPage extends Component {
-  componentDidMount() {
-    const { location } = this.props;
-    const filters = getFiltersFromUrl(location, false);
+  constructor(props) {
+    super(props);
 
-    this.props.actions.fetchResources();
-    this.props.actions.fetchUnits();
-    this.props.actions.fetchReservations({
-      all: true,
-      isOwn: true,
-      page: filters && filters.page ? Number(filters.page) : 1,
-      pageSize: 10,
-      ordering: '-begin',
+    this.state = {
+      upcomingReservation: {
+        ...this.initialModelState,
+        loading: true,
+        count: 0,
+      },
+      pastReservation: {
+        ...this.initialModelState,
+        count: 0,
+      },
+      resource: this.initialModelState,
+      unit: this.initialModelState,
+      tab: TABS.UPCOMING,
+    };
+  }
+
+  componentDidMount() {
+    this.loadUpcomingReservations();
+    this.loadModel('resource', { page_size: 500 });
+    this.loadModel('unit', { page_size: 500, unit_has_resource: true });
+  }
+
+  get initialModelState() {
+    return initialModelState;
+  }
+
+  get isLoading() {
+    const {
+      upcomingReservation, pastReservation, resource, unit,
+    } = this.state;
+
+    return upcomingReservation.loading || pastReservation.loading || resource.loading || unit.loading;
+  }
+
+  get filters() {
+    return searchUtils.getFiltersFromUrl(this.props.location, false);
+  }
+
+  get page() {
+    const filterCache = this.filters;
+
+    return filterCache && filterCache.page ? Number(filterCache.page) : 1;
+  }
+
+  get count() {
+    if (this.tab === TABS.UPCOMING) {
+      return this.state.upcomingReservation.count;
+    }
+
+    if (this.tab === TABS.PAST) {
+      return this.state.pastReservation.count;
+    }
+
+    return 0;
+  }
+
+  get pages() {
+    return Math.round(this.count / PAGE_SIZE);
+  }
+
+  get tab() {
+    return this.state.tab;
+  }
+
+  get reservations() {
+    if (this.tab === TABS.UPCOMING) {
+      return this.state.upcomingReservation.data;
+    }
+
+    if (this.tab === TABS.PAST) {
+      return this.state.pastReservation.data;
+    }
+
+    return [];
+  }
+
+  getModelDataAsObject = (name, idKey = 'id') => {
+    const models = this.state[name].data;
+    const dataAsObject = {};
+
+    models.forEach((model) => {
+      const id = get(model, idKey);
+
+      dataAsObject[id] = model;
     });
+
+    return dataAsObject;
+  }
+
+  setModel = (name, data, cb) => {
+    const currentState = get(this.state, name, {});
+
+    this.setState({
+      [name]: {
+        ...currentState,
+        ...data,
+      },
+    }, cb);
+  }
+
+  loadModel = (name, params, mapResponseToState, stateName) => {
+    const nameInState = stateName || name;
+
+    this.setModel(nameInState, {
+      loading: true,
+    });
+
+    client.get(name, params)
+      .then((response) => {
+        const defaultNextState = {
+          loading: false,
+          data: get(response.data, 'results', []),
+        };
+        const customNextState = mapResponseToState ? mapResponseToState(response) : {};
+
+        this.setModel(nameInState, {
+          ...defaultNextState,
+          ...customNextState,
+        });
+      });
+  }
+
+  fetchReservations = (namespace, getFilters) => {
+    const filters = getFilters ? getFilters(this.filters) : this.filters;
+    const params = {
+      ...filters,
+      // Ignore default date search parameter because this view is not
+      // date specific.
+      date: undefined,
+      page_size: PAGE_SIZE,
+      include: 'resource_detail',
+      is_own: true,
+    };
+
+    this.loadModel('reservation', params, response => ({
+      count: response.data.count,
+    }), `${namespace}Reservation`);
+  };
+
+  loadUpcomingReservations = (getFilters) => {
+    const getFilterWithDefaults = (defaultFilters) => {
+      const filters = { ...defaultFilters, ordering: 'begin' };
+
+      return getFilters ? getFilters(filters) : filters;
+    };
+
+    this.fetchReservations('upcoming', getFilterWithDefaults);
+  }
+
+  loadPastReservations = (getFilters) => {
+    const getFilterWithDefaults = (defaultFilters) => {
+      const now = moment().format('YYYY-MM-DD[T]HH:mmZZ');
+      const filters = {
+        ...defaultFilters,
+        all: true,
+        ordering: '-begin',
+        // Note that using this method to fetch a reservation has a
+        // weakness: it'll also list currently ongoing reservations. By
+        // common heuristics these should not be considered to be in the
+        // past, but I could not find a more efficient way to find past
+        // reservations.
+        start: moment(ARBITRARY_START_DATETIME, 'YYYY-MM-DD[T]HH:mm').format('YYYY-MM-DD[T]HH:mmZZ'),
+        end: now,
+      };
+
+      return getFilters ? getFilters(filters) : filters;
+    };
+
+    this.fetchReservations('past', getFilterWithDefaults);
+  }
+
+  handlePageChange = (newPage) => {
+    const { history } = this.props;
+    const filters = this.filters;
+    const nextFilters = { ...filters, page: newPage };
+
+    history.push({
+      search: searchUtils.getSearchFromFilters(nextFilters),
+    });
+
+    if (this.tab === TABS.UPCOMING) {
+      this.loadUpcomingReservations(defaultFilters => ({ ...defaultFilters, ...nextFilters }));
+    }
+
+    if (this.tab === TABS.PAST) {
+      this.loadPastReservations(defaultFilters => ({ ...defaultFilters, ...nextFilters }));
+    }
+  };
+
+  handleTabChange = (tab) => {
+    if (this.tab === tab) {
+      return;
+    }
+
+    const { history } = this.props;
+    // Reset pagination
+    const nextFilters = { };
+
+    history.push({
+      search: searchUtils.getSearchFromFilters(nextFilters),
+    });
+
+    this.setState({ tab });
+
+    if (tab === TABS.UPCOMING) {
+      this.loadUpcomingReservations(filters => pick(filters, UPCOMING_PARAMETERS));
+    }
+
+    if (tab === TABS.PAST) {
+      this.loadPastReservations(filters => pick(filters, PAST_PARAMETERS));
+    }
   }
 
   render() {
     const {
-      resourcesLoaded,
-      reservationsLoading,
       t,
     } = this.props;
+
+    const resourcesAsObject = this.getModelDataAsObject('resource');
+    const unitsAsObject = this.getModelDataAsObject('unit');
+    const upcomingReservationLoading = this.state.upcomingReservation.loading;
+    const upcomingReservationCount = this.state.upcomingReservation.count;
+
     return (
       <div className="app-UserReservationPage">
         <PageWrapper
@@ -46,20 +268,51 @@ class UnconnectedUserReservationsPage extends Component {
           title={t('UserReservationsPage.title')}
           transparent={false}
         >
-          <Loader loaded={resourcesLoaded}>
-            <div>
-              <h1>{t('UserReservationsPage.title')}</h1>
-              <ReservationList
-                fetchReservations={this.props.actions.fetchReservations}
-                history={this.props.history}
-                loading={reservationsLoading}
-                location={this.props.location}
-                pageSize={PAGE_SIZE}
-              />
+          <div>
+            <h1>{t('UserReservationsPage.title')}</h1>
+            <div className="app-UserReservationPage__tabs">
+              <button
+                aria-selected={this.tab === TABS.UPCOMING}
+                className={classNames('app-UserReservationPage__tab', {
+                  'app-UserReservationPage__tab--active': this.tab === TABS.UPCOMING,
+                })}
+                onClick={() => this.handleTabChange(TABS.UPCOMING)}
+                role="tab"
+                type="button"
+              >
+                {t('ReservationListContainer.comingReservations')}
+                {' '}
+                {!upcomingReservationLoading ? `(${upcomingReservationCount})` : ''}
+              </button>
+              <button
+                aria-selected={this.tab === TABS.PAST}
+                className={classNames('app-UserReservationPage__tab', {
+                  'app-UserReservationPage__tab--active': this.tab === TABS.PAST,
+                })}
+                onClick={() => this.handleTabChange(TABS.PAST)}
+                role="tab"
+                type="button"
+              >
+                {t('ReservationListContainer.pastReservations')}
+              </button>
             </div>
-            <ReservationCancelModal />
-            <ReservationInfoModal />
-          </Loader>
+            <Loader loaded={!this.isLoading}>
+              {/* In order to avoid mounting multiple instances of the
+                  same component, we change data instead of component
+                  instance. */}
+              <ReservationList
+                loading={this.isLoading}
+                onPageChange={this.handlePageChange}
+                page={this.page}
+                pages={this.pages}
+                reservations={this.reservations}
+                resources={resourcesAsObject}
+                units={unitsAsObject}
+              />
+            </Loader>
+          </div>
+          <ReservationCancelModal />
+          <ReservationInfoModal />
         </PageWrapper>
       </div>
     );
@@ -67,26 +320,13 @@ class UnconnectedUserReservationsPage extends Component {
 }
 
 UnconnectedUserReservationsPage.propTypes = {
-  actions: PropTypes.object.isRequired,
   history: PropTypes.object,
   location: PropTypes.object,
-  resourcesLoaded: PropTypes.bool.isRequired,
-  reservationsLoading: PropTypes.bool,
   t: PropTypes.func.isRequired,
 };
 UnconnectedUserReservationsPage = injectT(UnconnectedUserReservationsPage);  // eslint-disable-line
 
-function mapDispatchToProps(dispatch) {
-  const actionCreators = {
-    fetchReservations,
-    fetchResources,
-    fetchUnits,
-  };
-
-  return { actions: bindActionCreators(actionCreators, dispatch) };
-}
-
 export { UnconnectedUserReservationsPage };
-export default connect(userReservationsPageSelector, mapDispatchToProps)(
+export default connect(userReservationsPageSelector)(
   UnconnectedUserReservationsPage,
 );

--- a/app/pages/user-reservations/UserReservationsPage.js
+++ b/app/pages/user-reservations/UserReservationsPage.js
@@ -48,14 +48,12 @@ class UnconnectedUserReservationsPage extends Component {
         ...this.initialModelState,
         count: 0,
       },
-      unit: this.initialModelState,
       tab: TABS.UPCOMING,
     };
   }
 
   componentDidMount() {
     this.loadUpcomingReservations();
-    this.loadModel('unit', { page_size: 500, unit_has_resource: true });
   }
 
   get initialModelState() {
@@ -64,10 +62,10 @@ class UnconnectedUserReservationsPage extends Component {
 
   get isLoading() {
     const {
-      upcomingReservation, pastReservation, unit,
+      upcomingReservation, pastReservation,
     } = this.state;
 
-    return upcomingReservation.loading || pastReservation.loading || unit.loading;
+    return upcomingReservation.loading || pastReservation.loading;
   }
 
   get filters() {
@@ -254,7 +252,6 @@ class UnconnectedUserReservationsPage extends Component {
       t,
     } = this.props;
 
-    const unitsAsObject = this.getModelDataAsObject('unit');
     const upcomingReservationLoading = this.state.upcomingReservation.loading;
     const upcomingReservationCount = this.state.upcomingReservation.count;
 
@@ -303,7 +300,6 @@ class UnconnectedUserReservationsPage extends Component {
                 page={this.page}
                 pages={this.pages}
                 reservations={this.reservations}
-                units={unitsAsObject}
               />
             </Loader>
           </div>

--- a/app/pages/user-reservations/UserReservationsPage.js
+++ b/app/pages/user-reservations/UserReservationsPage.js
@@ -48,7 +48,6 @@ class UnconnectedUserReservationsPage extends Component {
         ...this.initialModelState,
         count: 0,
       },
-      resource: this.initialModelState,
       unit: this.initialModelState,
       tab: TABS.UPCOMING,
     };
@@ -56,7 +55,6 @@ class UnconnectedUserReservationsPage extends Component {
 
   componentDidMount() {
     this.loadUpcomingReservations();
-    this.loadModel('resource', { page_size: 500 });
     this.loadModel('unit', { page_size: 500, unit_has_resource: true });
   }
 
@@ -66,10 +64,10 @@ class UnconnectedUserReservationsPage extends Component {
 
   get isLoading() {
     const {
-      upcomingReservation, pastReservation, resource, unit,
+      upcomingReservation, pastReservation, unit,
     } = this.state;
 
-    return upcomingReservation.loading || pastReservation.loading || resource.loading || unit.loading;
+    return upcomingReservation.loading || pastReservation.loading || unit.loading;
   }
 
   get filters() {
@@ -256,7 +254,6 @@ class UnconnectedUserReservationsPage extends Component {
       t,
     } = this.props;
 
-    const resourcesAsObject = this.getModelDataAsObject('resource');
     const unitsAsObject = this.getModelDataAsObject('unit');
     const upcomingReservationLoading = this.state.upcomingReservation.loading;
     const upcomingReservationCount = this.state.upcomingReservation.count;
@@ -306,7 +303,6 @@ class UnconnectedUserReservationsPage extends Component {
                 page={this.page}
                 pages={this.pages}
                 reservations={this.reservations}
-                resources={resourcesAsObject}
                 units={unitsAsObject}
               />
             </Loader>

--- a/app/pages/user-reservations/UserReservationsPage.js
+++ b/app/pages/user-reservations/UserReservationsPage.js
@@ -110,19 +110,6 @@ class UnconnectedUserReservationsPage extends Component {
     return [];
   }
 
-  getModelDataAsObject = (name, idKey = 'id') => {
-    const models = this.state[name].data;
-    const dataAsObject = {};
-
-    models.forEach((model) => {
-      const id = get(model, idKey);
-
-      dataAsObject[id] = model;
-    });
-
-    return dataAsObject;
-  }
-
   setModel = (name, data, cb) => {
     const currentState = get(this.state, name, {});
 

--- a/app/pages/user-reservations/__tests__/UserReservationsPage.test.js
+++ b/app/pages/user-reservations/__tests__/UserReservationsPage.test.js
@@ -52,7 +52,7 @@ describe('pages/user-reservations/UserReservationsPage', () => {
 
       wrapperInstance.componentDidMount();
 
-      expect(loadModelMock).toHaveBeenCalledTimes(3);
+      expect(loadModelMock).toHaveBeenCalledTimes(2);
       expect(loadModelMock).toHaveBeenCalledWith(
         'reservation',
         {
@@ -65,7 +65,6 @@ describe('pages/user-reservations/UserReservationsPage', () => {
         expect.any(Function),
         'upcomingReservation',
       );
-      expect(loadModelMock).toHaveBeenCalledWith('resource', { page_size: 500 });
       expect(loadModelMock).toHaveBeenCalledWith('unit', { page_size: 500, unit_has_resource: true });
     });
   });

--- a/app/pages/user-reservations/__tests__/UserReservationsPage.test.js
+++ b/app/pages/user-reservations/__tests__/UserReservationsPage.test.js
@@ -52,7 +52,7 @@ describe('pages/user-reservations/UserReservationsPage', () => {
 
       wrapperInstance.componentDidMount();
 
-      expect(loadModelMock).toHaveBeenCalledTimes(2);
+      expect(loadModelMock).toHaveBeenCalledTimes(1);
       expect(loadModelMock).toHaveBeenCalledWith(
         'reservation',
         {
@@ -65,7 +65,6 @@ describe('pages/user-reservations/UserReservationsPage', () => {
         expect.any(Function),
         'upcomingReservation',
       );
-      expect(loadModelMock).toHaveBeenCalledWith('unit', { page_size: 500, unit_has_resource: true });
     });
   });
 

--- a/app/pages/user-reservations/__tests__/userReservationsPageSelector.test.js
+++ b/app/pages/user-reservations/__tests__/userReservationsPageSelector.test.js
@@ -10,12 +10,4 @@ describe('pages/user-reservations/userReservationsPageSelector', () => {
   test('returns isAdmin', () => {
     expect(getSelected().isAdmin).toBeDefined();
   });
-
-  test('returns resourcesLoaded', () => {
-    expect(getSelected().resourcesLoaded).toBeDefined();
-  });
-
-  test('returns reservationsLoading', () => {
-    expect(getSelected().reservationsLoading).toBeDefined();
-  });
 });

--- a/app/pages/user-reservations/_user-reservations-page.scss
+++ b/app/pages/user-reservations/_user-reservations-page.scss
@@ -14,4 +14,27 @@
   .app-PageWrapper {
     background-color: $hel-silver;
   }
+
+  &__tabs {
+    margin-bottom: 18px;
+  }
+
+  &__tab {
+    padding: 0;
+
+    color: $black;
+    font-weight: $font-weight-bold;
+    font-size: 30px;
+
+    border: none;
+    background: none;
+
+    &:not(:last-child) {
+      margin-right: 30px;
+    }
+
+    &--active {
+      border-bottom: 4px solid $black;
+    }
+  }
 }

--- a/app/pages/user-reservations/reservation-list/ReservationListContainer.js
+++ b/app/pages/user-reservations/reservation-list/ReservationListContainer.js
@@ -19,19 +19,16 @@ class UnconnectedReservationListContainer extends Component {
   renderReservationListItem(reservation) {
     const {
       isAdmin,
-      units,
     } = this.props;
     const staffUnits = [];
-    const resourceUnit = reservation.resource.unit;
-    const unit = resourceUnit ? get(units, resourceUnit.id, {}) : {};
+    const unitId = get(reservation, 'resource.unit.id', null);
 
     return (
       <ReservationListItem
         isAdmin={isAdmin}
-        isStaff={includes(staffUnits, unit.id)}
+        isStaff={includes(staffUnits, unitId)}
         key={reservation.url}
         reservation={reservation}
-        unit={unit}
       />
     );
   }
@@ -74,7 +71,6 @@ UnconnectedReservationListContainer.propTypes = {
   loading: PropTypes.bool.isRequired,
   reservations: PropTypes.array.isRequired,
   t: PropTypes.func.isRequired,
-  units: PropTypes.object.isRequired,
   onPageChange: PropTypes.func.isRequired,
   page: PropTypes.number.isRequired,
   pages: PropTypes.number.isRequired,

--- a/app/pages/user-reservations/reservation-list/ReservationListContainer.js
+++ b/app/pages/user-reservations/reservation-list/ReservationListContainer.js
@@ -3,12 +3,12 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import Loader from 'react-loader';
 import { connect } from 'react-redux';
+import get from 'lodash/get';
 
 import Pagination from '../../../../src/common/pagination/Pagination';
 import injectT from '../../../i18n/injectT';
 import ReservationListItem from './ReservationListItem';
 import reservationListSelector from './reservationListSelector';
-import { getFiltersFromUrl, getSearchFromFilters } from '../../../../src/domain/search/utils';
 
 class UnconnectedReservationListContainer extends Component {
   constructor(props) {
@@ -16,43 +16,21 @@ class UnconnectedReservationListContainer extends Component {
     this.renderReservationListItem = this.renderReservationListItem.bind(this);
   }
 
-  componentDidUpdate(prevProps) {
-    const { fetchReservations, location, pageSize } = this.props;
-
-    if (prevProps.location !== location) {
-      const filters = getFiltersFromUrl(location, false);
-      fetchReservations({
-        page: filters && filters.page ? Number(filters.page) : 1,
-        pageSize,
-        all: true,
-        isOwn: true,
-        ordering: '-begin',
-      });
-    }
-  }
-
-  onPageChange = (newPage) => {
-    const { history, location } = this.props;
-    const filters = getFiltersFromUrl(location, false);
-    history.push({
-      search: getSearchFromFilters({ ...filters, page: newPage }),
-    });
-  };
-
   renderReservationListItem(reservation) {
     const {
       isAdmin,
       resources,
-      staffUnits,
       units,
     } = this.props;
-    const resource = resources[reservation.resource] || {};
-    const unit = resource.unit ? units[resource.unit] || {} : {};
+    const staffUnits = [];
+    const resource = get(resources, reservation.resource.id, {});
+    const resourceUnit = reservation.resource.unit;
+    const unit = resourceUnit ? get(units, resourceUnit.id, {}) : {};
 
     return (
       <ReservationListItem
         isAdmin={isAdmin}
-        isStaff={includes(staffUnits, resource.unit)}
+        isStaff={includes(staffUnits, unit.id)}
         key={reservation.url}
         reservation={reservation}
         resource={resource}
@@ -65,32 +43,24 @@ class UnconnectedReservationListContainer extends Component {
     const {
       emptyMessage,
       loading,
-      location,
       reservations,
-      paginatedReservations,
-      pageSize,
+      page,
+      pages,
       t,
     } = this.props;
 
-    const { comingReservations, pastReservations, count } = paginatedReservations;
-
-    const filters = getFiltersFromUrl(location, false);
-
     return (
       <Loader loaded={!loading}>
-        {reservations.length
+        {reservations.length > 0
           ? (
             <div>
               <ul className="reservation-list">
-                {comingReservations.length > 1 && <h1>{t('ReservationListContainer.comingReservations')}</h1>}
-                {comingReservations.map(this.renderReservationListItem)}
-                {pastReservations.length > 1 && <h1>{t('ReservationListContainer.pastReservations')}</h1>}
-                {pastReservations.map(this.renderReservationListItem)}
+                {reservations.map(this.renderReservationListItem)}
               </ul>
               <Pagination
-                onChange={this.onPageChange}
-                page={filters && filters.page ? Number(filters.page) : 1}
-                pages={Math.round(count / pageSize)}
+                onChange={this.props.onPageChange}
+                page={page}
+                pages={pages}
               />
             </div>
           )
@@ -103,19 +73,15 @@ class UnconnectedReservationListContainer extends Component {
 
 UnconnectedReservationListContainer.propTypes = {
   emptyMessage: PropTypes.string,
-  filter: PropTypes.string, // eslint-disable-line react/no-unused-prop-types
-  fetchReservations: PropTypes.func.isRequired,
   isAdmin: PropTypes.bool.isRequired,
-  history: PropTypes.object,
   loading: PropTypes.bool.isRequired,
-  location: PropTypes.object,
-  paginatedReservations: PropTypes.object.isRequired,
-  pageSize: PropTypes.number.isRequired,
   reservations: PropTypes.array.isRequired,
   resources: PropTypes.object.isRequired,
-  staffUnits: PropTypes.array.isRequired,
   t: PropTypes.func.isRequired,
   units: PropTypes.object.isRequired,
+  onPageChange: PropTypes.func.isRequired,
+  page: PropTypes.number.isRequired,
+  pages: PropTypes.number.isRequired,
 };
 UnconnectedReservationListContainer = injectT(UnconnectedReservationListContainer);  // eslint-disable-line
 

--- a/app/pages/user-reservations/reservation-list/ReservationListContainer.js
+++ b/app/pages/user-reservations/reservation-list/ReservationListContainer.js
@@ -19,11 +19,9 @@ class UnconnectedReservationListContainer extends Component {
   renderReservationListItem(reservation) {
     const {
       isAdmin,
-      resources,
       units,
     } = this.props;
     const staffUnits = [];
-    const resource = get(resources, reservation.resource.id, {});
     const resourceUnit = reservation.resource.unit;
     const unit = resourceUnit ? get(units, resourceUnit.id, {}) : {};
 
@@ -33,7 +31,6 @@ class UnconnectedReservationListContainer extends Component {
         isStaff={includes(staffUnits, unit.id)}
         key={reservation.url}
         reservation={reservation}
-        resource={resource}
         unit={unit}
       />
     );
@@ -76,7 +73,6 @@ UnconnectedReservationListContainer.propTypes = {
   isAdmin: PropTypes.bool.isRequired,
   loading: PropTypes.bool.isRequired,
   reservations: PropTypes.array.isRequired,
-  resources: PropTypes.object.isRequired,
   t: PropTypes.func.isRequired,
   units: PropTypes.object.isRequired,
   onPageChange: PropTypes.func.isRequired,

--- a/app/pages/user-reservations/reservation-list/ReservationListItem.js
+++ b/app/pages/user-reservations/reservation-list/ReservationListItem.js
@@ -18,6 +18,8 @@ import { getReservationPrice, getTaxPercentage } from '../../../../src/domain/re
 import ResourceHydrator from './ResourceHydrator';
 
 class ReservationListItem extends Component {
+  wrapperRef = React.createRef();
+
   localize(translationObject) {
     return dataUtils.getLocalizedFieldValue(translationObject, this.props.locale, true);
   }
@@ -49,9 +51,9 @@ class ReservationListItem extends Component {
     const statusLabel = constants.RESERVATION_STATE_LABELS[reservation.state];
 
     return (
-      <ResourceHydrator id={reservation.resource.id}>
+      <ResourceHydrator id={reservation.resource.id} wrappingRef={this.wrapperRef}>
         {hydratedResource => (
-          <li className="reservation">
+          <li className="reservation" ref={this.wrapperRef}>
             <div className="col-md-3 col-lg-2 image-container">
               {hydratedResource.data !== null && (
                 <Link
@@ -129,7 +131,6 @@ class ReservationListItem extends Component {
             </div>
           </li>
         )}
-
       </ResourceHydrator>
     );
   }

--- a/app/pages/user-reservations/reservation-list/ReservationListItem.js
+++ b/app/pages/user-reservations/reservation-list/ReservationListItem.js
@@ -100,13 +100,11 @@ class ReservationListItem extends Component {
                   />
                   <TimeRange begin={reservation.begin} end={reservation.end} />
                 </div>
-                {hasCompleteResource && (
-                  <ReservationAccessCode
-                    reservation={reservation}
-                    resource={completeResource}
-                    text={t('ReservationListItem.accessCodeText')}
-                  />
-                )}
+                <ReservationAccessCode
+                  reservation={reservation}
+                  resource={completeResource}
+                  text={t('ReservationListItem.accessCodeText')}
+                />
                 {hasCompleteResource && (
                   hasProducts(completeResource)
                   && !completeResource.staff_event

--- a/app/pages/user-reservations/reservation-list/ReservationListItem.js
+++ b/app/pages/user-reservations/reservation-list/ReservationListItem.js
@@ -120,14 +120,12 @@ class ReservationListItem extends Component {
                 )}
               </div>
               <div className="col-xs-4 col-md-3 col-lg-3 action-container">
-                {hasCompleteResource && (
-                  <ReservationControls
-                    isAdmin={isAdmin}
-                    isStaff={isStaff}
-                    reservation={reservation}
-                    resource={completeResource}
-                  />
-                )}
+                <ReservationControls
+                  isAdmin={isAdmin}
+                  isStaff={isStaff}
+                  reservation={reservation}
+                  resource={completeResource}
+                />
               </div>
             </li>
           );

--- a/app/pages/user-reservations/reservation-list/ReservationListItem.js
+++ b/app/pages/user-reservations/reservation-list/ReservationListItem.js
@@ -4,6 +4,7 @@ import React, { Component } from 'react';
 import { Link } from 'react-router-dom';
 import iconHome from 'hel-icons/dist/shapes/home.svg';
 
+import * as dataUtils from '../../../../src/common/data/utils';
 import InfoLabel from '../../../../src/common/label/InfoLabel';
 import constants from '../../../constants/AppConstants';
 import iconCalendar from '../../../assets/icons/calendar.svg';
@@ -16,9 +17,13 @@ import { getResourcePageUrl, hasProducts } from '../../../utils/resourceUtils';
 import { getReservationPrice, getTaxPercentage } from '../../../../src/domain/resource/utils';
 
 class ReservationListItem extends Component {
+  localize(translationObject) {
+    return dataUtils.getLocalizedFieldValue(translationObject, this.props.locale, true);
+  }
+
   renderImage(image) {
     if (image && image.url) {
-      return <img alt={image.caption} className="resourceImg" src={image.url} />;
+      return <img alt={this.localize(image.caption)} className="resourceImg" src={image.url} />;
     }
     return null;
   }
@@ -54,23 +59,31 @@ class ReservationListItem extends Component {
         <div className="col-xs-8 col-md-6 col-lg-7 reservation-details">
           <div className="reservation-state-label-container">
             {hasProducts(resource)
-              && !reservation.staffEvent
+              && !reservation.staff_event
               && price > 0 && (
                 <InfoLabel labelStyle={paymentLabel.labelBsStyle} labelText={t(paymentLabel.labelTextId)} />
             )}
             <InfoLabel labelStyle={statusLabel.labelBsStyle} labelText={t(statusLabel.labelTextId)} />
           </div>
           <Link to={getResourcePageUrl(resource)}>
-            <h4>{resource.name}</h4>
+            <h4>{this.localize(resource.name)}</h4>
           </Link>
           <div>
-            <img alt={resource.type.name} className="location" src={iconHome} />
-            <span className="unit-name">{unit.name}</span>
+            <img
+              alt={this.localize(resource.type.name)}
+              className="location"
+              src={iconHome}
+            />
+            <span className="unit-name">{this.localize(unit.name)}</span>
             {nameSeparator}
-            <span>{unit.streetAddress}</span>
+            <span>{this.localize(unit.street_address)}</span>
           </div>
           <div>
-            <img alt={resource.type.name} className="timeslot" src={iconCalendar} />
+            <img
+              alt={this.localize(resource.type.name)}
+              className="timeslot"
+              src={iconCalendar}
+            />
             <TimeRange begin={reservation.begin} end={reservation.end} />
           </div>
           <ReservationAccessCode
@@ -79,7 +92,7 @@ class ReservationListItem extends Component {
             text={t('ReservationListItem.accessCodeText')}
           />
           {hasProducts(resource)
-            && !reservation.staffEvent
+            && !reservation.staff_event
             && price > 0 && (
             <div>
               <span className="price">{`${t('common.totalPriceLabel')}: `}</span>
@@ -106,6 +119,7 @@ ReservationListItem.propTypes = {
   reservation: PropTypes.object.isRequired,
   resource: PropTypes.object.isRequired,
   t: PropTypes.func.isRequired,
+  locale: PropTypes.string.isRequired,
   unit: PropTypes.object.isRequired,
 };
 

--- a/app/pages/user-reservations/reservation-list/ReservationListItem.js
+++ b/app/pages/user-reservations/reservation-list/ReservationListItem.js
@@ -52,85 +52,86 @@ class ReservationListItem extends Component {
 
     return (
       <ResourceHydrator id={reservation.resource.id} wrappingRef={this.wrapperRef}>
-        {hydratedResource => (
-          <li className="reservation" ref={this.wrapperRef}>
-            <div className="col-md-3 col-lg-2 image-container">
-              {hydratedResource.data !== null && (
-                <Link
-                  aria-hidden="true"
-                  tabIndex="-1"
-                  to={getResourcePageUrl(hydratedResource.data)}
-                >
-                  {this.renderImage(getMainImage(hydratedResource.data.images))}
-                </Link>
-              )}
-            </div>
-            <div className="col-xs-8 col-md-6 col-lg-7 reservation-details">
-              <div className="reservation-state-label-container">
-                {hydratedResource.data !== null && (
-                  hasProducts(resource)
-                    && !hydratedResource.data.staff_event
+        {(result) => {
+          const hasCompleteResource = result.data !== null;
+          const completeResource = result.data;
+
+          return (
+            <li className="reservation" ref={this.wrapperRef}>
+              <div className="col-md-3 col-lg-2 image-container">
+                {hasCompleteResource && (
+                  <Link
+                    aria-hidden="true"
+                    tabIndex="-1"
+                    to={getResourcePageUrl(completeResource)}
+                  >
+                    {this.renderImage(getMainImage(completeResource.images))}
+                  </Link>
+                )}
+              </div>
+              <div className="col-xs-8 col-md-6 col-lg-7 reservation-details">
+                <div className="reservation-state-label-container">
+                  {hasCompleteResource && (
+                    hasProducts(completeResource)
+                    && !completeResource.data.staff_event
                     && price > 0 && (
                       <InfoLabel labelStyle={paymentLabel.labelBsStyle} labelText={t(paymentLabel.labelTextId)} />
-                  )
-                )}
-                <InfoLabel labelStyle={statusLabel.labelBsStyle} labelText={t(statusLabel.labelTextId)} />
-              </div>
-              <Link to={getResourcePageUrl(resource)}>
-                <h4>{this.localize(resource.name)}</h4>
-              </Link>
-              <div>
-                {hydratedResource.data !== null && (
+                    )
+                  )}
+                  <InfoLabel labelStyle={statusLabel.labelBsStyle} labelText={t(statusLabel.labelTextId)} />
+                </div>
+                <Link to={getResourcePageUrl(resource)}>
+                  <h4>{this.localize(resource.name)}</h4>
+                </Link>
+                <div>
                   <img
-                    alt={this.localize(hydratedResource.data.type.name)}
+                    alt={hasCompleteResource ? this.localize(completeResource.type.name) : ''}
                     className="location"
                     src={iconHome}
                   />
-                )}
-                <span className="unit-name">{this.localize(unit.name)}</span>
-                {nameSeparator}
-                <span>{this.localize(unit.street_address)}</span>
-              </div>
-              <div>
-                {hydratedResource.data !== null && (
+                  <span className="unit-name">{this.localize(unit.name)}</span>
+                  {nameSeparator}
+                  <span>{this.localize(unit.street_address)}</span>
+                </div>
+                <div>
                   <img
-                    alt={this.localize(hydratedResource.data.type.name)}
+                    alt={hasCompleteResource ? this.localize(completeResource.type.name) : ''}
                     className="timeslot"
                     src={iconCalendar}
                   />
+                  <TimeRange begin={reservation.begin} end={reservation.end} />
+                </div>
+                {hasCompleteResource && (
+                  <ReservationAccessCode
+                    reservation={reservation}
+                    resource={completeResource}
+                    text={t('ReservationListItem.accessCodeText')}
+                  />
                 )}
-                <TimeRange begin={reservation.begin} end={reservation.end} />
+                {hasCompleteResource && (
+                  hasProducts(completeResource)
+                  && !completeResource.staff_event
+                  && price > 0 && (
+                    <div>
+                      <span className="price">{`${t('common.totalPriceLabel')}: `}</span>
+                      <span>{t('common.priceWithVAT', tVariables)}</span>
+                    </div>
+                  )
+                )}
               </div>
-              {hydratedResource.data !== null && (
-                <ReservationAccessCode
-                  reservation={reservation}
-                  resource={hydratedResource.data}
-                  text={t('ReservationListItem.accessCodeText')}
-                />
-              )}
-              {hydratedResource.data !== null && (
-                hasProducts(hydratedResource.data)
-                && !hydratedResource.data.staff_event
-                && price > 0 && (
-                  <div>
-                    <span className="price">{`${t('common.totalPriceLabel')}: `}</span>
-                    <span>{t('common.priceWithVAT', tVariables)}</span>
-                  </div>
-                )
-              )}
-            </div>
-            <div className="col-xs-4 col-md-3 col-lg-3 action-container">
-              {hydratedResource.data !== null && (
-                <ReservationControls
-                  isAdmin={isAdmin}
-                  isStaff={isStaff}
-                  reservation={reservation}
-                  resource={hydratedResource.data}
-                />
-              )}
-            </div>
-          </li>
-        )}
+              <div className="col-xs-4 col-md-3 col-lg-3 action-container">
+                {hasCompleteResource && (
+                  <ReservationControls
+                    isAdmin={isAdmin}
+                    isStaff={isStaff}
+                    reservation={reservation}
+                    resource={completeResource}
+                  />
+                )}
+              </div>
+            </li>
+          );
+        }}
       </ResourceHydrator>
     );
   }

--- a/app/pages/user-reservations/reservation-list/ReservationListItem.js
+++ b/app/pages/user-reservations/reservation-list/ReservationListItem.js
@@ -31,9 +31,10 @@ class ReservationListItem extends Component {
 
   render() {
     const {
-      isAdmin, isStaff, reservation, t, unit,
+      isAdmin, isStaff, reservation, t,
     } = this.props;
     const resource = reservation.resource;
+    const unit = reservation.resource.unit;
 
     const nameSeparator = isEmpty(resource) || isEmpty(unit) ? '' : ', ';
 
@@ -140,7 +141,6 @@ ReservationListItem.propTypes = {
   reservation: PropTypes.object.isRequired,
   t: PropTypes.func.isRequired,
   locale: PropTypes.string.isRequired,
-  unit: PropTypes.object.isRequired,
 };
 
 export default injectT(ReservationListItem);

--- a/app/pages/user-reservations/reservation-list/ReservationListItem.js
+++ b/app/pages/user-reservations/reservation-list/ReservationListItem.js
@@ -40,13 +40,6 @@ class ReservationListItem extends Component {
 
     const nameSeparator = isEmpty(resource) || isEmpty(unit) ? '' : ', ';
 
-    const price = getReservationPrice(reservation.begin, reservation.end, resource);
-    const vat = getTaxPercentage(resource);
-    const tVariables = {
-      price,
-      vat,
-    };
-
     const paymentLabel = constants.RESERVATION_PAYMENT_LABELS[reservation.state];
     const statusLabel = constants.RESERVATION_STATE_LABELS[reservation.state];
 
@@ -55,6 +48,12 @@ class ReservationListItem extends Component {
         {(result) => {
           const hasCompleteResource = result.data !== null;
           const completeResource = result.data;
+          const price = getReservationPrice(reservation.begin, reservation.end, resource);
+          const vat = getTaxPercentage(resource);
+          const tVariables = {
+            price,
+            vat,
+          };
 
           return (
             <li className="reservation" ref={this.wrapperRef}>

--- a/app/pages/user-reservations/reservation-list/ReservationListItem.js
+++ b/app/pages/user-reservations/reservation-list/ReservationListItem.js
@@ -23,7 +23,7 @@ class ReservationListItem extends Component {
 
   renderImage(image) {
     if (image && image.url) {
-      return <img alt={this.localize(image.caption)} className="resourceImg" src={image.url} />;
+      return <img alt={this.localize(image.caption)} className="resourceImg" src={`${image.url}?dim=700x420`} />;
     }
     return null;
   }

--- a/app/pages/user-reservations/reservation-list/ResourceHydrator.js
+++ b/app/pages/user-reservations/reservation-list/ResourceHydrator.js
@@ -1,0 +1,40 @@
+import PropTypes from 'prop-types';
+import { Component } from 'react';
+import get from 'lodash/get';
+
+import client from '../../../../src/common/api/client';
+
+class ResourceHydrator extends Component {
+  static propTypes = {
+    id: PropTypes.string.isRequired,
+    children: PropTypes.func.isRequired,
+  }
+
+  state = {
+    loading: false,
+    data: null,
+    error: null,
+  }
+
+  componentDidMount() {
+    const { id } = this.props;
+
+    this.setState({
+      loading: false,
+    });
+
+    client.get(`resource/${id}`)
+      .then((response) => {
+        this.setState({
+          loading: false,
+          data: get(response, 'data', null),
+        });
+      });
+  }
+
+  render() {
+    return this.props.children(this.state);
+  }
+}
+
+export default ResourceHydrator;

--- a/app/pages/user-reservations/reservation-list/__tests__/ReservationListContainer.test.js
+++ b/app/pages/user-reservations/reservation-list/__tests__/ReservationListContainer.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import Immutable from 'seamless-immutable';
 import simple from 'simple-mock';
+import snakeCaseKeys from 'snakecase-keys';
 
 import Reservation from '../../../../utils/fixtures/Reservation';
 import Resource from '../../../../utils/fixtures/Resource';
@@ -11,6 +12,19 @@ import {
 } from '../ReservationListContainer';
 import ReservationListItem from '../ReservationListItem';
 
+// This project handles API responses differently based on the method
+// that is used for fetching. Data in the redux store is in camelCase,
+// but data fetched through the apiClient is in snake_case. This
+// component was previously used in a context where API data
+// originated from the redux store, but now lives in a context where
+// this data comes directly from the apiClient.
+
+// To be able to use the same test tooling, we are transforming the
+// camelCase mock objects into snake_case mock objects.
+const makeReservation = (...args) => snakeCaseKeys(Reservation.build(...args));
+const makeResource = (...args) => snakeCaseKeys(Resource.build(...args));
+const makeUnit = (...args) => snakeCaseKeys(Unit.build(...args));
+
 describe('pages/user-reservations/reservation-list/ReservationListContainer', () => {
   const fetchReservations = simple.stub();
   function getWrapper(props) {
@@ -18,43 +32,26 @@ describe('pages/user-reservations/reservation-list/ReservationListContainer', ()
       fetchReservations,
       isAdmin: false,
       loading: false,
-      location: {
-        search: '',
-      },
       reservations: [],
       resources: {},
       staffUnits: [],
-      paginatedReservations: {},
-      pageSize: 0,
       units: {},
+      onPageChange: () => {},
+      page: 0,
+      pages: 0,
     };
     return shallowWithIntl(<ReservationListContainer {...defaults} {...props} />);
   }
 
   describe('with reservations', () => {
-    const unit = Unit.build();
-    const resource = Resource.build({ unit: unit.id });
+    const unit = makeUnit();
+    const resource = makeResource({ unit });
     const props = {
       isAdmin: false,
-      location: {
-        search: '',
-      },
       reservations: Immutable([
-        Reservation.build({ resource: resource.id }),
-        Reservation.build({ resource: 'unfetched-resource' }),
+        makeReservation({ resource }),
+        makeReservation({ resource: 'unfetched-resource' }),
       ]),
-      paginatedReservations: {
-        count: 0,
-        comingReservations: Immutable([
-          Reservation.build({ resource: resource.id }),
-          Reservation.build({ resource: 'unfetched-resource' }),
-        ]),
-        pastReservations: Immutable([
-          Reservation.build({ resource: resource.id }),
-          Reservation.build({ resource: 'unfetched-resource' }),
-        ]),
-      },
-      pageSize: 10,
       resources: Immutable({
         [resource.id]: resource,
       }),
@@ -75,8 +72,7 @@ describe('pages/user-reservations/reservation-list/ReservationListContainer', ()
     describe('rendering individual reservations', () => {
       test('renders a ReservationListItem for every reservation in props', () => {
         const reservationListItems = getWithReservationsWrapper().find(ReservationListItem);
-        const { comingReservations, pastReservations } = props.paginatedReservations;
-        expect(reservationListItems).toHaveLength(comingReservations.length + pastReservations.length);
+        expect(reservationListItems).toHaveLength(props.reservations.length);
       });
 
       test('passes isAdmin, isStaff and reservation', () => {

--- a/app/pages/user-reservations/reservation-list/__tests__/ReservationListContainer.test.js
+++ b/app/pages/user-reservations/reservation-list/__tests__/ReservationListContainer.test.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import Immutable from 'seamless-immutable';
-import simple from 'simple-mock';
 import snakeCaseKeys from 'snakecase-keys';
 
 import Reservation from '../../../../utils/fixtures/Reservation';
@@ -26,14 +25,11 @@ const makeResource = (...args) => snakeCaseKeys(Resource.build(...args));
 const makeUnit = (...args) => snakeCaseKeys(Unit.build(...args));
 
 describe('pages/user-reservations/reservation-list/ReservationListContainer', () => {
-  const fetchReservations = simple.stub();
   function getWrapper(props) {
     const defaults = {
-      fetchReservations,
       isAdmin: false,
       loading: false,
       reservations: [],
-      resources: {},
       staffUnits: [],
       units: {},
       onPageChange: () => {},
@@ -52,9 +48,6 @@ describe('pages/user-reservations/reservation-list/ReservationListContainer', ()
         makeReservation({ resource }),
         makeReservation({ resource: 'unfetched-resource' }),
       ]),
-      resources: Immutable({
-        [resource.id]: resource,
-      }),
       units: Immutable({
         [unit.id]: unit,
       }),
@@ -81,8 +74,7 @@ describe('pages/user-reservations/reservation-list/ReservationListContainer', ()
           const actualProps = reservationListItem.props();
           expect(actualProps.isAdmin).toBe(props.isAdmin);
           expect(actualProps.isStaff).toBe(false);
-          expect(reservationListItems.at(0).prop('resource')).toEqual(resource);
-          expect(reservationListItems.at(1).prop('resource')).toEqual({});
+          expect(reservationListItems.at(0).prop('reservation')).toEqual(props.reservations[0]);
           expect(reservationListItems.at(0).prop('unit')).toEqual(unit);
           expect(reservationListItems.at(1).prop('unit')).toEqual({});
         });

--- a/app/pages/user-reservations/reservation-list/__tests__/ReservationListContainer.test.js
+++ b/app/pages/user-reservations/reservation-list/__tests__/ReservationListContainer.test.js
@@ -31,7 +31,6 @@ describe('pages/user-reservations/reservation-list/ReservationListContainer', ()
       loading: false,
       reservations: [],
       staffUnits: [],
-      units: {},
       onPageChange: () => {},
       page: 0,
       pages: 0,
@@ -48,9 +47,6 @@ describe('pages/user-reservations/reservation-list/ReservationListContainer', ()
         makeReservation({ resource }),
         makeReservation({ resource: 'unfetched-resource' }),
       ]),
-      units: Immutable({
-        [unit.id]: unit,
-      }),
     };
 
     function getWithReservationsWrapper() {
@@ -75,8 +71,7 @@ describe('pages/user-reservations/reservation-list/ReservationListContainer', ()
           expect(actualProps.isAdmin).toBe(props.isAdmin);
           expect(actualProps.isStaff).toBe(false);
           expect(reservationListItems.at(0).prop('reservation')).toEqual(props.reservations[0]);
-          expect(reservationListItems.at(0).prop('unit')).toEqual(unit);
-          expect(reservationListItems.at(1).prop('unit')).toEqual({});
+          expect(reservationListItems.at(1).prop('reservation')).toEqual(props.reservations[1]);
         });
       });
     });

--- a/app/pages/user-reservations/reservation-list/__tests__/ReservationListItem.test.js
+++ b/app/pages/user-reservations/reservation-list/__tests__/ReservationListItem.test.js
@@ -74,7 +74,7 @@ describe('pages/user-reservations/reservation-list/ReservationListItem', () => {
 
       expect(image).toHaveLength(1);
       expect(image.props().alt).toBe(props.resource.images[0].caption.fi);
-      expect(image.props().src).toBe(props.resource.images[0].url);
+      expect(image.props().src).toBe(`${props.resource.images[0].url}?dim=700x420`);
     });
 
     test('contains two links to resource page with correct props', () => {

--- a/app/pages/user-reservations/reservation-list/__tests__/ReservationListItem.test.js
+++ b/app/pages/user-reservations/reservation-list/__tests__/ReservationListItem.test.js
@@ -47,7 +47,9 @@ const makeImage = (...args) => snakeCaseKeys(injectTranslations(Image.build(...a
 const makeUnit = (...args) => snakeCaseKeys(injectTranslations(Unit.build(...args), ['name']));
 
 describe('pages/user-reservations/reservation-list/ReservationListItem', () => {
+  const unit = Immutable(makeUnit());
   const resource = Immutable(makeResource({
+    unit,
     images: [makeImage()],
     type: { name: 'test_type' },
   }));
@@ -55,7 +57,6 @@ describe('pages/user-reservations/reservation-list/ReservationListItem', () => {
     isAdmin: false,
     isStaff: false,
     reservation: Immutable(makeReservation({ resource })),
-    unit: Immutable(makeUnit()),
   };
   const hydratedResource = {
     loading: false,
@@ -104,7 +105,7 @@ describe('pages/user-reservations/reservation-list/ReservationListItem', () => {
     });
 
     test('displays the name of the given unit in props', () => {
-      const expected = props.unit.name.fi;
+      const expected = props.reservation.resource.unit.name.fi;
 
       expect(component.find('.unit-name').text()).toContain(expected);
     });

--- a/app/pages/user-reservations/reservation-list/__tests__/reservationListSelector.test.js
+++ b/app/pages/user-reservations/reservation-list/__tests__/reservationListSelector.test.js
@@ -11,20 +11,4 @@ describe('pages/user-reservations/reservation-list/reservationListSelector', () 
   test('returns isAdmin', () => {
     expect(getSelected().isAdmin).toBeDefined();
   });
-
-  test('returns isFetchingReservations', () => {
-    expect(getSelected().isFetchingReservations).toBeDefined();
-  });
-
-  test('returns reservations', () => {
-    expect(getSelected().reservations).toBeDefined();
-  });
-
-  test('returns resources from the state', () => {
-    expect(getSelected().resources).toBeDefined();
-  });
-
-  test('returns units from the state', () => {
-    expect(getSelected().units).toBeDefined();
-  });
 });

--- a/app/pages/user-reservations/reservation-list/reservationListSelector.js
+++ b/app/pages/user-reservations/reservation-list/reservationListSelector.js
@@ -1,19 +1,9 @@
 import { createStructuredSelector } from 'reselect';
 
-import ActionTypes from '../../../constants/ActionTypes';
 import { isAdminSelector } from '../../../state/selectors/authSelectors';
-import { resourcesSelector, unitsSelector } from '../../../state/selectors/dataSelectors';
-import requestIsActiveSelectorFactory from '../../../state/selectors/factories/requestIsActiveSelectorFactory';
-import sortedReservationsSelector from '../../../state/selectors/sortedReservationsSelector';
-import paginatedReservationsSelector from '../../../state/selectors/paginatedReservationsSelector';
 
 const reservationListSelector = createStructuredSelector({
   isAdmin: isAdminSelector,
-  isFetchingReservations: requestIsActiveSelectorFactory(ActionTypes.API.RESERVATIONS_GET_REQUEST),
-  reservations: sortedReservationsSelector,
-  paginatedReservations: paginatedReservationsSelector,
-  resources: resourcesSelector,
-  units: unitsSelector,
 });
 
 export default reservationListSelector;

--- a/app/pages/user-reservations/userReservationsPageSelector.js
+++ b/app/pages/user-reservations/userReservationsPageSelector.js
@@ -2,13 +2,8 @@ import { createStructuredSelector } from 'reselect';
 
 import { isAdminSelector } from '../../state/selectors/authSelectors';
 
-const resourcesLoadedSelector = state => !state.api.shouldFetch.resources;
-const reservationsLoadingSelector = state => state.api.activeRequests.RESERVATIONS_GET_REQUEST === 1;
-
 const userReservationsPageSelector = createStructuredSelector({
   isAdmin: isAdminSelector,
-  resourcesLoaded: resourcesLoadedSelector,
-  reservationsLoading: reservationsLoadingSelector,
 });
 
 export default userReservationsPageSelector;

--- a/app/shared/reservation-access-code/ReservationAccessCode.js
+++ b/app/shared/reservation-access-code/ReservationAccessCode.js
@@ -10,7 +10,7 @@ const ReservationAccessCode = ({ reservation, resource, text }) => {
     return <span />;
   }
   if (isAccessCodeGenerated(reservation)) {
-    return <GeneratedAccessCode accessCode={reservation.accessCode} text={text} />;
+    return <GeneratedAccessCode accessCode={reservation.access_code} text={text} />;
   }
   if (resource && isAccessCodePending(reservation, resource)) {
     return <PendingAccessCode />;

--- a/app/shared/reservation-access-code/__tests__/ReservationAccessCode.test.js
+++ b/app/shared/reservation-access-code/__tests__/ReservationAccessCode.test.js
@@ -12,7 +12,7 @@ describe('shared/reservation-access-code/ReservationAccessCode', () => {
 
   const defaultProps = {
     reservation: createReservation(),
-    resource: createResource({ generateAccessCodes: true }),
+    resource: createResource({ generate_access_codes: true }),
   };
 
   function getWrapper(extraProps) {
@@ -20,13 +20,13 @@ describe('shared/reservation-access-code/ReservationAccessCode', () => {
   }
 
   test('renders GeneratedAccessCode when PIN is available', () => {
-    const reservation = createReservation({ accessCode: '1232' });
+    const reservation = createReservation({ access_code: '1232' });
     const wrapper = getWrapper({ reservation });
     expect(wrapper.name()).toContain('GeneratedAccessCode');
   });
 
   test('renders PendingAccessCode when PIN is pending', () => {
-    const resource = createResource({ generateAccessCodes: false });
+    const resource = createResource({ generate_access_codes: false });
     const wrapper = getWrapper({ resource });
     expect(wrapper.name()).toContain('PendingAccessCode');
   });
@@ -38,7 +38,7 @@ describe('shared/reservation-access-code/ReservationAccessCode', () => {
 
   test('renders empty span when reservation that would produce pending PIN is cancelled', () => {
     const reservation = createReservation({ state: 'cancelled' });
-    const resource = createResource({ generateAccessCodes: false });
+    const resource = createResource({ generate_access_codes: false });
     const wrapper = getWrapper({ reservation, resource });
     expect(wrapper.equals(<span />)).toBe(true);
   });

--- a/app/shared/reservation-access-code/helpers.js
+++ b/app/shared/reservation-access-code/helpers.js
@@ -1,13 +1,13 @@
 import has from 'lodash/has';
 
-export const isAccessCodeGenerated = reservation => has(reservation, 'accessCode') && reservation.accessCode !== null;
+export const isAccessCodeGenerated = reservation => has(reservation, 'access_code') && reservation.access_code !== null;
 
 // eslint-disable-next-line arrow-body-style
 export const isAccessCodePending = (reservation, resource) => {
   // resource.generateAccessCodes:
   // true => respa generates an access_code for reservation (immediately)
   // false => an access_code will be generated for reservation 24h before it starts
-  return !isAccessCodeGenerated(reservation) && resource.generateAccessCodes === false;
+  return !isAccessCodeGenerated(reservation) && resource.generate_access_codes === false;
 };
 
 export const isReservationCancelled = reservation => reservation.state === 'cancelled';

--- a/app/shared/reservation-controls/ReservationControls.js
+++ b/app/shared/reservation-controls/ReservationControls.js
@@ -7,25 +7,24 @@ import injectT from '../../i18n/injectT';
 import { hasProducts } from '../../utils/resourceUtils';
 
 class ReservationControls extends Component {
-  constructor(props) {
-    super(props);
-    this.buttons = {
+  get buttons() {
+    return {
       cancel: (
         <Button
           bsStyle="danger"
           key="cancelButton"
-          onClick={props.onCancelClick}
+          onClick={this.props.onCancelClick}
         >
-          {props.t('ReservationControls.cancel')}
+          {this.props.t('ReservationControls.cancel')}
         </Button>
       ),
       confirm: (
         <Button
           bsStyle="success"
           key="confirmButton"
-          onClick={props.onConfirmClick}
+          onClick={this.props.onConfirmClick}
         >
-          {props.t('ReservationControls.confirm')}
+          {this.props.t('ReservationControls.confirm')}
         </Button>
       ),
       deny: (
@@ -34,26 +33,31 @@ class ReservationControls extends Component {
           key="denyButton"
           onClick={this.props.onDenyClick}
         >
-          {props.t('ReservationControls.deny')}
+          {this.props.t('ReservationControls.deny')}
         </Button>
       ),
       edit: (
         <Button
           bsStyle="primary"
-          disabled={!this.props.isStaff && !this.props.isAdmin && hasProducts(this.props.resource)}
+          disabled={(
+            !this.props.isStaff
+            && !this.props.isAdmin
+            && hasProducts(this.props.resource))
+            || this.props.resource !== null
+          }
           key="editButton"
-          onClick={props.onEditClick}
+          onClick={this.props.onEditClick}
         >
-          {props.t('ReservationControls.edit')}
+          {this.props.t('ReservationControls.edit')}
         </Button>
       ),
       info: (
         <Button
           bsStyle="default"
           key="infoButton"
-          onClick={props.onInfoClick}
+          onClick={this.props.onInfoClick}
         >
-          {props.t('ReservationControls.info')}
+          {this.props.t('ReservationControls.info')}
         </Button>
       ),
     };

--- a/app/shared/reservation-controls/ReservationControls.js
+++ b/app/shared/reservation-controls/ReservationControls.js
@@ -60,7 +60,7 @@ class ReservationControls extends Component {
   }
 
   renderButtons(buttons, isAdmin, isStaff, reservation) {
-    if (!reservation.needManualConfirmation) {
+    if (!reservation.need_manual_confirmation) {
       if (reservation.state === 'cancelled') {
         return null;
       }

--- a/app/shared/reservation-controls/ReservationControlsContainer.js
+++ b/app/shared/reservation-controls/ReservationControlsContainer.js
@@ -58,7 +58,7 @@ export class UnconnectedReservationControlsContainer extends Component {
     } = this.props;
     const nextUrl = getEditReservationUrl(reservation);
 
-    actions.selectReservationToEdit({ reservation, slotSize: resource.slotSize });
+    actions.selectReservationToEdit({ reservation, slotSize: resource.slot_size });
     history.push(nextUrl);
   }
 

--- a/app/shared/reservation-controls/ReservationControlsContainer.js
+++ b/app/shared/reservation-controls/ReservationControlsContainer.js
@@ -56,6 +56,11 @@ export class UnconnectedReservationControlsContainer extends Component {
     const {
       actions, reservation, resource, history,
     } = this.props;
+
+    if (!resource === null) {
+      return;
+    }
+
     const nextUrl = getEditReservationUrl(reservation);
 
     actions.selectReservationToEdit({ reservation, slotSize: resource.slot_size });
@@ -75,6 +80,7 @@ export class UnconnectedReservationControlsContainer extends Component {
       reservation,
       resource,
     } = this.props;
+
 
     return (
       <ReservationControls
@@ -97,7 +103,7 @@ UnconnectedReservationControlsContainer.propTypes = {
   isAdmin: PropTypes.bool.isRequired,
   isStaff: PropTypes.bool.isRequired,
   reservation: PropTypes.object.isRequired,
-  resource: PropTypes.object.isRequired,
+  resource: PropTypes.object,
   history: PropTypes.object.isRequired,
 };
 

--- a/app/shared/reservation-controls/__tests__/ReservationControls.test.js
+++ b/app/shared/reservation-controls/__tests__/ReservationControls.test.js
@@ -2,10 +2,22 @@ import React from 'react';
 import Button from 'react-bootstrap/lib/Button';
 import Immutable from 'seamless-immutable';
 import simple from 'simple-mock';
+import snakeCaseKeys from 'snakecase-keys';
 
 import Reservation from '../../../utils/fixtures/Reservation';
 import { makeButtonTests, shallowWithIntl } from '../../../utils/testUtils';
 import ReservationControls from '../ReservationControls';
+
+// This project handles API responses differently based on the method
+// that is used for fetching. Data in the redux store is in camelCase,
+// but data fetched through the apiClient is in snake_case. This
+// component was previously used in a context where API data
+// originated from the redux store, but now lives in a context where
+// this data comes directly from the apiClient.
+
+// To be able to use the same test tooling, we are transforming the
+// camelCase mock objects into snake_case mock objects.
+const makeReservation = (...args) => snakeCaseKeys(Reservation.build(...args));
 
 describe('shared/reservation-controls/ReservationControls', () => {
   const onCancelClick = simple.stub();
@@ -32,7 +44,7 @@ describe('shared/reservation-controls/ReservationControls', () => {
     const isAdmin = true;
 
     describe('with regular reservation', () => {
-      const reservation = Reservation.build({ needManualConfirmation: false, state: 'confirmed' });
+      const reservation = makeReservation({ needManualConfirmation: false, state: 'confirmed' });
       const buttons = getWrapper(reservation, isAdmin).find(Button);
 
       test('renders two buttons', () => {
@@ -49,7 +61,7 @@ describe('shared/reservation-controls/ReservationControls', () => {
     });
 
     describe('with preliminary reservation in requested state', () => {
-      const reservation = Reservation.build({ needManualConfirmation: true, state: 'requested' });
+      const reservation = makeReservation({ needManualConfirmation: true, state: 'requested' });
 
       describe('if user has staff permissions', () => {
         const isStaff = true;
@@ -95,7 +107,7 @@ describe('shared/reservation-controls/ReservationControls', () => {
     });
 
     describe('with preliminary reservation in cancelled state', () => {
-      const reservation = Reservation.build({ needManualConfirmation: true, state: 'cancelled' });
+      const reservation = makeReservation({ needManualConfirmation: true, state: 'cancelled' });
       const buttons = getWrapper(reservation, isAdmin).find(Button);
 
       test('renders one button', () => {
@@ -108,7 +120,7 @@ describe('shared/reservation-controls/ReservationControls', () => {
     });
 
     describe('with preliminary reservation in denied state', () => {
-      const reservation = Reservation.build({ needManualConfirmation: true, state: 'denied' });
+      const reservation = makeReservation({ needManualConfirmation: true, state: 'denied' });
       const buttons = getWrapper(reservation, isAdmin).find(Button);
 
       test('renders one button', () => {
@@ -121,7 +133,7 @@ describe('shared/reservation-controls/ReservationControls', () => {
     });
 
     describe('with preliminary reservation in confirmed state', () => {
-      const reservation = Reservation.build({ needManualConfirmation: true, state: 'confirmed' });
+      const reservation = makeReservation({ needManualConfirmation: true, state: 'confirmed' });
 
       describe('if user has staff permissions', () => {
         const isStaff = true;
@@ -167,7 +179,7 @@ describe('shared/reservation-controls/ReservationControls', () => {
     const isAdmin = false;
 
     describe('with regular reservation', () => {
-      const reservation = Reservation.build({ needManualConfirmation: false, state: 'confirmed' });
+      const reservation = makeReservation({ needManualConfirmation: false, state: 'confirmed' });
       const buttons = getWrapper(reservation, isAdmin).find(Button);
 
       test('renders two buttons', () => {
@@ -184,7 +196,7 @@ describe('shared/reservation-controls/ReservationControls', () => {
     });
 
     describe('with preliminary reservation in requested state', () => {
-      const reservation = Reservation.build({ needManualConfirmation: true, state: 'requested' });
+      const reservation = makeReservation({ needManualConfirmation: true, state: 'requested' });
       const buttons = getWrapper(reservation, isAdmin).find(Button);
 
       test('renders three buttons', () => {
@@ -205,7 +217,7 @@ describe('shared/reservation-controls/ReservationControls', () => {
     });
 
     describe('with preliminary reservation in cancelled state', () => {
-      const reservation = Reservation.build({ needManualConfirmation: true, state: 'cancelled' });
+      const reservation = makeReservation({ needManualConfirmation: true, state: 'cancelled' });
       const buttons = getWrapper(reservation, isAdmin).find(Button);
 
       test('renders one button', () => {
@@ -218,7 +230,7 @@ describe('shared/reservation-controls/ReservationControls', () => {
     });
 
     describe('with preliminary reservation in denied state', () => {
-      const reservation = Reservation.build({ needManualConfirmation: true, state: 'denied' });
+      const reservation = makeReservation({ needManualConfirmation: true, state: 'denied' });
       const buttons = getWrapper(reservation, isAdmin).find(Button);
 
       test('renders one button', () => {
@@ -231,7 +243,7 @@ describe('shared/reservation-controls/ReservationControls', () => {
     });
 
     describe('with preliminary reservation in confirmed state', () => {
-      const reservation = Reservation.build({ needManualConfirmation: true, state: 'confirmed' });
+      const reservation = makeReservation({ needManualConfirmation: true, state: 'confirmed' });
       const buttons = getWrapper(reservation, isAdmin).find(Button);
 
       test('renders two buttons', () => {

--- a/app/shared/reservation-controls/__tests__/ReservationControlsContainer.test.js
+++ b/app/shared/reservation-controls/__tests__/ReservationControlsContainer.test.js
@@ -1,6 +1,7 @@
 import { shallow } from 'enzyme';
 import React from 'react';
 import simple from 'simple-mock';
+import snakeCaseKeys from 'snakecase-keys';
 
 import Reservation from '../../../utils/fixtures/Reservation';
 import Resource from '../../../utils/fixtures/Resource';
@@ -11,8 +12,18 @@ import {
 } from '../ReservationControlsContainer';
 
 describe('shared/reservation-controls/ReservationControlsContainer', () => {
-  const resource = Resource.build();
-  const reservation = Reservation.build({ resource: resource.id });
+  // This project handles API responses differently based on the method
+  // that is used for fetching. Data in the redux store is in camelCase,
+  // but data fetched through the apiClient is in snake_case. This
+  // component was previously used in a context where API data
+  // originated from the redux store, but now lives in a context where
+  // this data comes directly from the apiClient.
+
+  // To be able to use the same test tooling, we are transforming the
+  // camelCase mock objects into snake_case mock objects.
+  const resource = snakeCaseKeys(Resource.build());
+  const reservation = snakeCaseKeys(Reservation.build({ resource: resource.id }));
+
   const history = {
     push: () => {},
   };
@@ -97,7 +108,7 @@ describe('shared/reservation-controls/ReservationControlsContainer', () => {
         expect(props.actions.selectReservationToEdit.callCount).toBe(1);
         expect(props.actions.selectReservationToEdit.lastCall.args[0]).toEqual({
           reservation: props.reservation,
-          slotSize: props.resource.slotSize,
+          slotSize: props.resource.slot_size,
         });
       },
     );

--- a/package.json
+++ b/package.json
@@ -127,6 +127,7 @@
     "rosie": "1.6.0",
     "sass-loader": "7.1.0",
     "simple-mock": "0.8.0",
+    "snakecase-keys": "^3.1.2",
     "style-loader": "0.23.1",
     "terser-webpack-plugin": "^1.2.2",
     "url-loader": "1.1.2",

--- a/src/domain/reservation/manage/pincode/__tests__/ManageReservationsPincode.test.js
+++ b/src/domain/reservation/manage/pincode/__tests__/ManageReservationsPincode.test.js
@@ -1,10 +1,22 @@
 import React from 'react';
 import toJSON from 'enzyme-to-json';
 import { shallow } from 'enzyme';
+import snakeCaseKeys from 'snakecase-keys';
 
 import ManageReservationsPincode from '../ManageReservationsPincode';
 import reservation from '../../../../../common/data/fixtures/reservation';
 import resource from '../../../../../common/data/fixtures/resource';
+
+// This project handles API responses differently based on the method
+// that is used for fetching. Data in the redux store is in camelCase,
+// but data fetched through the apiClient is in snake_case. This
+// component was previously used in a context where API data
+// originated from the redux store, but now lives in a context where
+// this data comes directly from the apiClient.
+
+// To be able to use the same test tooling, we are transforming the
+// camelCase mock objects into snake_case mock objects.
+const makeSnakeCase = obj => snakeCaseKeys(obj);
 
 describe('ManageReservationsPincode', () => {
   function getWrapper(props) {
@@ -16,20 +28,20 @@ describe('ManageReservationsPincode', () => {
   const pendingCodeResource = resource.attr('generateAccessCodes', false);
 
   test('renders correctly', () => {
-    const wrapper = getWrapper({ reservation: reservation.build() });
+    const wrapper = getWrapper({ reservation: makeSnakeCase(reservation.build()) });
     expect(toJSON(wrapper)).toMatchSnapshot();
   });
 
   test('show Icon when accessCode pending', () => {
     const wrapper = getWrapper({
-      reservation: reservation.build({ resource: pendingCodeResource.build() }),
+      reservation: reservation.build({ resource: makeSnakeCase(pendingCodeResource.build()) }),
     });
     expect(wrapper.debug()).toContain('img');
   });
 
   test('show **** when accessCode exist', () => {
     reservation.attr('accessCode', 1234);
-    const wrapper = getWrapper({ reservation: reservation.build() });
+    const wrapper = getWrapper({ reservation: makeSnakeCase(reservation.build()) });
     expect(wrapper.html()).toContain('****');
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -5975,6 +5975,11 @@ map-obj@^1.0.0, map-obj@^1.0.1:
   resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-1.0.1.tgz#d933ceb9205d82bdcf4886f6742bdc2b4dea146d"
   integrity sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=
 
+map-obj@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-4.1.0.tgz#b91221b542734b9f14256c0132c897c5d7256fd5"
+  integrity sha512-glc9y00wgtwcDmp7GaE/0b0OnxpNJsVf3ael/An6Fe2Q51LLwN1er6sdomLRzz5h0+yMpiYLhWYF5R7HeqVd4g==
+
 map-visit@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/map-visit/-/map-visit-1.0.0.tgz#ecdca8f13144e660f1b5bd41f12f3479d98dfb8f"
@@ -8551,6 +8556,14 @@ slice-ansi@^2.1.0:
     astral-regex "^1.0.0"
     is-fullwidth-code-point "^2.0.0"
 
+snakecase-keys@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/snakecase-keys/-/snakecase-keys-3.1.2.tgz#afb05f2c5b63e84a4e3d6c8c117c99a0026a839c"
+  integrity sha512-NrzHj8ctStnd1LYx3+L4buS7yildFum7WAbQQxkhPCNi3Qeqv7hoBne2c9n++HWxDG9Nv23pNEyyLCITZTv24Q==
+  dependencies:
+    map-obj "^4.0.0"
+    to-snake-case "^1.0.0"
+
 snapdragon-node@^2.0.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/snapdragon-node/-/snapdragon-node-2.1.1.tgz#6c175f86ff14bdb0724563e8f3c1b021a286853b"
@@ -9116,6 +9129,13 @@ to-regex@^3.0.1, to-regex@^3.0.2:
     extend-shallow "^3.0.2"
     regex-not "^1.0.2"
     safe-regex "^1.1.0"
+
+to-snake-case@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/to-snake-case/-/to-snake-case-1.0.0.tgz#ce746913897946019a87e62edfaeaea4c608ab8c"
+  integrity sha1-znRpE4l5RgGah+Yu366upMYIq4w=
+  dependencies:
+    to-space-case "^1.0.0"
 
 to-space-case@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
These changes aim to improve the performance of the my reservations page. The page takes a long time to load as of now and may even crash for devices with lower performance, for instance mobile.

## Causes for performance issues

While inspecting the performance issues I, with the help of Samuel, identified two key causes:
1) Requests were configured to fetch a very large set of data (500 pages)
2) Images were loaded in full size

### Context for large sets of data  
It looked like the reason for the large data set was that the resource object returned inlined to the reservation object is missing some fields which the list requires. To combat this, *all resources*  were fetched into the redux state so that they could be used to "hydrate" the incomplete `reservation.resource` objects. Due to the nature of redux and its normalized state, this must have been seen as a fast fix. I found a comment from some years ago that labeled the 500 page fetch as a temporary fix--into the annals with this one.

The side effect for this fetch is that it:  
1. creates a very large redux state object that harms frontend performance and
2. creates a request to respa that takes a long time to complete.

This same logic applied to units as well. But based on my understanding of the code, the `reservation.resource.unit` field actually provides all the information we need directly, so I am not entirely sure why a similar 500 page request was made for units.

## Rationale for changes

**Refactoring from redux to component state**  
In these changes I move the my-reservation container components into using component state instead of redux. This same action was completed for the manage resources page, which Samuel pointed to me as one place in the app where performance had been improved.

Migrating from redux into component state may offer some benefits when it comes to performance, but these should be marginal when compared to the lighter request we made. I still completed these changes because I trust that this direction was chosen for a valid reason before.

**Using a tabbed layout**  
Previously all the items were shown in a single list. Due to how the API works, this meant that upcoming reservations were shown in an illogical order: the reservation farthest away from this moment was first.

To resolve this issue past and upcoming reservations are now fetched separately and the user is able to change between the two by using a tab layout. I've demonstrated this change to the PO and it was accepted.

**Requesting additional resource information on demand**  
Previously, as I explained earlier, the app fetched "all the resources" into its state in order to be able to make the `reservation.resource` object complete.

After these changes the extra fields for `reservation.resource` are fetched "on demand". The conditions for "on demand" are filled when:
1) The reservation is on the page (pagination) that is currently being rendered
2) The reservation is visible in the window

This way we make about 3-4 request on first load, on smaller screens even less:
1) We fetch the reservations
2) we fetch `reservations.resource` for the first 2-3 reservations on the list

This way we:
1) Don't make that many more requests compared to before
2) We don't bloat the state
3) We don't make demanding requests to respa

As a downside I'd list:  
1) Reservation items are not completely usable on first render
     - Image will load in async manner (preferable behaviour most likely)
     - Icon alt texts are empty on first render --> should not impact accessibility that much as in most cases the `alt` attribute will have appropriate content when the user arrives to it
     - Edit button is disabled
     - Price is not shown
     - InfoLabel is not shown
     - Access code is not shown
2) We don't have "resource caching", i.e. we'll make a new fetch when we've already fetched the same resource before.

I did my best to avoid popping in the view. Currently these two things pop (based on my knowledge):  
- Access code
- Info label

**Removing additional unit fetch**  
As far I understood, there was no reason to fetch units into a separate state. To met it looked like the object in `reservation.resource.unit` was complete.

## Results

Testing the view by simply comparing its load time with Varaamo's test version should be enough to get a sense of the performance difference.