### PR TITLE
VAR-330 | Show payment terms defined in resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   **CHANGELOG**
   - [#1118](https://github.com/City-of-Helsinki/varaamo/pull/1118) Added support for unit manager role; unit managers now have the same permissions as unit admins do
   - [#1125](https://github.com/City-of-Helsinki/varaamo/pull/1125) Added support for unit viewer role; unit viewers are allowed to complete the same actions as unit admins or unit managers in the UI, but Respa may block some requests for users with this role
+  - [#1127](https://github.com/City-of-Helsinki/varaamo/pull/1127) Added support for resource payment terms
 
 # 0.9.0
   **MINOR CHANGES**

--- a/app/pages/AppContainer.js
+++ b/app/pages/AppContainer.js
@@ -8,7 +8,7 @@ import { connect } from 'react-redux';
 import { createStructuredSelector } from 'reselect';
 import { withRouter } from 'react-router-dom';
 import { NotificationContainer } from 'react-notifications';
-import firebase from 'firebase';
+import firebase from 'firebase/app';
 
 import { isAdminSelector } from '../state/selectors/authSelectors';
 import { fetchUser } from '../actions/userActions';

--- a/app/pages/reservation/reservation-information/ReservationInformationForm.js
+++ b/app/pages/reservation/reservation-information/ReservationInformationForm.js
@@ -415,7 +415,7 @@ class UnconnectedReservationInformationForm extends Component {
             <React.Fragment>
               <h2 className="app-ReservationPage__title">{t('paymentTerms.title')}</h2>
               <div className="terms-box">
-                {t('paymentTerms.terms')}
+                <WrappedText text={resource.paymentTerms} />
               </div>
               {this.renderPaymentTermsField()}
             </React.Fragment>

--- a/app/pages/resource/resource-info/ResourceInfo.js
+++ b/app/pages/resource/resource-info/ResourceInfo.js
@@ -15,6 +15,7 @@ function ResourceInfo({
   isLoggedIn, resource, unit, t,
 }) {
   const serviceMapUrl = getServiceMapUrl(unit);
+  const hasProducts = resource.products && resource.products.length > 0;
 
   return (
     <section className="app-ResourceInfo">
@@ -35,6 +36,12 @@ function ResourceInfo({
       {resource.genericTerms && (
         <ResourcePanel defaultExpanded={false} header={t('ResourcePage.genericTermsHeader')}>
           <WrappedText text={resource.genericTerms} />
+        </ResourcePanel>
+      )}
+
+      {hasProducts && resource.paymentTerms && (
+        <ResourcePanel defaultExpanded={false} header={t('paymentTerms.title')}>
+          <WrappedText text={resource.paymentTerms} />
         </ResourcePanel>
       )}
 

--- a/app/pages/resource/resource-info/__tests__/ResourceInfo.test.js
+++ b/app/pages/resource/resource-info/__tests__/ResourceInfo.test.js
@@ -16,6 +16,7 @@ describe('pages/resource/resource-info/ResourceInfo', () => {
         description: 'Some description',
         genericTerms: 'some generic terms',
         specificTerms: 'some specific terms',
+        paymentTerms: 'some payment terms',
         maxPricePerHour: '30',
         peopleCapacity: '16',
         type: {
@@ -117,5 +118,23 @@ describe('pages/resource/resource-info/ResourceInfo', () => {
       .find('a');
 
     expect(link).toHaveLength(0);
+  });
+
+  test('renders payment terms when resource has products and a paymentTerms field', () => {
+    const resource = Resource.build({
+      description: 'Some description',
+      genericTerms: 'some generic terms',
+      specificTerms: 'some specific terms',
+      paymentTerms: 'some payment terms',
+      products: [{}],
+      maxPricePerHour: '30',
+      peopleCapacity: '16',
+      type: {
+        name: 'workplace',
+      },
+    });
+    const wrapper = getWrapper({ resource });
+
+    expect(wrapper.find({ header: 'paymentTerms.title' }).length).toEqual(1);
   });
 });

--- a/src/common/notificator/create/CreateNotifications.js
+++ b/src/common/notificator/create/CreateNotifications.js
@@ -1,6 +1,8 @@
 import React, { Component } from 'react';
 import { Grid } from 'react-bootstrap';
-import { auth, firestore } from 'firebase';
+import firebase from 'firebase/app';
+import 'firebase/auth';
+import 'firebase/firestore';
 import Loader from 'react-loader';
 import moment from 'moment';
 
@@ -39,11 +41,11 @@ class CreateNotifications extends Component {
   }
 
   componentDidMount() {
-    this.unsubscribeAuthListener = auth().onAuthStateChanged((user) => {
+    this.unsubscribeAuthListener = firebase.auth().onAuthStateChanged((user) => {
       this.setState({ superuser: !!user, loading: false });
     });
 
-    this.unsubscribeNotificationsListener = firestore().collection('notifications').onSnapshot((querySnap) => {
+    this.unsubscribeNotificationsListener = firebase.firestore().collection('notifications').onSnapshot((querySnap) => {
       const notifications = [];
       querySnap.forEach((doc) => {
         const notification = formatValuesForUse(doc.data());
@@ -61,7 +63,7 @@ class CreateNotifications extends Component {
 
   logIn = () => {
     const { email, password } = this.state;
-    auth().signInWithEmailAndPassword(email, password)
+    firebase.auth().signInWithEmailAndPassword(email, password)
     // eslint-disable-next-line no-console
       .catch(err => console.log('ERROR', err));
   };
@@ -111,7 +113,7 @@ class CreateNotifications extends Component {
     // Modify data so it will be saved correctly
     newNotification = formatValuesForDatabase(newNotification);
 
-    firestore().collection('notifications').add(newNotification)
+    firebase.firestore().collection('notifications').add(newNotification)
       .then(() => {
         // Reset values
         this.setState({
@@ -126,7 +128,7 @@ class CreateNotifications extends Component {
     let selectedNotification = JSON.parse(JSON.stringify(this.state.selectedNotification));
     selectedNotification = formatValuesForDatabase(selectedNotification);
 
-    firestore().collection('notifications').doc(selectedNotification.id).set(selectedNotification)
+    firebase.firestore().collection('notifications').doc(selectedNotification.id).set(selectedNotification)
       .then(() => {
         this.setState({
           selectedNotification: {},
@@ -138,7 +140,7 @@ class CreateNotifications extends Component {
 
   deleteNotification = () => {
     const { selectedNotification } = this.state;
-    firestore().collection('notifications').doc(selectedNotification.id).delete()
+    firebase.firestore().collection('notifications').doc(selectedNotification.id).delete()
       .then(() => {
         this.setState({
           selectedNotification: {},

--- a/src/common/notificator/create/form/CreateNotificationsForm.js
+++ b/src/common/notificator/create/form/CreateNotificationsForm.js
@@ -1,5 +1,6 @@
 import React, { useRef, useState } from 'react';
-import { auth } from 'firebase';
+import firebase from 'firebase/app';
+import 'firebase/auth';
 import Select from 'react-select';
 import { Row, Col } from 'react-bootstrap';
 import PropTypes from 'prop-types';
@@ -32,7 +33,7 @@ const CreateNotificationsForm = (props) => {
       {!isEditing && (
         <React.Fragment>
           <div className="button-row">
-            <button onClick={() => auth().signOut()} type="button">Sign out</button>
+            <button onClick={() => firebase.auth().signOut()} type="button">Sign out</button>
           </div>
           <h4>Create new notification</h4>
         </React.Fragment>

--- a/src/common/notificator/user/UserNotificator.js
+++ b/src/common/notificator/user/UserNotificator.js
@@ -3,7 +3,8 @@ import PropTypes from 'prop-types';
 import Grid from 'react-bootstrap/lib/Grid';
 import Row from 'react-bootstrap/lib/Row';
 import Col from 'react-bootstrap/lib/Col';
-import { firestore } from 'firebase';
+import firebase from 'firebase/app';
+import 'firebase/firestore';
 import ReactHtmlWrapper from 'react-html-parser';
 import classNames from 'classnames';
 import orderBy from 'lodash/orderBy';
@@ -20,7 +21,7 @@ class UserNotificator extends Component {
   };
 
   componentDidMount() {
-    this.unsubscribeNotificationListener = firestore()
+    this.unsubscribeNotificationListener = firebase.firestore()
       .collection('notifications')
       .where('active', '==', true)
       .onSnapshot(this.onNotificationSnapshot);

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@ import React from 'react';
 import { render } from 'react-dom';
 import { Provider } from 'react-intl-redux';
 import { BrowserRouter as Router } from 'react-router-dom';
-import firebase from 'firebase';
+import firebase from 'firebase/app';
 
 import '../app/assets/styles/main.scss';
 import '../app/assets/styles/customization/espoo/customization.scss';


### PR DESCRIPTION
In these changes I am adding payment terms into the resource information page. They are displayed if the resource has products (`products.length > 0`) and the `paymentTerms` field can be found from the resource object. The payment terms contain information about cancellation policies, so we want to give users easy access to them directly from the resource page.

In these changes I am also replacing hardcoded payment terms within the reservation edit form with the value we receive from the API.

The test version of Respa does not, at the time of writing this PR, yet support the `payment_terms` field, but the task tracking it is in the review phase.

----

**Import firebase as described in console warning**   
Currently firebase gives out warnings for imports that are only compatible with a development environment. These warnings are also logged in production. I changed the imports to respect the pattern that was described in the warning.