### PR TITLE
VAR-276 | Add support for viewer role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
   **CHANGELOG**
   - [#1118](https://github.com/City-of-Helsinki/varaamo/pull/1118) Added support for unit manager role; unit managers now have the same permissions as unit admins do
+  - [#1125](https://github.com/City-of-Helsinki/varaamo/pull/1125) Added support for unit viewer role; unit viewers are allowed to complete the same actions as unit admins or unit managers in the UI, but Respa may block some requests for users with this role
 
 # 0.9.0
   **MINOR CHANGES**

--- a/app/shared/form-fields/ReservationTimeControls.js
+++ b/app/shared/form-fields/ReservationTimeControls.js
@@ -38,6 +38,10 @@ class ReservationTimeControls extends Component {
     end: PropTypes.object.isRequired,
     period: PropTypes.string,
     timeFormat: PropTypes.string,
+    constraints: PropTypes.shape({
+      startTime: PropTypes.string, // HH:mm
+      endTime: PropTypes.string, // HH:mm
+    }),
   };
 
   static defaultProps = {
@@ -52,10 +56,40 @@ class ReservationTimeControls extends Component {
     this.handleDateChange = this.handleDateChange.bind(this);
   }
 
+  get startTime() {
+    const { constraints } = this.props;
+
+    if (constraints && constraints.startTime) {
+      const [hours, minutes] = constraints.startTime.split(':');
+
+      return moment().startOf('day').set({
+        hour: hours,
+        minute: minutes,
+      });
+    }
+
+    return moment().startOf('day');
+  }
+
+  get endTime() {
+    const { constraints } = this.props;
+
+    if (constraints && constraints.endTime) {
+      const [hours, minutes] = constraints.endTime.split(':');
+
+      return moment().endOf('day').set({
+        hour: hours,
+        minute: minutes,
+      });
+    }
+
+    return moment().endOf('day');
+  }
+
   getTimeOptions() {
     const { period, timeFormat } = this.props;
-    const start = moment().startOf('day');
-    const end = moment().endOf('day');
+    const start = this.startTime;
+    const end = this.endTime;
     const range = moment.range(moment(start), moment(end));
     const duration = moment.duration(period);
 

--- a/app/shared/form-fields/__tests__/ReservationTimeControls.test.js
+++ b/app/shared/form-fields/__tests__/ReservationTimeControls.test.js
@@ -62,6 +62,13 @@ describe('shared/form-fields/ReservationTimeControls', () => {
   });
 
   describe('getTimeOptions', () => {
+    const timeToNumber = (time) => {
+      const [hours, minutes] = time.split(':');
+
+      return Number(hours + minutes);
+    };
+    const optionsToNumber = options => options.map(({ value }) => timeToNumber(value));
+
     test(
       'returns time options using props.period as the duration between times ',
       () => {
@@ -97,6 +104,22 @@ describe('shared/form-fields/ReservationTimeControls', () => {
         expect(options).toEqual(expected);
       },
     );
+
+    test('when constraints.startTime is set, time options before startTime won\'t be listed', () => {
+      const startTime = '10:00';
+      const wrapper = getWrapper({ constraints: { startTime } });
+      const options = wrapper.instance().getTimeOptions();
+
+      expect(optionsToNumber(options).filter(option => option < timeToNumber(startTime)).length).toEqual(0);
+    });
+
+    test('when constraints.endTime is set, time options after endTime won\'t be listed', () => {
+      const endTime = '17:00';
+      const wrapper = getWrapper({ constraints: { endTime } });
+      const options = wrapper.instance().getTimeOptions();
+
+      expect(optionsToNumber(options).filter(option => option > timeToNumber(endTime)).length).toEqual(0);
+    });
   });
 
   describe('handleBeginTimeChange', () => {

--- a/app/shared/modals/reservation-info/ReservationEditForm.js
+++ b/app/shared/modals/reservation-info/ReservationEditForm.js
@@ -10,7 +10,10 @@ import FormControl from 'react-bootstrap/lib/FormControl';
 import FormGroup from 'react-bootstrap/lib/FormGroup';
 import Well from 'react-bootstrap/lib/Well';
 import { Field, Fields, reduxForm } from 'redux-form';
+import moment from 'moment';
 
+import { resourceRoles, resourcePermissionTypes } from '../../../../src/domain/resource/permissions/constants';
+import { hasPermissionForResource } from '../../../../src/domain/resource/permissions/utils';
 import { getReservationPrice, getTaxPercentage } from '../../../../src/domain/resource/utils';
 import FormTypes from '../../../constants/FormTypes';
 import ReduxFormField from '../../form-fields/ReduxFormField';
@@ -97,9 +100,36 @@ class UnconnectedReservationEditForm extends Component {
 
   renderReservationTime() {
     const {
-      isEditing, reservation, resource, t,
+      isEditing, reservation, resource, t, userUnitRole,
     } = this.props;
+
     if (isEditing) {
+      const canIgnoreOpeningHours = hasPermissionForResource(
+        userUnitRole,
+        resourcePermissionTypes.CAN_IGNORE_OPENING_HOURS,
+      );
+      const reservationDate = moment(reservation.begin).format('YYYY-MM-DD');
+      // We have a generic utility function with the same purpose, but
+      // for some reason the fields on the resource object are in
+      // camelCase when we access them here. The generic utility
+      // function assumes snake_case.
+      const getOpenHours = (resource0, reservationDate0) => {
+        const openHours = resource0.openingHours || [];
+
+        return openHours.find(openHour => openHour.date === reservationDate0);
+      };
+      const openingHoursForReservationDate = getOpenHours(resource, reservationDate);
+      const getConstraints = (openingHours) => {
+        if (!openingHours || canIgnoreOpeningHours) {
+          return undefined;
+        }
+
+        return {
+          startTime: moment(openingHours.opens).format('HH:mm'),
+          endTime: moment(openingHours.closes).format('HH:mm'),
+        };
+      };
+
       return (
         <FormGroup id="reservation-time">
           <Col sm={3}>
@@ -108,6 +138,8 @@ class UnconnectedReservationEditForm extends Component {
           <Col sm={9}>
             <Fields
               component={ReservationTimeControls}
+              constraints={getConstraints(openingHoursForReservationDate)}
+              disabled={!canIgnoreOpeningHours && !openingHoursForReservationDate}
               names={['begin', 'end']}
               period={resource.slotSize}
             />
@@ -125,7 +157,7 @@ class UnconnectedReservationEditForm extends Component {
       isAdmin,
       isEditing,
       isSaving,
-      isStaff,
+      userUnitRole,
       onCancelEditClick,
       onStartEditClick,
       reservation,
@@ -142,6 +174,10 @@ class UnconnectedReservationEditForm extends Component {
       price,
       tax,
     };
+    const canViewExtraFields = hasPermissionForResource(
+      userUnitRole,
+      resourcePermissionTypes.CAN_VIEW_RESERVATION_EXTRA_FIELDS,
+    );
 
     const { billingFirstName, billingLastName, billingEmailAddress } = reservation;
 
@@ -174,7 +210,7 @@ class UnconnectedReservationEditForm extends Component {
           && price > 0
         // eslint-disable-next-line max-len
           && this.renderInfoRow(t('ReservationInformationForm.refundPolicyTitle'), t('ReservationInformationForm.refundPolicyText'))}
-        {isStaff && this.renderStaticInfoRow('reserverId')}
+        {canViewExtraFields && this.renderStaticInfoRow('reserverId')}
         {this.renderStaticInfoRow('reserverPhoneNumber')}
         {this.renderStaticInfoRow('reserverEmailAddress')}
         {this.renderAddressRow('reserverAddress')}
@@ -223,7 +259,7 @@ UnconnectedReservationEditForm.propTypes = {
   isAdmin: PropTypes.bool.isRequired,
   isEditing: PropTypes.bool.isRequired,
   isSaving: PropTypes.bool.isRequired,
-  isStaff: PropTypes.bool.isRequired,
+  userUnitRole: PropTypes.oneOf([...Object.values(resourceRoles), null]),
   onCancelEditClick: PropTypes.func.isRequired,
   onStartEditClick: PropTypes.func.isRequired,
   reservation: PropTypes.object.isRequired,

--- a/app/shared/modals/reservation-info/ReservationEditForm.js
+++ b/app/shared/modals/reservation-info/ReservationEditForm.js
@@ -21,6 +21,15 @@ import ReservationTimeControls from '../../form-fields/ReservationTimeControls';
 import TimeRange from '../../time-range/TimeRange';
 import injectT from '../../../i18n/injectT';
 
+// We have a generic utility function with the same purpose, but it has
+// been developed to be snake_case compatible. In this view we are still
+// using resource objects from the redux state, and those use camelCase.
+const getReservationOpeningHoursByDate = (resource, reservationDate) => {
+  const openHours = resource.openingHours || [];
+
+  return openHours.find(openHour => openHour.date === reservationDate);
+};
+
 class UnconnectedReservationEditForm extends Component {
   constructor(props) {
     super(props);
@@ -109,16 +118,7 @@ class UnconnectedReservationEditForm extends Component {
         resourcePermissionTypes.CAN_IGNORE_OPENING_HOURS,
       );
       const reservationDate = moment(reservation.begin).format('YYYY-MM-DD');
-      // We have a generic utility function with the same purpose, but
-      // for some reason the fields on the resource object are in
-      // camelCase when we access them here. The generic utility
-      // function assumes snake_case.
-      const getOpenHours = (resource0, reservationDate0) => {
-        const openHours = resource0.openingHours || [];
-
-        return openHours.find(openHour => openHour.date === reservationDate0);
-      };
-      const openingHoursForReservationDate = getOpenHours(resource, reservationDate);
+      const openingHoursForReservationDate = getReservationOpeningHoursByDate(resource, reservationDate);
       const getConstraints = (openingHours) => {
         if (!openingHours || canIgnoreOpeningHours) {
           return undefined;

--- a/app/shared/modals/reservation-info/ReservationEditForm.js
+++ b/app/shared/modals/reservation-info/ReservationEditForm.js
@@ -20,6 +20,7 @@ import ReduxFormField from '../../form-fields/ReduxFormField';
 import ReservationTimeControls from '../../form-fields/ReservationTimeControls';
 import TimeRange from '../../time-range/TimeRange';
 import injectT from '../../../i18n/injectT';
+import constants from '../../../constants/AppConstants';
 
 // We have a generic utility function with the same purpose, but it has
 // been developed to be snake_case compatible. In this view we are still
@@ -117,7 +118,7 @@ class UnconnectedReservationEditForm extends Component {
         userUnitRole,
         resourcePermissionTypes.CAN_IGNORE_OPENING_HOURS,
       );
-      const reservationDate = moment(reservation.begin).format('YYYY-MM-DD');
+      const reservationDate = moment(reservation.begin).format(constants.DATE_FORMAT);
       const openingHoursForReservationDate = getReservationOpeningHoursByDate(resource, reservationDate);
       const getConstraints = (openingHours) => {
         if (!openingHours || canIgnoreOpeningHours) {

--- a/app/shared/modals/reservation-info/__tests__/ReservationInfoModal.test.js
+++ b/app/shared/modals/reservation-info/__tests__/ReservationInfoModal.test.js
@@ -35,7 +35,7 @@ describe('shared/modals/reservation-info/ReservationInfoModal', () => {
     isAdmin: false,
     isEditing: false,
     isSaving: false,
-    isStaff: false,
+    userUnitRole: null,
     onCancelClick: () => null,
     onCancelEditClick: () => null,
     onConfirmClick: () => null,
@@ -99,9 +99,9 @@ describe('shared/modals/reservation-info/ReservationInfoModal', () => {
           return getWrapper(props).find('.comments-form');
         }
 
-        describe('if user has admin rights but reservation is not editable', () => {
+        describe('if user has comment viewing rights rights but reservation is not editable', () => {
           const props = {
-            isAdmin: true,
+            userUnitRole: 'UNIT_ADMINISTRATOR',
             reservationIsEditable: false,
           };
 
@@ -110,9 +110,9 @@ describe('shared/modals/reservation-info/ReservationInfoModal', () => {
           });
         });
 
-        describe('if user has admin rights and reservation is editable', () => {
+        describe('if user has comment viewing rights rights and reservation is editable', () => {
           const props = {
-            isAdmin: true,
+            userUnitRole: 'UNIT_ADMINISTRATOR',
             reservationIsEditable: true,
           };
 
@@ -186,7 +186,7 @@ describe('shared/modals/reservation-info/ReservationInfoModal', () => {
 
         test('is not rendered if user is not a staff member', () => {
           const props = {
-            isStaff: false,
+            userUnitRole: null,
             reservationIsEditable: true,
             reservation: { ...reservation, state: 'requested' },
           };
@@ -195,7 +195,7 @@ describe('shared/modals/reservation-info/ReservationInfoModal', () => {
 
         test('is not rendered if reservation is not editable', () => {
           const props = {
-            isStaff: true,
+            userUnitRole: 'UNIT_ADMINISTRATOR',
             reservationIsEditable: false,
             reservation: { ...reservation, state: 'requested' },
           };
@@ -204,7 +204,7 @@ describe('shared/modals/reservation-info/ReservationInfoModal', () => {
 
         test('is not rendered if reservation state is not "requested"', () => {
           const props = {
-            isStaff: true,
+            userUnitRole: 'UNIT_ADMINISTRATOR',
             reservationIsEditable: true,
             reservation: { ...reservation, state: 'confirmed' },
           };
@@ -215,7 +215,7 @@ describe('shared/modals/reservation-info/ReservationInfoModal', () => {
           'is rendered if user is staff, reservation is editable and in "requested" state',
           () => {
             const props = {
-              isStaff: true,
+              userUnitRole: 'UNIT_ADMINISTRATOR',
               reservationIsEditable: true,
               reservation: { ...reservation, state: 'requested' },
             };
@@ -234,7 +234,7 @@ describe('shared/modals/reservation-info/ReservationInfoModal', () => {
 
         test('is not rendered if user is not a staff member', () => {
           const props = {
-            isStaff: false,
+            userUnitRole: null,
             reservationIsEditable: true,
             reservation: { ...reservation, state: 'requested' },
           };
@@ -243,7 +243,7 @@ describe('shared/modals/reservation-info/ReservationInfoModal', () => {
 
         test('is not rendered if reservation is not editable', () => {
           const props = {
-            isStaff: true,
+            userUnitRole: 'UNIT_ADMINISTRATOR',
             reservationIsEditable: false,
             reservation: { ...reservation, state: 'requested' },
           };
@@ -252,7 +252,7 @@ describe('shared/modals/reservation-info/ReservationInfoModal', () => {
 
         test('is not rendered if reservation state is not "requested"', () => {
           const props = {
-            isStaff: true,
+            userUnitRole: 'UNIT_ADMINISTRATOR',
             reservationIsEditable: true,
             reservation: { ...reservation, state: 'confirmed' },
           };
@@ -263,7 +263,7 @@ describe('shared/modals/reservation-info/ReservationInfoModal', () => {
           'is rendered if user is staff, reservation is editable and in "requested" state',
           () => {
             const props = {
-              isStaff: true,
+              userUnitRole: 'UNIT_ADMINISTRATOR',
               reservationIsEditable: true,
               reservation: { ...reservation, state: 'requested' },
             };

--- a/app/shared/modals/reservation-info/__tests__/reservationInfoModalSelector.test.js
+++ b/app/shared/modals/reservation-info/__tests__/reservationInfoModalSelector.test.js
@@ -44,8 +44,8 @@ describe('shared/modals/reservation-info/reservationInfoModalSelector', () => {
     });
   });
 
-  test('returns isStaff', () => {
-    expect(getSelected().isStaff).toBeDefined();
+  test('returns userUnitRole', () => {
+    expect(getSelected().userUnitRole).toBeDefined();
   });
 
   test('returns correct reservation from the state', () => {

--- a/app/shared/modals/reservation-info/reservationInfoModalSelector.js
+++ b/app/shared/modals/reservation-info/reservationInfoModalSelector.js
@@ -2,7 +2,7 @@ import moment from 'moment';
 import { createSelector, createStructuredSelector } from 'reselect';
 
 import ActionTypes from '../../../constants/ActionTypes';
-import { createIsStaffSelector, isAdminSelector } from '../../../state/selectors/authSelectors';
+import { createUserUnitRoleSelector, isAdminSelector } from '../../../state/selectors/authSelectors';
 import { createResourceSelector } from '../../../state/selectors/dataSelectors';
 import requestIsActiveSelectorFactory from '../../../state/selectors/factories/requestIsActiveSelectorFactory';
 
@@ -29,7 +29,7 @@ const reservationInfoModalSelector = createStructuredSelector({
   isAdmin: isAdminSelector,
   isEditing: state => state.ui.reservationInfoModal.isEditing,
   isSaving: requestIsActiveSelectorFactory(ActionTypes.API.RESERVATION_PUT_REQUEST),
-  isStaff: createIsStaffSelector(resourceSelector),
+  userUnitRole: createUserUnitRoleSelector(resourceSelector),
   reservation: reservationSelector,
   reservationIsEditable: reservationIsEditableSelector,
   resource: resourceSelector,

--- a/app/state/selectors/__tests__/authSelectors.test.js
+++ b/app/state/selectors/__tests__/authSelectors.test.js
@@ -6,7 +6,14 @@ import {
   isAdminSelector,
   isLoggedInSelector,
   createIsStaffSelector,
+  createIsUnitViewerSelector,
 } from '../authSelectors';
+
+const getMockResource = overrides => ({
+  ...Resource.build(),
+  ...overrides,
+});
+const mockResourceSelector = overrides => () => getMockResource(overrides);
 
 describe('state/selectors/authSelectors', () => {
   describe('currentUserSelector', () => {
@@ -86,12 +93,6 @@ describe('state/selectors/authSelectors', () => {
   });
 
   describe('createIsStaffSelector', () => {
-    const getMockResource = overrides => ({
-      ...Resource.build(),
-      ...overrides,
-    });
-    const mockResourceSelector = overrides => () => getMockResource(overrides);
-
     test('returns true when the user has unit admin permission for resource', () => {
       const selector = createIsStaffSelector(mockResourceSelector({ userPermissions: { isAdmin: true } }));
 
@@ -100,6 +101,14 @@ describe('state/selectors/authSelectors', () => {
 
     test('returns true when the user has unit manager permission for resource', () => {
       const selector = createIsStaffSelector(mockResourceSelector({ userPermissions: { isManager: true } }));
+
+      expect(selector()).toEqual(true);
+    });
+  });
+
+  describe('createIsUnitViewerSelector', () => {
+    test('returns true when the user has unit admin permission for the resource', () => {
+      const selector = createIsUnitViewerSelector(mockResourceSelector({ userPermissions: { isViewer: true } }));
 
       expect(selector()).toEqual(true);
     });

--- a/app/state/selectors/__tests__/authSelectors.test.js
+++ b/app/state/selectors/__tests__/authSelectors.test.js
@@ -6,7 +6,6 @@ import {
   isAdminSelector,
   isLoggedInSelector,
   createIsStaffSelector,
-  createIsUnitViewerSelector,
 } from '../authSelectors';
 
 const getMockResource = overrides => ({
@@ -104,11 +103,9 @@ describe('state/selectors/authSelectors', () => {
 
       expect(selector()).toEqual(true);
     });
-  });
 
-  describe('createIsUnitViewerSelector', () => {
-    test('returns true when the user has unit admin permission for the resource', () => {
-      const selector = createIsUnitViewerSelector(mockResourceSelector({ userPermissions: { isViewer: true } }));
+    test('returns true when the user has unit viewer permission for resource', () => {
+      const selector = createIsStaffSelector(mockResourceSelector({ userPermissions: { isViewer: true } }));
 
       expect(selector()).toEqual(true);
     });

--- a/app/state/selectors/authSelectors.js
+++ b/app/state/selectors/authSelectors.js
@@ -70,27 +70,23 @@ function createUserUnitRoleSelector(resourceSelector) {
 }
 
 /**
- * Check if a user has admin or manager permission for a unit.
- * TODO: Find a better name for this.
+ * Check if the user is either admin, manager or viewer in the unit the
+ * resource belongs to.
  *
- * 2020/02/07
- * I added support for the manager role. According to the spec, the
- * unit manager should have the exact same permissions as the unit admin
- * has. I couldn't get a good sense of the permission management
- * architecture, but it seems like this selector is the easiest way to
- * add support for this role
+ * For more fine grained control, use the hasPermissionForResource
+ * utility function.
  */
 function createIsStaffSelector(resourceSelector) {
   return createSelector(
     createIsUnitAdminSelector(resourceSelector),
     createIsUnitManagerSelector(resourceSelector),
-    (isAdmin, isManager) => isAdmin || isManager,
+    createIsUnitViewerSelector(resourceSelector),
+    (isUnitAdmin, isUnitManager, isUnitViewer) => isUnitAdmin || isUnitManager || isUnitViewer,
   );
 }
 
 export {
   createIsStaffSelector,
-  createIsUnitViewerSelector,
   currentUserSelector,
   createUserUnitRoleSelector,
   isAdminSelector,

--- a/app/state/selectors/authSelectors.js
+++ b/app/state/selectors/authSelectors.js
@@ -45,6 +45,17 @@ function createIsUnitManagerSelector(resourceSelector) {
 }
 
 /**
+ * Check if the user has manager level permissions for the resource.
+ * I.e. if they are a unit manager for the resource in question.
+ */
+function createIsUnitViewerSelector(resourceSelector) {
+  return createSelector(
+    resourceSelector,
+    resource => Boolean(get(resource, 'userPermissions.isViewer', false)),
+  );
+}
+
+/**
  * Check if a user has admin or manager permission for a unit.
  * TODO: Find a better name for this.
  *
@@ -65,6 +76,7 @@ function createIsStaffSelector(resourceSelector) {
 
 export {
   createIsStaffSelector,
+  createIsUnitViewerSelector,
   currentUserSelector,
   isAdminSelector,
   isLoggedInSelector,

--- a/app/state/selectors/authSelectors.js
+++ b/app/state/selectors/authSelectors.js
@@ -1,6 +1,8 @@
 import { createSelector } from 'reselect';
 import { get } from 'lodash';
 
+import { roleMapper } from '../../../src/domain/resource/permissions/utils';
+
 const userIdSelector = state => state.auth.userId;
 const usersSelector = state => state.data.users;
 
@@ -56,6 +58,18 @@ function createIsUnitViewerSelector(resourceSelector) {
 }
 
 /**
+ * Returns user's role in unit.
+ */
+function createUserUnitRoleSelector(resourceSelector) {
+  return createSelector(
+    createIsUnitAdminSelector(resourceSelector),
+    createIsUnitManagerSelector(resourceSelector),
+    createIsUnitViewerSelector(resourceSelector),
+    (isUnitAdmin, isUnitManager, isUnitViewer) => roleMapper(isUnitAdmin, isUnitManager, isUnitViewer),
+  );
+}
+
+/**
  * Check if a user has admin or manager permission for a unit.
  * TODO: Find a better name for this.
  *
@@ -78,6 +92,7 @@ export {
   createIsStaffSelector,
   createIsUnitViewerSelector,
   currentUserSelector,
+  createUserUnitRoleSelector,
   isAdminSelector,
   isLoggedInSelector,
 };

--- a/docs/PERMISSIONS.md
+++ b/docs/PERMISSIONS.md
@@ -1,0 +1,145 @@
+# Permission system
+
+Unfortunately this is not a complete description of the permission system--you'll need to get your hands dirty to fully figure it out. I hope that these docs help you get started. To represent this fact, I am adopting a less official tone for this documentation.
+
+Permission management for the combination of Varaamo and Respa happens in multiple places with varying approaches. Some rules are explicit, some are implicit, some are documented and some are harder to come by.
+
+Please extend this documentation when you face problems. I'll write down the points of confusion I faced. I hope that this information can be helpful for later developers in resolving theirs--but I make no promises of completeness nor total correctness.
+
+## Permissions in Respa
+
+When in doubt, your best bet is to go through Respa's source code. The model declaration files will contain most of the permission checks you care about, or they'll at least point you to the place where you can find them.
+
+Respa uses a combination of roles and permission to allow and disallow user actions. You can find the documentation for Respa's permissions here: https://github.com/City-of-Helsinki/respa/blob/develop/docs/permissions.rst
+
+A user can have a role that describes their status within the whole system or within a unit. The unit role is used to describe the user's permissions for both the `reservation` and `resource` objects. Currently Varaamo mostly relies on the `is_staff` flag found from the `user` object as well as the `user_permissions` object found from among the fields of `reservation` and `resource`.
+
+If you read through the documentation you may get a sense that it's geared more towards interoperability between Respa and the admin UI than Respa and Varaamo. That's why, although you can use the documentation as a lead, you can't necessarily use it to solve all of the questions you face.
+
+When I developed the permission system, I mostly did it for `resource` objects. Another important part of the puzzle is the `reservation` object, but I personally only have a limited visibility into that.
+
+### Mixed implicit and explicit permissions
+A source of possible danger when it comes to `resource` permissions is that some of them are explicit while some others are not. If you check the `user_permission` object that Respa returns, you'll notice that it has a composition along these lines of:
+
+```js
+{
+  is_admin: false,
+  is_manager: true,
+  is_viewer: false,
+  can_make_reservations: true,
+  can_ignore_opening_hours: true,
+  ...,
+}
+```
+
+Here `can_make_reservations` and `can_ignore_opening_hours` are explicitly stated. On top of these permissions, "meta" (or implicit) permissions also exist. The user receives these based on their unit role. For instance, at one point, the following list was documented within the Respa repository in the permission docs linked previously:
+
+```js
+[
+  'can_make_reservations',
+  'can_modify_reservations',
+  'can_ignore_opening_hours',
+  'can_view_reservation_access_code',
+  'can_view_reservation_extra_fields',
+  'can_view_reservation_user',
+  'can_access_reservation_comments',
+  'can_comment_reservations',
+  'can_view_reservation_catering_orders',
+  'can_bypass_payment',
+]
+```
+
+This architecture forces us to use the permissions system in two ways. We can deduce some permissions directly from the API response. And some permissions we need to deduce based on the role. For the latter case, to make the code maintainable, we need to maintain a role matrix within the Varaamo repository. With this approach, compared to using permissions directly from the API, we are disconnecting the permission business logic from its source.
+
+### Possibilities for permission clashes
+The permission system is not guaranteed to be completely transparent. I am aware of two instance where its possible to to arrive at an application state where role permissions are limited "unexpectedly". These cases you are able to deduce by reading the Respa source code.
+
+**Unit viewer does not have modification permission when resource is not reservable**  
+The unit viewer has the permission `can_modify_reservations`, but this does not apply when the `resource` the has the `reservable` flag set as `false`. From an API consumer perspective this might be hard to spot.
+
+**Unit viewer does not have commenting permission when mandatory fields are missing from a `reservation`**  
+The unit viewer has the permission `can_comment_reservations`, but it's possible to get the `reservation` into a state where the `viewer` is not able to modify the `reservation` at all.
+
+Here's a case for reproduction:
+1) Create a new reservation into as a unit admin, ignore billing information
+2) Log out
+3) Sign in as resource's unit viewer
+4) Go into My Premises
+5) Open the reservation you created during step 1
+6) Add a comment
+
+Commenting is just a `PUT` call into the `reservation` resource and as such expects the entire `reservation` object.
+
+Because unit `admin` is able to ignore fields the unit `viewer` is not, editing becomes impossible for the viewer until someone fills out the billing information for the `reservation`. 
+
+## Permissions in Varaamo
+Permissions within Varaamo are still mainly controlled with `selectors`. Some permissions are managed by interpreting API responses directly. I also developed a function that allows to check whether a role has permission(s) for an action.
+
+### Permissions with Selectors
+At the time of writing this document, the file `authSelectors`<sup>1</sup> contained the most commonly used selectors for permission management.
+
+**`isAdminSelector`**  
+As you can probably decipher from the content of this selector, it actually checks whether the user is staff _within the entire Respa system_. If you go and check the Respa permission document, under [Implementation of the Roles](https://github.com/City-of-Helsinki/respa/blob/develop/docs/permissions.rst#implementation-of-the-roles) section, you'll find the following:
+
+>All users having any of these Super User, Administrator or Manager statuses are considered "staff" and should have the is_staff property of the User object set to True.
+
+This means that a user with a unit `manager` role for any unit, is considered to be "staff" within the entire Respa system.
+
+```js
+const isAdminSelector = createSelector(
+  currentUserSelector,
+  currentUser => Boolean(currentUser.isStaff),
+);
+```
+
+There's a naming collision here, because the name implies admin within Varaamo, but it actually communicates staff status. One way to make sense of it is to think it like this: from Varaamo's perspective staff users are admin users. _But_ permissions do vary between the roles that receive the staff label. That's why we need more fine grained control.
+
+**`createIsStaffSelector`**  
+So here we are using the staff name, but we are still lacking some clarity. On the surface this function seems to be eerily similar with the one we just introduced: it's checking whether the user has a set of roles for a unit, and if so, communicates that they are staff.
+
+```js
+function createIsStaffSelector(resourceSelector) {
+  return createSelector(
+    createIsUnitAdminSelector(resourceSelector),
+    createIsUnitManagerSelector(resourceSelector),
+    createIsUnitViewerSelector(resourceSelector),
+    (isUnitAdmin, isUnitManager, isUnitViewer) => isUnitAdmin || isUnitManager || isUnitViewer,
+  );
+}
+```
+
+The difference, you might be able to spot when you read the function, is that this staff status is `resource` specific. With this selector you are able to ask "is the current user staff for this resource".
+
+NOTE
+* This concept of "unit staff" does not exist in Respa. Instead it's a concept we use in Varaamo to allow "staff" users to complete "staff" specific actions.
+* Unit `admin` and unit `manager` should be able to complete exactly the same actions within Varaamo--but unit `viewer` has some further limitations. _All of these are not currently addressed in Varaamo_. Instead, Varaamo allows the viewer user to make requests they do not have permission to complete and will then rely on the error handling logic within the application to let the user know that their action failed.
+
+### Permissions with Other Means
+
+**Relying on API**  
+The API returns a `userPermission` object within the fields of for instance `resource` and `reservation`. At certain points of the application, this object is used directly to check user permissions. This approach avoids data model transformations, it avoids replicating the permission matrix and it lessens the need for scaffolding. By and large it seems like a neat approach for managing permissions.
+
+**`hasPermissionForResource`**  
+This is an utility function I developed to help myself when implementing the unit `viewer` role. To learn a bit more about the context for introducing this utility you can read through [#1125](https://github.com/City-of-Helsinki/varaamo/pull/1125).
+
+In short, originally the unit viewer had a more limited set of permissions. To address those, I needed a way to check permissions with finer control. Previously the app had relied on a boolean flag for roles. Retaining the approach would have resulted in prop drilling. I could have changed these boolean flags into role strings, but I decided to dwell deeper.
+
+Checking permissions instead of roles is nice because it makes the permission system extendable and modifiable. If we add a new role we can rely on the same permission checks, and if role permissions are modified we can just modify them in our single source of truth. The more convoluted cases, such as adding or changing permissions, have a great chance of being no more convoluted than they are when checking against a role directly.
+
+```js
+const canComment = hasPermissionForResource(
+  userUnitRole,
+  resourcePermissionTypes.CAN_COMMENT_RESERVATIONS
+);
+```
+
+`hasPermissionForResource` takes in a unit `role` and a `permission` or a list of `permissions`. Both valid roles and permission have been defined in resource permission constants<sup>2</sup>. This file also holds the permission matrix that is used to decipher what permission each role has.
+
+I added a helper selector into `authSelectors` called `createUserUnitRoleSelector`. You can use this selector to get a `hasPermissionForResource` compatible user unit role from a resource. In essence it transforms the role flags (`is_admin`, `is_manager`, ...) into string values (`resourceRoles.UNIT_ADMIN`, ...).
+
+---
+
+<sup>1</sup> `app/state/selectors/authSelectors.js`
+
+<sup>2</sup> `src/domain/resource/permissions/constants.js`
+

--- a/src/domain/resource/permissions/__tests__/__snapshots__/utils.test.js.snap
+++ b/src/domain/resource/permissions/__tests__/__snapshots__/utils.test.js.snap
@@ -1,0 +1,19 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`domain resource permission utility functions hasPermissionForResource throws an error when requiredPermissions is not one of string or array 1`] = `"requiredPermissions has to be either a string or an array."`;
+
+exports[`domain resource permission utility functions hasPermissionForResource throws an error when resourceRole is not supported 1`] = `"resourceRole needs to be one of: UNIT_ADMINISTRATOR, UNIT_MANAGER, UNIT_VIEWER."`;
+
+exports[`domain resource permission utility functions hasPermissionForResource warns when the permissions targeted with requiredPermissions are unknown 1`] = `
+Array [
+  "Permission asked with unknown permission: IMAGINARY_PERMISSION.
+Permission needs to be on of: can_make_reservations, can_modify_reservations, can_ignore_opening_hours, can_view_reservation_access_code, can_view_reservation_extra_fields, can_view_reservation_user, can_access_reservation_comments, can_comment_reservations, can_view_reservation_catering_orders, can_bypass_payment.",
+]
+`;
+
+exports[`domain resource permission utility functions hasPermissionForResource warns when the permissions targeted with requiredPermissions are unknown 2`] = `
+Array [
+  "Permission asked with unknown permission: IMAGINARY_PERMISSION_0, IMAGINARY_PERMISSION_1.
+Permission needs to be on of: can_make_reservations, can_modify_reservations, can_ignore_opening_hours, can_view_reservation_access_code, can_view_reservation_extra_fields, can_view_reservation_user, can_access_reservation_comments, can_comment_reservations, can_view_reservation_catering_orders, can_bypass_payment.",
+]
+`;

--- a/src/domain/resource/permissions/__tests__/utils.test.js
+++ b/src/domain/resource/permissions/__tests__/utils.test.js
@@ -1,0 +1,93 @@
+import { hasPermissionForResource, roleMapper } from '../utils';
+import { resourceRoles, resourcePermissionTypes } from '../constants';
+
+describe('domain resource permission utility functions', () => {
+  describe('hasPermissionForResource', () => {
+    test('should return false when resourceRole is undefined or null', () => {
+      expect(hasPermissionForResource(null)).toEqual(false);
+      expect(hasPermissionForResource(undefined)).toEqual(false);
+    });
+
+    test('throws an error when resourceRole is not supported', () => {
+      expect(() => {
+        hasPermissionForResource('IMAGINARY_ROLE');
+      }).toThrowErrorMatchingSnapshot();
+    });
+
+    test('throws an error when requiredPermissions is not one of string or array', () => {
+      expect(() => {
+        hasPermissionForResource(resourceRoles.UNIT_ADMINISTRATOR, 0);
+      }).toThrowErrorMatchingSnapshot();
+    });
+
+    test('warns when the permissions targeted with requiredPermissions are unknown', () => {
+    // eslint-disable-next-line no-console
+      const originalWarn = global.console.warn;
+      let lastCall = null;
+      const mockWarn = jest.fn((...args) => {
+        lastCall = args;
+      });
+      // eslint-disable-next-line no-console
+      global.console.warn = mockWarn;
+
+      hasPermissionForResource(resourceRoles.UNIT_ADMINISTRATOR, 'IMAGINARY_PERMISSION');
+
+      expect(lastCall).toMatchSnapshot();
+
+      hasPermissionForResource(resourceRoles.UNIT_ADMINISTRATOR, ['IMAGINARY_PERMISSION_0', 'IMAGINARY_PERMISSION_1']);
+
+      expect(lastCall).toMatchSnapshot();
+
+      // eslint-disable-next-line no-console
+      global.console.warn = originalWarn;
+    });
+
+    test('should work with a supported role and a known permission string', () => {
+      const consoleWarnSpy = jest.spyOn(global.console, 'warn');
+      const admin = resourceRoles.UNIT_ADMINISTRATOR;
+      const viewer = resourceRoles.UNIT_VIEWER;
+      const canIgnoreOpeningHours = resourcePermissionTypes.CAN_IGNORE_OPENING_HOURS;
+
+      // Should return true because admin has this permission
+      expect(hasPermissionForResource(admin, canIgnoreOpeningHours)).toEqual(true);
+      // Should return false because viewer does not have this permission
+      expect(hasPermissionForResource(viewer, canIgnoreOpeningHours)).toEqual(false);
+
+      expect(consoleWarnSpy).not.toHaveBeenCalled();
+    });
+
+    test('should work with a supported role and an array of known permission strings', () => {
+      const consoleWarnSpy = jest.spyOn(global.console, 'warn');
+      const admin = resourceRoles.UNIT_ADMINISTRATOR;
+      const viewer = resourceRoles.UNIT_VIEWER;
+      const canIgnoreOpeningHoursAndModifyReservations = [
+        resourcePermissionTypes.CAN_IGNORE_OPENING_HOURS, resourcePermissionTypes.CAN_MODIFY_RESERVATIONS,
+      ];
+
+      // Should return true because admin has all the permissions
+      expect(hasPermissionForResource(admin, canIgnoreOpeningHoursAndModifyReservations)).toEqual(true);
+      // Should return false because viewer does not have one of the permission
+      expect(hasPermissionForResource(viewer, canIgnoreOpeningHoursAndModifyReservations)).toEqual(false);
+
+      expect(consoleWarnSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('roleMapper', () => {
+    test('returns UNIT_ADMINISTRATOR when isAdmin is true', () => {
+      expect(roleMapper(true)).toEqual(resourceRoles.UNIT_ADMINISTRATOR);
+    });
+
+    test('returns UNIT_MANAGER when isAdmin is falsy and isManager is true', () => {
+      expect(roleMapper(false, true)).toEqual(resourceRoles.UNIT_MANAGER);
+    });
+
+    test('returns UNIT_MANAGER when isAdmin is falsy, isManager is falsy and isViewer is true', () => {
+      expect(roleMapper(false, false, true)).toEqual(resourceRoles.UNIT_VIEWER);
+    });
+
+    test('returns null when all parameters are falsy', () => {
+      expect(roleMapper(false, false, false)).toEqual(null);
+    });
+  });
+});

--- a/src/domain/resource/permissions/constants.js
+++ b/src/domain/resource/permissions/constants.js
@@ -35,7 +35,9 @@ const UNIT_MANAGER_PERMISSIONS = [
   resourcePermissionTypes.CAN_IGNORE_OPENING_HOURS,
   resourcePermissionTypes.CAN_VIEW_RESERVATIONS_ACCESS_CODE,
   resourcePermissionTypes.CAN_VIEW_RESERVATION_EXTRA_FIELDS,
+  resourcePermissionTypes.CAN_VIEW_RESERVATION_USER,
   resourcePermissionTypes.CAN_ACCESS_RESERVATION_COMMENTS,
+  resourcePermissionTypes.CAN_COMMENT_RESERVATIONS,
   resourcePermissionTypes.CAN_VIEW_RESERVATION_CATERING_ORDERS,
   resourcePermissionTypes.CAN_BYPASS_PAYMENT,
 ];

--- a/src/domain/resource/permissions/constants.js
+++ b/src/domain/resource/permissions/constants.js
@@ -1,0 +1,54 @@
+export const resourcePermissionTypes = Object.freeze({
+  CAN_MAKE_RESERVATIONS: 'can_make_reservations',
+  CAN_MODIFY_RESERVATIONS: 'can_modify_reservations',
+  CAN_IGNORE_OPENING_HOURS: 'can_ignore_opening_hours',
+  CAN_VIEW_RESERVATIONS_ACCESS_CODE: 'can_view_reservation_access_code',
+  CAN_VIEW_RESERVATION_EXTRA_FIELDS: 'can_view_reservation_extra_fields',
+  CAN_VIEW_RESERVATION_USER: 'can_view_reservation_user',
+  CAN_ACCESS_RESERVATION_COMMENTS: 'can_access_reservation_comments',
+  CAN_COMMENT_RESERVATIONS: 'can_comment_reservations',
+  CAN_VIEW_RESERVATION_CATERING_ORDERS: 'can_view_reservation_catering_orders',
+  CAN_BYPASS_PAYMENT: 'can_bypass_payment',
+});
+
+export const resourceRoles = Object.freeze({
+  UNIT_ADMINISTRATOR: 'UNIT_ADMINISTRATOR',
+  UNIT_MANAGER: 'UNIT_MANAGER',
+  UNIT_VIEWER: 'UNIT_VIEWER',
+});
+
+const UNIT_ADMINISTRATOR_PERMISSIONS = [
+  resourcePermissionTypes.CAN_MAKE_RESERVATIONS,
+  resourcePermissionTypes.CAN_MODIFY_RESERVATIONS,
+  resourcePermissionTypes.CAN_IGNORE_OPENING_HOURS,
+  resourcePermissionTypes.CAN_VIEW_RESERVATIONS_ACCESS_CODE,
+  resourcePermissionTypes.CAN_VIEW_RESERVATION_EXTRA_FIELDS,
+  resourcePermissionTypes.CAN_VIEW_RESERVATION_USER,
+  resourcePermissionTypes.CAN_ACCESS_RESERVATION_COMMENTS,
+  resourcePermissionTypes.CAN_COMMENT_RESERVATIONS,
+  resourcePermissionTypes.CAN_VIEW_RESERVATION_CATERING_ORDERS,
+  resourcePermissionTypes.CAN_BYPASS_PAYMENT,
+];
+const UNIT_MANAGER_PERMISSIONS = [
+  resourcePermissionTypes.CAN_MAKE_RESERVATIONS,
+  resourcePermissionTypes.CAN_MODIFY_RESERVATIONS,
+  resourcePermissionTypes.CAN_IGNORE_OPENING_HOURS,
+  resourcePermissionTypes.CAN_VIEW_RESERVATIONS_ACCESS_CODE,
+  resourcePermissionTypes.CAN_VIEW_RESERVATION_EXTRA_FIELDS,
+  resourcePermissionTypes.CAN_ACCESS_RESERVATION_COMMENTS,
+  resourcePermissionTypes.CAN_VIEW_RESERVATION_CATERING_ORDERS,
+  resourcePermissionTypes.CAN_BYPASS_PAYMENT,
+];
+const UNIT_VIEWER_PERMISSIONS = [
+  resourcePermissionTypes.CAN_MODIFY_RESERVATIONS,
+  resourcePermissionTypes.CAN_VIEW_RESERVATIONS_ACCESS_CODE,
+  resourcePermissionTypes.CAN_VIEW_RESERVATION_EXTRA_FIELDS,
+  resourcePermissionTypes.CAN_VIEW_RESERVATION_USER,
+  resourcePermissionTypes.CAN_ACCESS_RESERVATION_COMMENTS,
+  resourcePermissionTypes.CAN_COMMENT_RESERVATIONS,
+];
+export const resourcePermissionsByRole = Object.freeze({
+  [resourceRoles.UNIT_ADMINISTRATOR]: UNIT_ADMINISTRATOR_PERMISSIONS,
+  [resourceRoles.UNIT_MANAGER]: UNIT_MANAGER_PERMISSIONS,
+  [resourceRoles.UNIT_VIEWER]: UNIT_VIEWER_PERMISSIONS,
+});

--- a/src/domain/resource/permissions/utils.js
+++ b/src/domain/resource/permissions/utils.js
@@ -24,7 +24,7 @@ const allValuesInArray = (subset, superset) => difference(subset, superset).leng
 
 export function hasPermissionForResource(resourceRole, requiredPermissions) {
   // undefined roles don't receive any permissions implicitly
-  if (resourceRole === undefined || resourceRole === null) {
+  if (!resourceRole) {
     return false;
   }
 

--- a/src/domain/resource/permissions/utils.js
+++ b/src/domain/resource/permissions/utils.js
@@ -1,0 +1,67 @@
+import difference from 'lodash/difference';
+
+import { resourceRoles, resourcePermissionTypes, resourcePermissionsByRole } from './constants';
+
+// Returns the role with the most permissions or null.
+export function roleMapper(isAdmin, isManager, isViewer) {
+  if (isAdmin) {
+    return resourceRoles.UNIT_ADMINISTRATOR;
+  }
+
+  if (isManager) {
+    return resourceRoles.UNIT_MANAGER;
+  }
+
+  if (isViewer) {
+    return resourceRoles.UNIT_VIEWER;
+  }
+
+  return null;
+}
+
+const permissionOptions = Object.values(resourcePermissionTypes);
+const allValuesInArray = (subset, superset) => difference(subset, superset).length === 0;
+
+export function hasPermissionForResource(resourceRole, requiredPermissions) {
+  // undefined roles don't receive any permissions implicitly
+  if (resourceRole === undefined || resourceRole === null) {
+    return false;
+  }
+
+  if (!Object.values(resourceRoles).includes(resourceRole)) {
+    throw Error(`resourceRole needs to be one of: ${Object.values(resourceRoles).join(', ')}.`);
+  }
+
+  if (!Array.isArray(requiredPermissions) && typeof requiredPermissions !== 'string') {
+    throw Error('requiredPermissions has to be either a string or an array.');
+  }
+
+  if (
+    Array.isArray(requiredPermissions)
+    && !allValuesInArray(requiredPermissions, permissionOptions)
+  ) {
+    const unknownPermissions = difference(requiredPermissions, permissionOptions);
+
+    // eslint-disable-next-line no-console
+    console.warn([
+      `Permission asked with unknown permission: ${unknownPermissions.join(', ')}.`,
+      `Permission needs to be on of: ${permissionOptions.join(', ')}.`,
+    ].join('\n'));
+  }
+
+  if (typeof requiredPermissions === 'string' && !permissionOptions.includes(requiredPermissions)) {
+    // eslint-disable-next-line no-console
+    console.warn([
+      `Permission asked with unknown permission: ${requiredPermissions}.`,
+      `Permission needs to be on of: ${permissionOptions.join(', ')}.`,
+    ].join('\n'));
+  }
+
+  const rolePermissions = resourcePermissionsByRole[resourceRole];
+
+  if (Array.isArray(requiredPermissions)) {
+    return allValuesInArray(requiredPermissions, rolePermissions);
+  }
+
+  return rolePermissions.includes(requiredPermissions);
+}


### PR DESCRIPTION
This PR comes with a story.

When I started working on this PR, the viewer role's permissions were different to that of a manager or admin. I developed the UI in a direction that would allow for us to take singular permissions into account--because the permissions `viewer` had required this.

Previously we were naively using the user's role to allow actions within the UI--after the change we check if the role in question has the specific permissions to do an action. This is a better approach because it's maintainable and extendable, unlike using roles directly. With three roles in play it felt like a valuable change.

Because the API does not return all the permission, some of them are implicit, I replicated the permission matrix from respa into our repo. Unlike with `reservations`, we aren't able to trust the `userPermissions` object when it comes to `resources`. That forced me to create more scaffolding in our end.

Well, when I mentioned these discrepancies in the permissions, the PO found them to be incorrect. Respa was updated and the `viewer` role received more permissions. This rendered some of the changes I made obsolete.

As I tested my implementation I found more odd behaviour. I got a lot of help from the respa team in uncovering the core reasons. I was able to nail down two niche cases in detail: 

>The unit viewer role doesn't have permissions to create, edit or comment reservations which have been made for resources that don't have reservations enabled (reservable = `false`).

> Please check Slack for the other case
>https://helsinkicity.slack.com/archives/C51R13GRZ/p1582108269166700

These cases offer their own UX conundrums and do not have an apparent best answer. Because these cases are niche, we decided not to address them. Instead, we will just elevate the `viewer` role to be on par with `admin` and `manager` within the Varaamo UI. Most of the time respa will be able to send a permission error Varaamo knows how to display to the user. If niche cases raise a lot of user feedback, we'll address them.

What does this mean? The user permission system I created is now in essence useless. I've received explicit permission from the PO to ignore permission differences between the roles if it expedites our development effort. So the smallest change we require now is changing the `createIsStaffSelector` to respect the unit `viewer` role. I've done that now. 

I still have the permission specific checks in the code I managed to develop before this decision was made.

Those checks are no longer vital code, but they are not dead code either. I don't really know whether I should purge them or not.

**Pros**  
- It's already developed
- It's the direction we should go towards
- It's not dead code

**Cons**  
- It makes the permission system of Varaamo more complicated to comprehend
- Respa's resource permissions aren't completely finalised yet, the model would likely change if there was enough resources put into the project (unlikely). At some point the API will likely return the complete permissions.

So when reviewing this PR, I'd appreciate opinions on whether I should discard
* Add support for unit viewer role and
* Sync permission with 0.9.0 version of respa

commits or not.