### PR TITLE
VAR-333, VAR-334, VAR-335 | Refactor reservation control buttons in my reservations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   - [#1118](https://github.com/City-of-Helsinki/varaamo/pull/1118) Added support for unit manager role; unit managers now have the same permissions as unit admins do
   - [#1125](https://github.com/City-of-Helsinki/varaamo/pull/1125) Added support for unit viewer role; unit viewers are allowed to complete the same actions as unit admins or unit managers in the UI, but Respa may block some requests for users with this role
   - [#1127](https://github.com/City-of-Helsinki/varaamo/pull/1127) Added support for resource payment terms
+  - [#1126](https://github.com/City-of-Helsinki/varaamo/pull/1126) Fixed my reservation crashing on some devices and improved performance
 
 # 0.9.0
   **MINOR CHANGES**

--- a/app/pages/user-reservations/__tests__/UserReservationsPage.test.js
+++ b/app/pages/user-reservations/__tests__/UserReservationsPage.test.js
@@ -14,6 +14,7 @@ describe('pages/user-reservations/UserReservationsPage', () => {
       push: () => {},
     },
     t: path => path,
+    reduxReservations: {},
   };
 
   function getWrapper(extraProps = {}) {

--- a/app/pages/user-reservations/reservation-list/ReservationListContainer.js
+++ b/app/pages/user-reservations/reservation-list/ReservationListContainer.js
@@ -1,9 +1,7 @@
-import includes from 'lodash/includes';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import Loader from 'react-loader';
 import { connect } from 'react-redux';
-import get from 'lodash/get';
 
 import Pagination from '../../../../src/common/pagination/Pagination';
 import injectT from '../../../i18n/injectT';
@@ -20,13 +18,10 @@ class UnconnectedReservationListContainer extends Component {
     const {
       isAdmin,
     } = this.props;
-    const staffUnits = [];
-    const unitId = get(reservation, 'resource.unit.id', null);
 
     return (
       <ReservationListItem
         isAdmin={isAdmin}
-        isStaff={includes(staffUnits, unitId)}
         key={reservation.url}
         reservation={reservation}
       />

--- a/app/pages/user-reservations/reservation-list/ReservationListItem.js
+++ b/app/pages/user-reservations/reservation-list/ReservationListItem.js
@@ -33,7 +33,7 @@ class ReservationListItem extends Component {
 
   render() {
     const {
-      isAdmin, isStaff, reservation, t,
+      isAdmin, reservation, t,
     } = this.props;
     const resource = reservation.resource;
     const unit = reservation.resource.unit;
@@ -119,7 +119,6 @@ class ReservationListItem extends Component {
               <div className="col-xs-4 col-md-3 col-lg-3 action-container">
                 <ReservationControls
                   isAdmin={isAdmin}
-                  isStaff={isStaff}
                   reservation={reservation}
                   resource={completeResource}
                 />
@@ -134,7 +133,6 @@ class ReservationListItem extends Component {
 
 ReservationListItem.propTypes = {
   isAdmin: PropTypes.bool.isRequired,
-  isStaff: PropTypes.bool.isRequired,
   reservation: PropTypes.object.isRequired,
   t: PropTypes.func.isRequired,
   locale: PropTypes.string.isRequired,

--- a/app/pages/user-reservations/reservation-list/ResourceHydrator.js
+++ b/app/pages/user-reservations/reservation-list/ResourceHydrator.js
@@ -78,10 +78,10 @@ const ResourceHydrator = ({ id, children, wrappingRef }) => {
 
   useIntersectionObserver(window, wrappingRef, handleOnIntersect, 0);
   useEffect(() => {
-    if (isIntersecting) {
+    if (isIntersecting && res.data === null) {
       fetch(id);
     }
-  }, [fetch, id, isIntersecting]);
+  }, [fetch, id, isIntersecting, res.data]);
 
 
   return children(res);

--- a/app/pages/user-reservations/reservation-list/__tests__/ReservationListContainer.test.js
+++ b/app/pages/user-reservations/reservation-list/__tests__/ReservationListContainer.test.js
@@ -64,12 +64,11 @@ describe('pages/user-reservations/reservation-list/ReservationListContainer', ()
         expect(reservationListItems).toHaveLength(props.reservations.length);
       });
 
-      test('passes isAdmin, isStaff and reservation', () => {
+      test('passes isAdmin and reservation', () => {
         const reservationListItems = getWithReservationsWrapper().find(ReservationListItem);
         reservationListItems.forEach((reservationListItem) => {
           const actualProps = reservationListItem.props();
           expect(actualProps.isAdmin).toBe(props.isAdmin);
-          expect(actualProps.isStaff).toBe(false);
           expect(reservationListItems.at(0).prop('reservation')).toEqual(props.reservations[0]);
           expect(reservationListItems.at(1).prop('reservation')).toEqual(props.reservations[1]);
         });

--- a/app/pages/user-reservations/reservation-list/__tests__/ReservationListItem.test.js
+++ b/app/pages/user-reservations/reservation-list/__tests__/ReservationListItem.test.js
@@ -131,7 +131,6 @@ describe('pages/user-reservations/reservation-list/ReservationListItem', () => {
       const actualProps = component.find(ReservationControls).props();
 
       expect(actualProps.isAdmin).toBe(false);
-      expect(actualProps.isStaff).toBe(false);
       expect(actualProps.reservation).toBe(props.reservation);
       expect(actualProps.resource).toBe(hydratedResource.data);
     });

--- a/app/pages/user-reservations/userReservationsPageSelector.js
+++ b/app/pages/user-reservations/userReservationsPageSelector.js
@@ -1,9 +1,11 @@
 import { createStructuredSelector } from 'reselect';
 
 import { isAdminSelector } from '../../state/selectors/authSelectors';
+import { reservationsSelector } from '../../state/selectors/dataSelectors';
 
 const userReservationsPageSelector = createStructuredSelector({
   isAdmin: isAdminSelector,
+  reduxReservations: reservationsSelector,
 });
 
 export default userReservationsPageSelector;

--- a/app/shared/_shared.scss
+++ b/app/shared/_shared.scss
@@ -14,6 +14,7 @@
 @import './progress-steps/progress-steps';
 @import './recurring-reservation-controls/recurring-reservation-controls';
 @import './reservation-confirmation/confirm-reservation-modal';
+@import './reservation-controls/reservation_controls';
 @import './reservation-date/reservation-date';
 @import './reservation-popover/reservation-popover';
 @import './resource-calendar/resource-calendar';

--- a/app/shared/modals/reservation-info/ReservationEditForm.js
+++ b/app/shared/modals/reservation-info/ReservationEditForm.js
@@ -180,7 +180,11 @@ class UnconnectedReservationEditForm extends Component {
       resourcePermissionTypes.CAN_VIEW_RESERVATION_EXTRA_FIELDS,
     );
 
-    const { billingFirstName, billingLastName, billingEmailAddress } = reservation;
+    const {
+      billingFirstName, billingLastName, billingEmailAddress, isOwn, user,
+    } = reservation;
+
+    const isAdminOrOwner = (isAdmin || isOwn);
 
     return (
       <Form
@@ -188,10 +192,12 @@ class UnconnectedReservationEditForm extends Component {
         horizontal
         onSubmit={handleSubmit}
       >
-        <Well>
-          {this.renderUserInfoRow('displayName', 'userName')}
-          {this.renderUserInfoRow('email', 'userEmail')}
-        </Well>
+        {user && (
+          <Well>
+            {this.renderUserInfoRow('displayName', 'userName')}
+            {this.renderUserInfoRow('email', 'userEmail')}
+          </Well>
+        )}
         { billingFirstName
         && billingLastName
         && this.renderInfoRow(t('common.paymentNameLabel'), `${billingFirstName} ${billingLastName}`)}
@@ -219,9 +225,9 @@ class UnconnectedReservationEditForm extends Component {
         {this.renderStaticInfoRow('accessCode')}
         {this.renderStaticInfoRow('reservationExtraQuestions')}
         {isAdmin && !reservationIsEditable && this.renderStaticInfoRow('comments')}
-        {isAdmin && reservationIsEditable && (
+        {isAdminOrOwner && reservationIsEditable && (
           <div className="form-controls">
-            {!isEditing && (
+            {isAdminOrOwner && !isEditing && (
               <Button
                 bsStyle="primary"
                 disabled={isSaving}
@@ -230,7 +236,7 @@ class UnconnectedReservationEditForm extends Component {
                 {t('ReservationEditForm.startEdit')}
               </Button>
             )}
-            {isEditing && (
+            {isAdmin && isEditing && (
               <Button
                 bsStyle="default"
                 disabled={isSaving}
@@ -239,7 +245,7 @@ class UnconnectedReservationEditForm extends Component {
                 {t('ReservationEditForm.cancelEdit')}
               </Button>
             )}
-            {isEditing && (
+            {isAdmin && isEditing && (
               <Button
                 bsStyle="primary"
                 disabled={isSaving}

--- a/app/shared/modals/reservation-info/ReservationInfoModal.js
+++ b/app/shared/modals/reservation-info/ReservationInfoModal.js
@@ -16,6 +16,7 @@ import InfoLabel from '../../../../src/common/label/InfoLabel';
 import { isStaffEvent, getEditReservationUrl } from '../../../utils/reservationUtils';
 import ReservationEditForm from './ReservationEditForm';
 import { hasProducts } from '../../../utils/resourceUtils';
+import { RESERVATION_STATE } from '../../../../src/constants/ReservationState';
 
 class ReservationInfoModal extends Component {
   constructor(props) {
@@ -79,8 +80,8 @@ class ReservationInfoModal extends Component {
     );
     const canModify = hasPermissionForResource(userUnitRole, resourcePermissionTypes.CAN_MODIFY_RESERVATIONS);
     const showCancelButton = reservationIsEditable && (
-      reservation.state === 'confirmed'
-      || (reservation.state === 'requested' && !isAdmin)
+      reservation.state === RESERVATION_STATE.CONFIRMED
+      || (reservation.state === RESERVATION_STATE.REQUESTED && !isAdmin)
     );
 
     const paymentLabel = constants.RESERVATION_PAYMENT_LABELS[reservation.state];

--- a/app/shared/modals/reservation-info/ReservationInfoModal.js
+++ b/app/shared/modals/reservation-info/ReservationInfoModal.js
@@ -13,7 +13,7 @@ import { hasPermissionForResource } from '../../../../src/domain/resource/permis
 import injectT from '../../../i18n/injectT';
 import ReservationCancelModal from '../reservation-cancel/ReservationCancelModalContainer';
 import InfoLabel from '../../../../src/common/label/InfoLabel';
-import { isStaffEvent } from '../../../utils/reservationUtils';
+import { isStaffEvent, getEditReservationUrl } from '../../../utils/reservationUtils';
 import ReservationEditForm from './ReservationEditForm';
 import { hasProducts } from '../../../utils/resourceUtils';
 
@@ -24,6 +24,7 @@ class ReservationInfoModal extends Component {
 
     this.handleEditFormSubmit = this.handleEditFormSubmit.bind(this);
     this.handleSaveCommentsClick = this.handleSaveCommentsClick.bind(this);
+    this.handleStartEditClick = this.handleStartEditClick.bind(this);
   }
 
   handleEditFormSubmit(values) {
@@ -37,6 +38,21 @@ class ReservationInfoModal extends Component {
     this.props.onSaveCommentsClick(comments);
   }
 
+  handleStartEditClick() {
+    const {
+      selectReservationToEdit, reservation, resource, history,
+    } = this.props;
+
+    if (!resource === null) {
+      return;
+    }
+
+    const nextUrl = getEditReservationUrl(reservation);
+
+    selectReservationToEdit({ reservation, slotSize: resource.slot_size });
+    history.push(nextUrl);
+  }
+
   render() {
     const {
       hideReservationInfoModal,
@@ -48,7 +64,6 @@ class ReservationInfoModal extends Component {
       onCancelEditClick,
       onConfirmClick,
       onDenyClick,
-      onStartEditClick,
       reservation,
       reservationIsEditable,
       resource,
@@ -57,16 +72,16 @@ class ReservationInfoModal extends Component {
     } = this.props;
 
     const disabled = isSaving || isEditing;
-    const showCancelButton = reservationIsEditable && (
-      reservation.state === 'confirmed'
-      || (reservation.state === 'requested' && !isAdmin)
-    );
     const canComment = hasPermissionForResource(userUnitRole, resourcePermissionTypes.CAN_COMMENT_RESERVATIONS);
     const canViewComment = hasPermissionForResource(
       userUnitRole,
       resourcePermissionTypes.CAN_ACCESS_RESERVATION_COMMENTS,
     );
     const canModify = hasPermissionForResource(userUnitRole, resourcePermissionTypes.CAN_MODIFY_RESERVATIONS);
+    const showCancelButton = reservationIsEditable && (
+      reservation.state === 'confirmed'
+      || (reservation.state === 'requested' && !isAdmin)
+    );
 
     const paymentLabel = constants.RESERVATION_PAYMENT_LABELS[reservation.state];
     const stateLabel = constants.RESERVATION_STATE_LABELS[reservation.state];
@@ -103,7 +118,7 @@ class ReservationInfoModal extends Component {
                 isEditing={isEditing}
                 isSaving={isSaving}
                 onCancelEditClick={onCancelEditClick}
-                onStartEditClick={onStartEditClick}
+                onStartEditClick={this.handleStartEditClick}
                 onSubmit={this.handleEditFormSubmit}
                 reservation={reservation}
                 reservationIsEditable={reservationIsEditable}
@@ -199,12 +214,13 @@ ReservationInfoModal.propTypes = {
   onDenyClick: PropTypes.func.isRequired,
   onEditFormSubmit: PropTypes.func.isRequired,
   onSaveCommentsClick: PropTypes.func.isRequired,
-  onStartEditClick: PropTypes.func.isRequired,
   reservation: PropTypes.object.isRequired,
   reservationIsEditable: PropTypes.bool.isRequired,
   resource: PropTypes.object.isRequired,
   show: PropTypes.bool.isRequired,
   t: PropTypes.func.isRequired,
+  selectReservationToEdit: PropTypes.func.isRequired,
+  history: PropTypes.object.isRequired,
 };
 
 export default injectT(ReservationInfoModal);

--- a/app/shared/modals/reservation-info/ReservationInfoModalContainer.js
+++ b/app/shared/modals/reservation-info/ReservationInfoModalContainer.js
@@ -1,5 +1,6 @@
 import { connect } from 'react-redux';
 import { reset as resetForm } from 'redux-form';
+import { withRouter } from 'react-router-dom';
 
 import FormTypes from '../../../constants/FormTypes';
 import {
@@ -14,6 +15,7 @@ import {
   openReservationCancelModal,
   selectReservationToCancel,
   startReservationEditInInfoModal,
+  selectReservationToEdit,
 } from '../../../actions/uiActions';
 import ReservationInfoModal from './ReservationInfoModal';
 import reservationInfoModalSelector from './reservationInfoModalSelector';
@@ -29,6 +31,7 @@ const actions = {
   putReservation,
   selectReservationToCancel,
   startReservationEditInInfoModal,
+  selectReservationToEdit,
 };
 
 export function mergeProps(stateProps, dispatchProps) {
@@ -50,8 +53,8 @@ export function mergeProps(stateProps, dispatchProps) {
     onSaveCommentsClick: (comments) => {
       dispatchProps.commentReservation(reservation, resource, comments);
     },
-    onStartEditClick: dispatchProps.startReservationEditInInfoModal,
+    selectReservationToEdit: dispatchProps.selectReservationToEdit,
   };
 }
 
-export default connect(reservationInfoModalSelector, actions, mergeProps)(ReservationInfoModal);
+export default connect(reservationInfoModalSelector, actions, mergeProps)(withRouter(ReservationInfoModal));

--- a/app/shared/modals/reservation-info/__tests__/ReservationInfoModal.test.js
+++ b/app/shared/modals/reservation-info/__tests__/ReservationInfoModal.test.js
@@ -42,11 +42,14 @@ describe('shared/modals/reservation-info/ReservationInfoModal', () => {
     onDenyClick: () => null,
     onEditFormSubmit: () => null,
     onSaveCommentsClick: () => null,
-    onStartEditClick: () => null,
     reservation: Immutable(reservation),
     reservationIsEditable: false,
     resource: Immutable(resource),
     show: true,
+    selectReservationToEdit: () => null,
+    history: {
+      push: jest.fn(),
+    },
   };
 
   function getWrapper(extraProps = {}) {

--- a/app/shared/reservation-controls/ReservationControls.js
+++ b/app/shared/reservation-controls/ReservationControls.js
@@ -88,33 +88,29 @@ class ReservationControls extends Component {
 
     switch (reservation.state) {
       case 'cancelled': {
-        return isAdmin
-          ? [buttons.info]
-          : [buttons.info];
+        return [];
       }
 
       case 'confirmed': {
         if (isAdmin) {
           return isStaff
-            ? [buttons.info, buttons.cancel, buttons.edit]
-            : [buttons.info, buttons.cancel];
+            ? [buttons.cancel, buttons.edit]
+            : [buttons.cancel];
         }
-        return [buttons.info, buttons.cancel];
+        return [buttons.cancel];
       }
 
       case 'denied': {
-        return isAdmin
-          ? [buttons.info]
-          : [buttons.info];
+        return [];
       }
 
       case 'requested': {
         if (isAdmin) {
           return isStaff
-            ? [buttons.info, buttons.confirm, buttons.deny, buttons.edit]
-            : [buttons.info, buttons.edit];
+            ? [buttons.confirm, buttons.deny, buttons.edit]
+            : [buttons.edit];
         }
-        return [buttons.info, buttons.edit, buttons.cancel];
+        return [buttons.edit, buttons.cancel];
       }
 
       default: {
@@ -125,14 +121,12 @@ class ReservationControls extends Component {
 
   render() {
     const { isAdmin, reservation } = this.props;
-
-    if (!reservation || moment() > moment(reservation.end)) {
-      return null;
-    }
+    const reservationIsInThePast = !reservation || moment() > moment(reservation.end);
 
     return (
       <div className="buttons">
-        {this.renderButtons(this.buttons, isAdmin, this.isStaff, reservation)}
+        <div className="app-ReservationControls__info-button-wrapper">{this.buttons.info}</div>
+        {!reservationIsInThePast && this.renderButtons(this.buttons, isAdmin, this.isStaff, reservation)}
       </div>
     );
   }

--- a/app/shared/reservation-controls/ReservationControls.js
+++ b/app/shared/reservation-controls/ReservationControls.js
@@ -5,6 +5,7 @@ import Button from 'react-bootstrap/lib/Button';
 
 import injectT from '../../i18n/injectT';
 import { hasProducts } from '../../utils/resourceUtils';
+import { getUnitRoleFromResource, getIsUnitStaff } from '../../../src/domain/resource/permissions/utils';
 
 class ReservationControls extends Component {
   get buttons() {
@@ -40,7 +41,7 @@ class ReservationControls extends Component {
         <Button
           bsStyle="primary"
           disabled={(
-            !this.props.isStaff
+            !this.isStaff
             && !this.props.isAdmin
             && hasProducts(this.props.resource))
             || this.props.resource !== null
@@ -61,6 +62,18 @@ class ReservationControls extends Component {
         </Button>
       ),
     };
+  }
+
+  get isStaff() {
+    const { resource } = this.props;
+
+    if (!resource) {
+      return false;
+    }
+
+    const isUnitStaff = getIsUnitStaff(getUnitRoleFromResource(resource));
+
+    return isUnitStaff;
   }
 
   renderButtons(buttons, isAdmin, isStaff, reservation) {
@@ -111,7 +124,7 @@ class ReservationControls extends Component {
   }
 
   render() {
-    const { isAdmin, isStaff, reservation } = this.props;
+    const { isAdmin, reservation } = this.props;
 
     if (!reservation || moment() > moment(reservation.end)) {
       return null;
@@ -119,7 +132,7 @@ class ReservationControls extends Component {
 
     return (
       <div className="buttons">
-        {this.renderButtons(this.buttons, isAdmin, isStaff, reservation)}
+        {this.renderButtons(this.buttons, isAdmin, this.isStaff, reservation)}
       </div>
     );
   }
@@ -127,7 +140,6 @@ class ReservationControls extends Component {
 
 ReservationControls.propTypes = {
   isAdmin: PropTypes.bool.isRequired,
-  isStaff: PropTypes.bool.isRequired,
   onCancelClick: PropTypes.func.isRequired,
   onConfirmClick: PropTypes.func.isRequired,
   onDenyClick: PropTypes.func.isRequired,

--- a/app/shared/reservation-controls/ReservationControls.js
+++ b/app/shared/reservation-controls/ReservationControls.js
@@ -71,9 +71,7 @@ class ReservationControls extends Component {
       return false;
     }
 
-    const isUnitStaff = getIsUnitStaff(getUnitRoleFromResource(resource));
-
-    return isUnitStaff;
+    return getIsUnitStaff(getUnitRoleFromResource(resource));
   }
 
   renderButtons(buttons, isAdmin, isStaff, reservation) {

--- a/app/shared/reservation-controls/ReservationControls.js
+++ b/app/shared/reservation-controls/ReservationControls.js
@@ -44,7 +44,7 @@ class ReservationControls extends Component {
             !this.isStaff
             && !this.props.isAdmin
             && hasProducts(this.props.resource))
-            || this.props.resource !== null
+            || this.props.resource === null
           }
           key="editButton"
           onClick={this.props.onEditClick}

--- a/app/shared/reservation-controls/ReservationControlsContainer.js
+++ b/app/shared/reservation-controls/ReservationControlsContainer.js
@@ -20,6 +20,7 @@ import {
 } from '../../actions/uiActions';
 import { getEditReservationUrl } from '../../utils/reservationUtils';
 import ReservationControls from './ReservationControls';
+import { RESERVATION_STATE } from '../../../src/constants/ReservationState';
 
 export class UnconnectedReservationControlsContainer extends Component {
   constructor(props) {
@@ -35,29 +36,38 @@ export class UnconnectedReservationControlsContainer extends Component {
   // redux state. The reservation prop this component receives may be in
   // snake_case. To ensure that we do not send a snake_cased object into
   // redux state, we are camelCasing the reservation object here.
-  get reservation() {
-    return camelCaseKeys(this.props.reservation);
+
+  // The redux state also expects a normalized reservation object. This
+  // is why we need to replace the inlined resource object wiht its id.
+  get reduxReservation() {
+    const reservation = this.props.reservation;
+    const resourceId = reservation.resource ? reservation.resource.id : undefined;
+
+    return camelCaseKeys({
+      ...reservation,
+      resource: resourceId,
+    });
   }
 
   handleCancelClick() {
     const { actions } = this.props;
-    actions.selectReservationToCancel(this.reservation);
+    actions.selectReservationToCancel(this.reduxReservation);
     actions.openReservationCancelModal();
   }
 
   handleConfirmClick() {
-    const { actions, isAdmin } = this.props;
+    const { actions, isAdmin, reservation } = this.props;
 
-    if (isAdmin && this.reservation.state === 'requested') {
-      actions.confirmPreliminaryReservation(this.reservation);
+    if (isAdmin && reservation.state === RESERVATION_STATE.REQUESTED) {
+      actions.confirmPreliminaryReservation(this.reduxReservation);
     }
   }
 
   handleDenyClick() {
-    const { actions, isAdmin } = this.props;
+    const { actions, isAdmin, reservation } = this.props;
 
-    if (isAdmin && this.reservation.state === 'requested') {
-      actions.denyPreliminaryReservation(this.reservation);
+    if (isAdmin && reservation.state === RESERVATION_STATE.REQUESTED) {
+      actions.denyPreliminaryReservation(this.reduxReservation);
     }
   }
 
@@ -70,16 +80,16 @@ export class UnconnectedReservationControlsContainer extends Component {
       return;
     }
 
-    const nextUrl = getEditReservationUrl(this.reservation);
+    const nextUrl = getEditReservationUrl(this.reduxReservation);
 
-    actions.selectReservationToEdit({ reservation: this.reservation, slotSize: resource.slot_size });
+    actions.selectReservationToEdit({ reservation: this.reduxReservation, slotSize: resource.slot_size });
     history.push(nextUrl);
   }
 
   handleInfoClick() {
     const { actions } = this.props;
 
-    actions.showReservationInfoModal(this.reservation);
+    actions.showReservationInfoModal(this.reduxReservation);
   }
 
   render() {

--- a/app/shared/reservation-controls/ReservationControlsContainer.js
+++ b/app/shared/reservation-controls/ReservationControlsContainer.js
@@ -3,6 +3,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 import { bindActionCreators } from 'redux';
+import camelCaseKeys from 'camelcase-keys';
 
 import {
   confirmPreliminaryReservation,
@@ -30,47 +31,55 @@ export class UnconnectedReservationControlsContainer extends Component {
     this.handleInfoClick = this.handleInfoClick.bind(this);
   }
 
+  // This component may send the reservation it receives as a prop into
+  // redux state. The reservation prop this component receives may be in
+  // snake_case. To ensure that we do not send a snake_cased object into
+  // redux state, we are camelCasing the reservation object here.
+  get reservation() {
+    return camelCaseKeys(this.props.reservation);
+  }
+
   handleCancelClick() {
-    const { actions, reservation } = this.props;
-    actions.selectReservationToCancel(reservation);
+    const { actions } = this.props;
+    actions.selectReservationToCancel(this.reservation);
     actions.openReservationCancelModal();
   }
 
   handleConfirmClick() {
-    const { actions, isAdmin, reservation } = this.props;
+    const { actions, isAdmin } = this.props;
 
-    if (isAdmin && reservation.state === 'requested') {
-      actions.confirmPreliminaryReservation(reservation);
+    if (isAdmin && this.reservation.state === 'requested') {
+      actions.confirmPreliminaryReservation(this.reservation);
     }
   }
 
   handleDenyClick() {
-    const { actions, isAdmin, reservation } = this.props;
+    const { actions, isAdmin } = this.props;
 
-    if (isAdmin && reservation.state === 'requested') {
-      actions.denyPreliminaryReservation(reservation);
+    if (isAdmin && this.reservation.state === 'requested') {
+      actions.denyPreliminaryReservation(this.reservation);
     }
   }
 
   handleEditClick() {
     const {
-      actions, reservation, resource, history,
+      actions, resource, history,
     } = this.props;
 
     if (!resource === null) {
       return;
     }
 
-    const nextUrl = getEditReservationUrl(reservation);
+    const nextUrl = getEditReservationUrl(this.reservation);
 
-    actions.selectReservationToEdit({ reservation, slotSize: resource.slot_size });
+    actions.selectReservationToEdit({ reservation: this.reservation, slotSize: resource.slot_size });
     history.push(nextUrl);
   }
 
   handleInfoClick() {
-    const { actions, reservation } = this.props;
+    const { actions } = this.props;
 
-    actions.showReservationInfoModal(reservation);
+    actions.showReservationInfoModal(this.reservation);
   }
 
   render() {

--- a/app/shared/reservation-controls/ReservationControlsContainer.js
+++ b/app/shared/reservation-controls/ReservationControlsContainer.js
@@ -76,7 +76,6 @@ export class UnconnectedReservationControlsContainer extends Component {
   render() {
     const {
       isAdmin,
-      isStaff,
       reservation,
       resource,
     } = this.props;
@@ -85,7 +84,6 @@ export class UnconnectedReservationControlsContainer extends Component {
     return (
       <ReservationControls
         isAdmin={isAdmin}
-        isStaff={isStaff}
         onCancelClick={this.handleCancelClick}
         onConfirmClick={this.handleConfirmClick}
         onDenyClick={this.handleDenyClick}
@@ -101,7 +99,6 @@ export class UnconnectedReservationControlsContainer extends Component {
 UnconnectedReservationControlsContainer.propTypes = {
   actions: PropTypes.object.isRequired,
   isAdmin: PropTypes.bool.isRequired,
-  isStaff: PropTypes.bool.isRequired,
   reservation: PropTypes.object.isRequired,
   resource: PropTypes.object,
   history: PropTypes.object.isRequired,

--- a/app/shared/reservation-controls/__tests__/ReservationControls.test.js
+++ b/app/shared/reservation-controls/__tests__/ReservationControls.test.js
@@ -5,6 +5,7 @@ import simple from 'simple-mock';
 import snakeCaseKeys from 'snakecase-keys';
 
 import Reservation from '../../../utils/fixtures/Reservation';
+import Resource from '../../../utils/fixtures/Resource';
 import { makeButtonTests, shallowWithIntl } from '../../../utils/testUtils';
 import ReservationControls from '../ReservationControls';
 
@@ -18,6 +19,7 @@ import ReservationControls from '../ReservationControls';
 // To be able to use the same test tooling, we are transforming the
 // camelCase mock objects into snake_case mock objects.
 const makeReservation = (...args) => snakeCaseKeys(Reservation.build(...args));
+const makeResource = (...args) => snakeCaseKeys(Resource.build(...args));
 
 describe('shared/reservation-controls/ReservationControls', () => {
   const onCancelClick = simple.stub();
@@ -27,15 +29,20 @@ describe('shared/reservation-controls/ReservationControls', () => {
   const onInfoClick = simple.stub();
 
   function getWrapper(reservation, isAdmin = false, isStaff = false) {
+    const defaultResource = makeResource();
+    const resource = {
+      ...defaultResource,
+      user_permissions: { ...defaultResource.user_permissions, is_admin: isStaff },
+    };
     const props = {
       isAdmin,
-      isStaff,
       onCancelClick,
       onConfirmClick,
       onDenyClick,
       onEditClick,
       onInfoClick,
       reservation: Immutable(reservation),
+      resource,
     };
     return shallowWithIntl(<ReservationControls {...props} />);
   }

--- a/app/shared/reservation-controls/__tests__/ReservationControls.test.js
+++ b/app/shared/reservation-controls/__tests__/ReservationControls.test.js
@@ -54,16 +54,20 @@ describe('shared/reservation-controls/ReservationControls', () => {
       const reservation = makeReservation({ needManualConfirmation: false, state: 'confirmed' });
       const buttons = getWrapper(reservation, isAdmin).find(Button);
 
-      test('renders two buttons', () => {
-        expect(buttons.length).toBe(2);
+      test('renders three buttons', () => {
+        expect(buttons.length).toBe(3);
       });
 
       describe('the first button', () => {
-        makeButtonTests(buttons.at(0), 'edit', 'ReservationControls.edit', onEditClick);
+        makeButtonTests(buttons.at(0), 'info', 'ReservationControls.info', onInfoClick);
       });
 
       describe('the second button', () => {
-        makeButtonTests(buttons.at(1), 'cancel', 'ReservationControls.cancel', onCancelClick);
+        makeButtonTests(buttons.at(1), 'edit', 'ReservationControls.edit', onEditClick);
+      });
+
+      describe('the third button', () => {
+        makeButtonTests(buttons.at(2), 'cancel', 'ReservationControls.cancel', onCancelClick);
       });
     });
 
@@ -189,16 +193,20 @@ describe('shared/reservation-controls/ReservationControls', () => {
       const reservation = makeReservation({ needManualConfirmation: false, state: 'confirmed' });
       const buttons = getWrapper(reservation, isAdmin).find(Button);
 
-      test('renders two buttons', () => {
-        expect(buttons.length).toBe(2);
+      test('renders three buttons', () => {
+        expect(buttons.length).toBe(3);
       });
 
       describe('the first button', () => {
-        makeButtonTests(buttons.at(0), 'edit', 'ReservationControls.edit', onEditClick);
+        makeButtonTests(buttons.at(0), 'info', 'ReservationControls.info', onInfoClick);
       });
 
       describe('the second button', () => {
-        makeButtonTests(buttons.at(1), 'cancel', 'ReservationControls.cancel', onCancelClick);
+        makeButtonTests(buttons.at(1), 'edit', 'ReservationControls.edit', onEditClick);
+      });
+
+      describe('the third button', () => {
+        makeButtonTests(buttons.at(2), 'cancel', 'ReservationControls.cancel', onCancelClick);
       });
     });
 

--- a/app/shared/reservation-controls/__tests__/ReservationControlsContainer.test.js
+++ b/app/shared/reservation-controls/__tests__/ReservationControlsContainer.test.js
@@ -2,6 +2,7 @@ import { shallow } from 'enzyme';
 import React from 'react';
 import simple from 'simple-mock';
 import snakeCaseKeys from 'snakecase-keys';
+import camelCaseKeys from 'camelcase-keys';
 
 import Reservation from '../../../utils/fixtures/Reservation';
 import Resource from '../../../utils/fixtures/Resource';
@@ -81,7 +82,7 @@ describe('shared/reservation-controls/ReservationControlsContainer', () => {
       'calls props.actions.selectReservationToCancel with this reservation',
       () => {
         expect(props.actions.selectReservationToCancel.callCount).toBe(1);
-        expect(props.actions.selectReservationToCancel.lastCall.args[0]).toEqual(props.reservation);
+        expect(props.actions.selectReservationToCancel.lastCall.args[0]).toEqual(camelCaseKeys(props.reservation));
       },
     );
 
@@ -107,7 +108,7 @@ describe('shared/reservation-controls/ReservationControlsContainer', () => {
       () => {
         expect(props.actions.selectReservationToEdit.callCount).toBe(1);
         expect(props.actions.selectReservationToEdit.lastCall.args[0]).toEqual({
-          reservation: props.reservation,
+          reservation: camelCaseKeys(props.reservation),
           slotSize: props.resource.slot_size,
         });
       },
@@ -131,7 +132,7 @@ describe('shared/reservation-controls/ReservationControlsContainer', () => {
       'calls the props.actions.showReservationInfoModal function with this reservation',
       () => {
         expect(props.actions.showReservationInfoModal.callCount).toBe(1);
-        expect(props.actions.showReservationInfoModal.lastCall.args[0]).toEqual(props.reservation);
+        expect(props.actions.showReservationInfoModal.lastCall.args[0]).toEqual(camelCaseKeys(props.reservation));
       },
     );
   });

--- a/app/shared/reservation-controls/__tests__/ReservationControlsContainer.test.js
+++ b/app/shared/reservation-controls/__tests__/ReservationControlsContainer.test.js
@@ -22,7 +22,7 @@ describe('shared/reservation-controls/ReservationControlsContainer', () => {
   // To be able to use the same test tooling, we are transforming the
   // camelCase mock objects into snake_case mock objects.
   const resource = snakeCaseKeys(Resource.build());
-  const reservation = snakeCaseKeys(Reservation.build({ resource: resource.id }));
+  const reservation = snakeCaseKeys(Reservation.build({ resource }));
 
   const history = {
     push: () => {},

--- a/app/shared/reservation-controls/__tests__/ReservationControlsContainer.test.js
+++ b/app/shared/reservation-controls/__tests__/ReservationControlsContainer.test.js
@@ -62,13 +62,13 @@ describe('shared/reservation-controls/ReservationControlsContainer', () => {
       const actualProps = container.find(ReservationControls).props();
 
       expect(actualProps.isAdmin).toBe(props.isAdmin);
-      expect(actualProps.isStaff).toBe(props.isStaff);
       expect(actualProps.onCancelClick).toBe(instance.handleCancelClick);
       expect(actualProps.onConfirmClick).toBe(instance.handleConfirmClick);
       expect(actualProps.onDenyClick).toBe(instance.handleDenyClick);
       expect(actualProps.onEditClick).toBe(instance.handleEditClick);
       expect(actualProps.onInfoClick).toBe(instance.handleInfoClick);
       expect(actualProps.reservation).toBe(props.reservation);
+      expect(actualProps.resource).toBe(props.resource);
     });
   });
 

--- a/app/shared/reservation-controls/__tests__/ReservationControlsContainer.test.js
+++ b/app/shared/reservation-controls/__tests__/ReservationControlsContainer.test.js
@@ -45,6 +45,7 @@ describe('shared/reservation-controls/ReservationControlsContainer', () => {
     reservation,
     resource,
   };
+  const transformedReservation = camelCaseKeys({ ...props.reservation, resource: props.reservation.resource.id });
 
   let container;
   let instance;
@@ -82,7 +83,8 @@ describe('shared/reservation-controls/ReservationControlsContainer', () => {
       'calls props.actions.selectReservationToCancel with this reservation',
       () => {
         expect(props.actions.selectReservationToCancel.callCount).toBe(1);
-        expect(props.actions.selectReservationToCancel.lastCall.args[0]).toEqual(camelCaseKeys(props.reservation));
+        expect(props.actions.selectReservationToCancel.lastCall.args[0])
+          .toEqual(transformedReservation);
       },
     );
 
@@ -108,7 +110,7 @@ describe('shared/reservation-controls/ReservationControlsContainer', () => {
       () => {
         expect(props.actions.selectReservationToEdit.callCount).toBe(1);
         expect(props.actions.selectReservationToEdit.lastCall.args[0]).toEqual({
-          reservation: camelCaseKeys(props.reservation),
+          reservation: transformedReservation,
           slotSize: props.resource.slot_size,
         });
       },
@@ -132,7 +134,8 @@ describe('shared/reservation-controls/ReservationControlsContainer', () => {
       'calls the props.actions.showReservationInfoModal function with this reservation',
       () => {
         expect(props.actions.showReservationInfoModal.callCount).toBe(1);
-        expect(props.actions.showReservationInfoModal.lastCall.args[0]).toEqual(camelCaseKeys(props.reservation));
+        expect(props.actions.showReservationInfoModal.lastCall.args[0])
+          .toEqual(transformedReservation);
       },
     );
   });

--- a/app/shared/reservation-controls/_reservation_controls.scss
+++ b/app/shared/reservation-controls/_reservation_controls.scss
@@ -1,0 +1,7 @@
+.app-ReservationControls {
+  &__info-button-wrapper {
+    &:not(:last-child) {
+      margin-bottom: 14px;
+    }
+  }
+}

--- a/app/state/reducers/ui/reservationsReducer.js
+++ b/app/state/reducers/ui/reservationsReducer.js
@@ -6,6 +6,7 @@ import moment from 'moment';
 import types from '../../../constants/ActionTypes';
 import ModalTypes from '../../../constants/ModalTypes';
 import { getTimeSlots } from '../../../utils/timeUtils';
+import { getReservationResourceId } from '../../../utils/reservationUtils';
 
 const initialState = Immutable({
   adminReservationFilters: {
@@ -24,11 +25,12 @@ function selectReservationToEdit(state, action) {
   const { slotSize, reservation } = action.payload;
   const slots = getTimeSlots(reservation.begin, reservation.end, slotSize);
   const firstSlot = first(slots);
+  const resourceId = getReservationResourceId(reservation.resource);
   const selected = [
     {
       begin: firstSlot.start,
       end: firstSlot.end,
-      resource: reservation.resource,
+      resource: resourceId,
     },
   ];
   if (slots.length > 1) {
@@ -36,12 +38,16 @@ function selectReservationToEdit(state, action) {
     selected.push({
       begin: lastSlot.start,
       end: lastSlot.end,
-      resource: reservation.resource,
+      resource: resourceId,
     });
   }
   return state.merge({
     selected,
-    toEdit: [reservation],
+    // Make sure that we do not pass an inlined resource. The UI will
+    // attempt to use the inlined incomplete resource, but it assumes it
+    // to be complete, which will result in errors when fields are
+    // missing unexpectedly.
+    toEdit: [{ ...reservation, resource: resourceId }],
   });
 }
 

--- a/app/state/reducers/ui/reservationsReducer.js
+++ b/app/state/reducers/ui/reservationsReducer.js
@@ -6,7 +6,6 @@ import moment from 'moment';
 import types from '../../../constants/ActionTypes';
 import ModalTypes from '../../../constants/ModalTypes';
 import { getTimeSlots } from '../../../utils/timeUtils';
-import { getReservationResourceId } from '../../../utils/reservationUtils';
 
 const initialState = Immutable({
   adminReservationFilters: {
@@ -25,12 +24,11 @@ function selectReservationToEdit(state, action) {
   const { slotSize, reservation } = action.payload;
   const slots = getTimeSlots(reservation.begin, reservation.end, slotSize);
   const firstSlot = first(slots);
-  const resourceId = getReservationResourceId(reservation.resource);
   const selected = [
     {
       begin: firstSlot.start,
       end: firstSlot.end,
-      resource: resourceId,
+      resource: reservation.resource,
     },
   ];
   if (slots.length > 1) {
@@ -38,16 +36,12 @@ function selectReservationToEdit(state, action) {
     selected.push({
       begin: lastSlot.start,
       end: lastSlot.end,
-      resource: resourceId,
+      resource: reservation.resource,
     });
   }
   return state.merge({
     selected,
-    // Make sure that we do not pass an inlined resource. The UI will
-    // attempt to use the inlined incomplete resource, but it assumes it
-    // to be complete, which will result in errors when fields are
-    // missing unexpectedly.
-    toEdit: [{ ...reservation, resource: resourceId }],
+    toEdit: [reservation],
   });
 }
 

--- a/app/state/selectors/authSelectors.js
+++ b/app/state/selectors/authSelectors.js
@@ -1,7 +1,6 @@
 import { createSelector } from 'reselect';
-import { get } from 'lodash';
 
-import { roleMapper } from '../../../src/domain/resource/permissions/utils';
+import { getUnitRoleFromResource, getIsUnitStaff } from '../../../src/domain/resource/permissions/utils';
 
 const userIdSelector = state => state.auth.userId;
 const usersSelector = state => state.data.users;
@@ -25,47 +24,12 @@ function isLoggedInSelector(state) {
 }
 
 /**
- * Check if the user has admin level permissions for the resource. I.e.
- * if they are a unit admin for the resource in question.
- */
-function createIsUnitAdminSelector(resourceSelector) {
-  return createSelector(
-    resourceSelector,
-    resource => Boolean(get(resource, 'userPermissions.isAdmin', false)),
-  );
-}
-
-/**
- * Check if the user has manager level permissions for the resource.
- * I.e. if they are a unit manager for the resource in question.
- */
-function createIsUnitManagerSelector(resourceSelector) {
-  return createSelector(
-    resourceSelector,
-    resource => Boolean(get(resource, 'userPermissions.isManager', false)),
-  );
-}
-
-/**
- * Check if the user has manager level permissions for the resource.
- * I.e. if they are a unit manager for the resource in question.
- */
-function createIsUnitViewerSelector(resourceSelector) {
-  return createSelector(
-    resourceSelector,
-    resource => Boolean(get(resource, 'userPermissions.isViewer', false)),
-  );
-}
-
-/**
- * Returns user's role in unit.
+ * Returns user's role in the unit the resource belongs to.
  */
 function createUserUnitRoleSelector(resourceSelector) {
   return createSelector(
-    createIsUnitAdminSelector(resourceSelector),
-    createIsUnitManagerSelector(resourceSelector),
-    createIsUnitViewerSelector(resourceSelector),
-    (isUnitAdmin, isUnitManager, isUnitViewer) => roleMapper(isUnitAdmin, isUnitManager, isUnitViewer),
+    resourceSelector,
+    resource => getUnitRoleFromResource(resource),
   );
 }
 
@@ -78,10 +42,8 @@ function createUserUnitRoleSelector(resourceSelector) {
  */
 function createIsStaffSelector(resourceSelector) {
   return createSelector(
-    createIsUnitAdminSelector(resourceSelector),
-    createIsUnitManagerSelector(resourceSelector),
-    createIsUnitViewerSelector(resourceSelector),
-    (isUnitAdmin, isUnitManager, isUnitViewer) => isUnitAdmin || isUnitManager || isUnitViewer,
+    createUserUnitRoleSelector(resourceSelector),
+    uiUnitRole => getIsUnitStaff(uiUnitRole),
   );
 }
 

--- a/app/utils/__tests__/reservationUtils.test.js
+++ b/app/utils/__tests__/reservationUtils.test.js
@@ -12,6 +12,7 @@ import {
   getMissingValues,
   getNextAvailableTime,
   getNextReservation,
+  getReservationResourceId,
   getReservationPrice,
 } from '../reservationUtils';
 
@@ -301,6 +302,22 @@ describe('Utils: reservationUtils', () => {
 
     test('returns the next reservation from a list of reservations', () => {
       expect(getNextReservation(unorderedReservations)).toEqual(nextReservation);
+    });
+  });
+
+  describe('getReservationResourceId', () => {
+    const resourceId = 'example-id';
+
+    test('should return id for inlined resource', () => {
+      expect(getReservationResourceId({ id: resourceId })).toEqual(resourceId);
+    });
+
+    test('should return id when resource field contains only the id', () => {
+      expect(getReservationResourceId(resourceId)).toEqual(resourceId);
+    });
+
+    test('should return undefined when resource is undefined', () => {
+      expect(getReservationResourceId()).toEqual(undefined);
     });
   });
 

--- a/app/utils/reservationUtils.js
+++ b/app/utils/reservationUtils.js
@@ -78,8 +78,11 @@ function getEditReservationUrl(reservation) {
   const date = moment(begin).format('YYYY-MM-DD');
   const beginStr = moment(begin).format('HH:mm');
   const endStr = moment(end).format('HH:mm');
+  // A reservation may be requested with the resource inlined. In these
+  // instances the id is contained in `resource.id` field.
+  const resourceId = resource && typeof resource === 'string' ? resource : resource.id;
 
-  return `/reservation?begin=${beginStr}&date=${date}&end=${endStr}&id=${id || ''}&resource=${resource}`;
+  return `/reservation?begin=${beginStr}&date=${date}&end=${endStr}&id=${id || ''}&resource=${resourceId}`;
 }
 /**
  * Get reservation price from resource. Get time conver

--- a/app/utils/reservationUtils.js
+++ b/app/utils/reservationUtils.js
@@ -71,6 +71,28 @@ function getNextReservation(reservations) {
   return find(orderedReservations, reservation => now < moment(reservation.begin));
 }
 
+// A reservation may be requested with the resource inlined. In these
+// instances the id is contained in `resource.id` field.
+function getReservationResourceId(resource) {
+  if (!resource) {
+    return undefined;
+  }
+
+  const resourceIsString = typeof resource === 'string';
+  const isResourceId = resourceIsString;
+  const isInlinedResource = !resourceIsString;
+
+  if (isResourceId) {
+    return resource;
+  }
+
+  if (isInlinedResource) {
+    return resource.id;
+  }
+
+  return undefined;
+}
+
 function getEditReservationUrl(reservation) {
   const {
     begin, end, id, resource,
@@ -78,9 +100,7 @@ function getEditReservationUrl(reservation) {
   const date = moment(begin).format('YYYY-MM-DD');
   const beginStr = moment(begin).format('HH:mm');
   const endStr = moment(end).format('HH:mm');
-  // A reservation may be requested with the resource inlined. In these
-  // instances the id is contained in `resource.id` field.
-  const resourceId = resource && typeof resource === 'string' ? resource : resource.id;
+  const resourceId = getReservationResourceId(resource);
 
   return `/reservation?begin=${beginStr}&date=${date}&end=${endStr}&id=${id || ''}&resource=${resourceId}`;
 }
@@ -131,6 +151,7 @@ export {
   getMissingValues,
   getNextAvailableTime,
   getNextReservation,
+  getReservationResourceId,
   getReservationPrice,
   getReservationPricePerPeriod,
 };

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@fullcalendar/timegrid": "^4.3.0",
     "axios": "^0.19.0",
     "bootstrap-sass": "3.4.1",
+    "camelcase-keys": "^6.1.2",
     "classnames": "2.2.5",
     "dotenv": "7.0.0",
     "dragscroll": "0.0.8",

--- a/src/domain/resource/permissions/constants.js
+++ b/src/domain/resource/permissions/constants.js
@@ -17,6 +17,12 @@ export const resourceRoles = Object.freeze({
   UNIT_VIEWER: 'UNIT_VIEWER',
 });
 
+export const UI_UNIT_STAFF_ROLES = [
+  resourceRoles.UNIT_ADMINISTRATOR,
+  resourceRoles.UNIT_MANAGER,
+  resourceRoles.UNIT_VIEWER,
+];
+
 const UNIT_ADMINISTRATOR_PERMISSIONS = [
   resourcePermissionTypes.CAN_MAKE_RESERVATIONS,
   resourcePermissionTypes.CAN_MODIFY_RESERVATIONS,

--- a/src/domain/resource/permissions/utils.js
+++ b/src/domain/resource/permissions/utils.js
@@ -1,23 +1,9 @@
 import difference from 'lodash/difference';
+import get from 'lodash/get';
 
-import { resourceRoles, resourcePermissionTypes, resourcePermissionsByRole } from './constants';
-
-// Returns the role with the most permissions or null.
-export function roleMapper(isAdmin, isManager, isViewer) {
-  if (isAdmin) {
-    return resourceRoles.UNIT_ADMINISTRATOR;
-  }
-
-  if (isManager) {
-    return resourceRoles.UNIT_MANAGER;
-  }
-
-  if (isViewer) {
-    return resourceRoles.UNIT_VIEWER;
-  }
-
-  return null;
-}
+import {
+  resourceRoles, resourcePermissionTypes, resourcePermissionsByRole, UI_UNIT_STAFF_ROLES,
+} from './constants';
 
 const permissionOptions = Object.values(resourcePermissionTypes);
 const allValuesInArray = (subset, superset) => difference(subset, superset).length === 0;
@@ -64,4 +50,36 @@ export function hasPermissionForResource(resourceRole, requiredPermissions) {
   }
 
   return rolePermissions.includes(requiredPermissions);
+}
+
+const getUserPermissions = resource => (
+  get(resource, 'user_permissions', false)
+  || get(resource, 'userPermissions', undefined)
+);
+
+// Returns the role with the most permissions or null.
+export function getUnitRoleFromResource(resource) {
+  const userPermissions = getUserPermissions(resource);
+
+  if (!userPermissions) {
+    return null;
+  }
+
+  if (userPermissions.is_admin || userPermissions.isAdmin) {
+    return resourceRoles.UNIT_ADMINISTRATOR;
+  }
+
+  if (userPermissions.is_manager || userPermissions.isManager) {
+    return resourceRoles.UNIT_MANAGER;
+  }
+
+  if (userPermissions.is_viewer || userPermissions.isViewer) {
+    return resourceRoles.UNIT_VIEWER;
+  }
+
+  return null;
+}
+
+export function getIsUnitStaff(unitRole) {
+  return UI_UNIT_STAFF_ROLES.includes(unitRole);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2360,6 +2360,15 @@ camelcase-keys@^2.0.0:
     camelcase "^2.0.0"
     map-obj "^1.0.0"
 
+camelcase-keys@^6.1.2:
+  version "6.1.2"
+  resolved "https://registry.yarnpkg.com/camelcase-keys/-/camelcase-keys-6.1.2.tgz#531a289aeea93249b63ec1249db9265f305041f7"
+  integrity sha512-QfFrU0CIw2oltVvpndW32kuJ/9YOJwUnmWrjlXt1nnJZHCaS9i6bfOpg9R4Lw8aZjStkJWM+jc0cdXjWBgVJSw==
+  dependencies:
+    camelcase "^5.3.1"
+    map-obj "^4.0.0"
+    quick-lru "^4.0.1"
+
 camelcase@5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.0.0.tgz#03295527d58bd3cd4aa75363f35b2e8d97be2f42"
@@ -7419,6 +7428,11 @@ querystring@0.2.0, querystring@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
   integrity sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=
+
+quick-lru@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-4.0.1.tgz#5b8878f113a58217848c6482026c73e1ba57727f"
+  integrity sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==
 
 raf@3.4.1, raf@^3.4.0:
   version "3.4.1"


### PR DESCRIPTION
This PR contains changes that were needed due to refactors in previous commits. It also contains the changes described in VAR-333, VAR-334 and VAR-335.

### VAR-333 | Always display info button

Previously the info button was only displayed for a subset of role and permission combinations. Now it should be displayed to everyone.

### VAR-334 | Send user to edit view instead of inline modal
Previously, when the user clicked on the edit button on `ReservationInfoModal`, an inline form would open within the modal. After these changes, the button will redirect the user into the reservation edit flow instead.

### VAR-335 | Ensure that a regular user does not see the commenting field in the `ReservationInfoModal`
This required no changes--this was already the case before.

### Allow owner or resource to access edit from resource info modal
I didn't create a subtask for this item, but it was discussed with the PO. A user with no roles, or the role os "reserver", should also be able to access the edit button within the `ReservationInfoModal`.

----

Other changes and fixes

**Fix incorrect isStaff status in ReservationControls**  
I tried to find out how this had worked previously. I didn't understand how `staffUnits` was passed to the list item component previously. With a search, I only found "staffUnits" from within the the reservation litem item component file.

Regardless, I refactored this logic to rely on the `resource` object. The permission is now checked deeper within the component hierarchy which isn't necessarily a positive, but at least it's easy for future devs to see how the logic works. I refactored the permission logic as well--this stuff was mostly implementation detail. I wanted to avoid creating utilities with similar purposes.

**Fix edit button being disabled when resource is found**  
This was a regression brought on by me in the last set of changes. The boolean logic here was the opposite to what it should have been.

**Avoid refetching hydrated resource**  
This is a small optimization. Previously resources would be fetched whenever they entered the view--even if they had been fetched once already.

**Fix reservation edit button leading nowhere**   
In the last batch of changes, the data model changed in a way that I did not expect. This resulted in the edit button creating a broken link. The reservation object may have a resource that's a string id referencing a resource, or then it may have an inlined resource object that contains a subset of the fields of the resource object. Previously the inlined case was not supported.

**Fix UI crashing on second step of reservation editing**  
An issue that has the same root cause then the last one: inlined resource object in the reservation object.

~~NOTE: I'll reconsider the two fixes above change after I've implemented all the changes requested in VAR-267. I think that it may be prudent to clean the inlined resource out of the reservation before sending it into the redux state instead of supporting both versions.~~
Done in "Clean reservation before sending into redux"

**Fix ReservationInfoForm not displaying all fields**  
This was an issue that had its roots in the combined use of `snake_case` and `camelCase` within the application. `ReservationInfoModal` assumes `camelCase`, but it received an object that used `snake_case`.

**Fix reservation state changes not giving feedback**  
This component was refactored to use its internal state for tracking
reservations. However, some components lower in the hierarchy operate
within the redux state.

For instance, a reservation may be canceled. In this instance, the user
action of cancelling the reservation changes the state of the
reservation within the redux state. There're no easy ways to hook into
the actions themselves.

With this change we are trying to reflect changes within the redux
state in the list of reservations managed within the user reservations
page. This way we are able to integrate these two states. Otherwise we
would need to create new versions of the components that are lower in
the hierarchy that allow hooking up to user actions.