### PR TITLE
Add preliminary contributing guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,9 @@
-Contributions are accepted as pull requests.
+Contributions are accepted as pull requests.  Please observe our coding
+practices at https://github.com/City-of-Helsinki/bestpractice/ .
 
-If you make a pull request, you may also want to contact varaamo-dev@hel.fi to tell about your contribution.
+If you make a pull request, you may also want to contact
+`varaamo@hel.fi` to tell about your contribution.
 
-Our contribution handling guidelines are at https://github.com/City-of-Helsinki/bestpractice/blob/master/accepting-contributions.md
+Our contribution handling guidelines are at
+https://github.com/City-of-Helsinki/bestpractice/blob/master/accepting-contributions.md
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,5 @@
+Contributions are accepted as pull requests.
+
+If you make a pull request, you may also want to contact varaamo-dev@hel.fi to tell about your contribution.
+
+Our contribution handling guidelines are at https://github.com/City-of-Helsinki/bestpractice/blob/master/accepting-contributions.md


### PR DESCRIPTION
To resolve #1120 we've created a set of guidelines for handling contributions. These are openly accessible at https://github.com/City-of-Helsinki/bestpractice/blob/master/accepting-contributions.md

To make these guidelines accessible through the Varaamo repo, we are adding contributing guidelines that link possible contributors to the resource above.

Closes #1120