### PR TITLE
VAR-266 | Usability improvements into reservation management page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
   - Changed search results sort order to be announced when sort order is changed
   - Fixed illegible icon names in toggles being read out loud by screen readers
   - Fixed missing line breaks in generic terms and specific terms
+  - Changed approve and deny buttons to be hidden when irrelevant in the manage reservations view
+  - Fixed translation error in the English version that caused confusion when approving reservations
 
   **CHANGELOG**
   - [#1118](https://github.com/City-of-Helsinki/varaamo/pull/1118) Added support for unit manager role; unit managers now have the same permissions as unit admins do

--- a/app/i18n/messages/en.json
+++ b/app/i18n/messages/en.json
@@ -242,7 +242,7 @@
   "ReservationInfo.reservationEarliestDays": "Reservation must be made {time} in advance",
   "ReservationInfo.reservationLatestDays": "Reservations can be made {time} in advance, until {date}",
   "ReservationInfoModal.cancelButton": "Cancel event",
-  "ReservationInfoModal.confirmButton": "Confirm reservation",
+  "ReservationInfoModal.approveButton": "Approve reservation",
   "ReservationInfoModal.denyButton": "Deny reservation",
   "ReservationInfoModal.saveComment": "Save comment",
   "ReservationInfoModal.title": "Reservation information.",

--- a/app/i18n/messages/fi.json
+++ b/app/i18n/messages/fi.json
@@ -242,7 +242,7 @@
   "ReservationInfo.reservationEarliestDays": "Varattava vähintään {time} etukäteen",
   "ReservationInfo.reservationLatestDays": "Varauksen voi tehdä {time} etukäteen, {date} asti",
   "ReservationInfoModal.cancelButton": "Peru varaus",
-  "ReservationInfoModal.confirmButton": "Hyväksy varaus",
+  "ReservationInfoModal.approveButton": "Hyväksy varaus",
   "ReservationInfoModal.denyButton": "Hylkää varaus",
   "ReservationInfoModal.saveComment": "Tallenna kommentti",
   "ReservationInfoModal.title": "Varauksen tiedot",

--- a/app/i18n/messages/sv.json
+++ b/app/i18n/messages/sv.json
@@ -244,7 +244,7 @@
   "ReservationInfo.reservationEarliestDays": "Bokning måste göras {time} i förväg",
   "ReservationInfo.reservationLatestDays": "Bokningar kan göras {time} i förväg, fram tills {date}",
   "ReservationInfoModal.cancelButton": "Annulera evenmanget",
-  "ReservationInfoModal.confirmButton": "Bekräfta reserveringen",
+  "ReservationInfoModal.approveButton": "Bekräfta reserveringen",
   "ReservationInfoModal.denyButton": "Förneka reserveringen",
   "ReservationInfoModal.saveComment": "Spara kommentar",
   "ReservationInfoModal.title": "Uppgifter om bokningen",

--- a/app/shared/modals/reservation-info/ReservationInfoModal.js
+++ b/app/shared/modals/reservation-info/ReservationInfoModal.js
@@ -167,7 +167,7 @@ class ReservationInfoModal extends Component {
               disabled={disabled}
               onClick={onConfirmClick}
             >
-              {t('ReservationInfoModal.confirmButton')}
+              {t('ReservationInfoModal.approveButton')}
             </Button>
           )}
           {showCancelButton && (

--- a/src/constants/ReservationState.js
+++ b/src/constants/ReservationState.js
@@ -3,4 +3,5 @@ export const RESERVATION_STATE = {
   REQUESTED: 'requested',
   CANCELLED: 'cancelled',
   DENIED: 'denied',
+  WAITING_FOR_PAYMENT: 'waiting_for_payment',
 };

--- a/src/domain/reservation/manage/action/ManageReservationsDropdown.js
+++ b/src/domain/reservation/manage/action/ManageReservationsDropdown.js
@@ -12,6 +12,8 @@ const UntranslatedManageReservationsDropdown = ({
   userCanModify,
   userCanCancel,
 }) => {
+  const isRequestedReservation = reservation.state === RESERVATION_STATE.REQUESTED;
+
   return (
     <div className="app-ManageReservationDropdown">
       {userCanModify && (
@@ -23,16 +25,20 @@ const UntranslatedManageReservationsDropdown = ({
             {t('ManageReservationsList.actionLabel.information')}
           </MenuItem>
 
-          <MenuItem
-            onClick={() => onEditReservation(reservation, RESERVATION_STATE.CONFIRMED)}
-          >
-            {t('ManageReservationsList.actionLabel.approve')}
-          </MenuItem>
-          <MenuItem
-            onClick={() => onEditReservation(reservation, RESERVATION_STATE.DENIED)}
-          >
-            {t('ManageReservationsList.actionLabel.deny')}
-          </MenuItem>
+          {isRequestedReservation && (
+            <>
+              <MenuItem
+                onClick={() => onEditReservation(reservation, RESERVATION_STATE.CONFIRMED)}
+              >
+                {t('ManageReservationsList.actionLabel.approve')}
+              </MenuItem>
+              <MenuItem
+                onClick={() => onEditReservation(reservation, RESERVATION_STATE.DENIED)}
+              >
+                {t('ManageReservationsList.actionLabel.deny')}
+              </MenuItem>
+            </>
+          )}
 
           <MenuItem
             onClick={onEditClick}

--- a/src/domain/reservation/manage/action/__tests__/ManageReservationsDropdown.test.js
+++ b/src/domain/reservation/manage/action/__tests__/ManageReservationsDropdown.test.js
@@ -5,11 +5,48 @@ import { UntranslatedManageReservationsDropdown as ManageReservationsDropdown } 
 import { shallowWithIntl } from '../../../../../../app/utils/testUtils';
 import reservation from '../../../../../common/data/fixtures/reservation';
 
+const findButtonByLabel = (wrapper, label) => wrapper.find({ children: `ManageReservationsList.actionLabel.${label}` });
+
 describe('ManageReservationsDropdown', () => {
+  const defaultProps = {
+    reservation: reservation.build({ state: null }),
+    t: path => path,
+    userCanModify: true,
+  };
+  const getWrapper = props => shallowWithIntl(
+    <ManageReservationsDropdown {...defaultProps} {...props} />,
+  );
+
   test('renders correctly', () => {
-    const wrapper = shallowWithIntl(
-      <ManageReservationsDropdown reservation={reservation.build()} t={() => 'foo'} userCanModify />,
-    );
-    expect(toJSON(wrapper)).toMatchSnapshot();
+    expect(toJSON(getWrapper())).toMatchSnapshot();
+  });
+
+  test('show information, edit and cancel buttons', () => {
+    const wrapper = getWrapper();
+
+    expect(findButtonByLabel(wrapper, 'information').length).toEqual(1);
+    expect(findButtonByLabel(wrapper, 'edit').length).toEqual(1);
+  });
+
+  test('do not show approve, deny and cancel buttons', () => {
+    const wrapper = getWrapper();
+
+    expect(findButtonByLabel(wrapper, 'approve').length).toEqual(0);
+    expect(findButtonByLabel(wrapper, 'deny').length).toEqual(0);
+    expect(findButtonByLabel(wrapper, 'cancel').length).toEqual(0);
+  });
+
+  describe('when state is requested', () => {
+    const getWrapperInRequestedState = props => getWrapper({
+      reservation: { ...defaultProps.reservation, state: 'requested' },
+      ...props,
+    });
+
+    test('show approve and deny button', () => {
+      const wrapper = getWrapperInRequestedState();
+
+      expect(findButtonByLabel(wrapper, 'approve').length).toEqual(1);
+      expect(findButtonByLabel(wrapper, 'deny').length).toEqual(1);
+    });
   });
 });

--- a/src/domain/reservation/manage/action/__tests__/ManageReservationsDropdown.test.js
+++ b/src/domain/reservation/manage/action/__tests__/ManageReservationsDropdown.test.js
@@ -21,7 +21,7 @@ describe('ManageReservationsDropdown', () => {
     expect(toJSON(getWrapper())).toMatchSnapshot();
   });
 
-  test('show information, edit and cancel buttons', () => {
+  test('show information and edit buttons', () => {
     const wrapper = getWrapper();
 
     expect(findButtonByLabel(wrapper, 'information').length).toEqual(1);
@@ -47,6 +47,14 @@ describe('ManageReservationsDropdown', () => {
 
       expect(findButtonByLabel(wrapper, 'approve').length).toEqual(1);
       expect(findButtonByLabel(wrapper, 'deny').length).toEqual(1);
+    });
+  });
+
+  describe('when props.userCanCancel is true', () => {
+    test('show cancel button', () => {
+      const wrapper = getWrapper({ userCanCancel: true });
+
+      expect(findButtonByLabel(wrapper, 'cancel').length).toEqual(1);
     });
   });
 });

--- a/src/domain/reservation/manage/action/__tests__/__snapshots__/ManageReservationsDropdown.test.js.snap
+++ b/src/domain/reservation/manage/action/__tests__/__snapshots__/ManageReservationsDropdown.test.js.snap
@@ -6,7 +6,7 @@ exports[`ManageReservationsDropdown renders correctly 1`] = `
 >
   <DropdownButton
     id="app-ManageReservationDropdown"
-    title="foo"
+    title="ManageReservationsList.actionsHeader"
   >
     <MenuItem
       bsClass="dropdown"
@@ -14,25 +14,7 @@ exports[`ManageReservationsDropdown renders correctly 1`] = `
       divider={false}
       header={false}
     >
-      foo
-    </MenuItem>
-    <MenuItem
-      bsClass="dropdown"
-      disabled={false}
-      divider={false}
-      header={false}
-      onClick={[Function]}
-    >
-      foo
-    </MenuItem>
-    <MenuItem
-      bsClass="dropdown"
-      disabled={false}
-      divider={false}
-      header={false}
-      onClick={[Function]}
-    >
-      foo
+      ManageReservationsList.actionLabel.information
     </MenuItem>
     <MenuItem
       bsClass="dropdown"
@@ -40,7 +22,7 @@ exports[`ManageReservationsDropdown renders correctly 1`] = `
       divider={false}
       header={false}
     >
-      foo
+      ManageReservationsList.actionLabel.edit
     </MenuItem>
   </DropdownButton>
 </div>

--- a/src/domain/reservation/modal/ReservationInformationModal.js
+++ b/src/domain/reservation/modal/ReservationInformationModal.js
@@ -133,7 +133,7 @@ const ReservationInformationModal = ({
           bsStyle="success"
           onClick={() => onEditReservation(normalizedReservation, RESERVATION_STATE.CONFIRMED)}
         >
-          {t('ReservationInfoModal.confirmButton')}
+          {t('ReservationInfoModal.approveButton')}
         </Button>
       </Modal.Footer>
       <ConnectedReservationCancelModal

--- a/src/domain/reservation/modal/ReservationInformationModal.js
+++ b/src/domain/reservation/modal/ReservationInformationModal.js
@@ -46,6 +46,7 @@ const ReservationInformationModal = ({
   const payerFirstName = get(reservation, 'billing_first_name', '');
   const payerLastName = get(reservation, 'billing_last_name', '');
   const payerEmail = get(reservation, 'billing_email_address', '');
+  const isRequestedReservation = reservation.state === RESERVATION_STATE.REQUESTED;
 
   return (
     <Modal
@@ -122,19 +123,23 @@ const ReservationInformationModal = ({
           {t('ReservationInfoModal.cancelButton')}
         </Button>
 
-        <Button
-          bsStyle="danger"
-          onClick={() => onEditReservation(normalizedReservation, RESERVATION_STATE.DENIED)}
-        >
-          {t('ReservationInfoModal.denyButton')}
-        </Button>
+        {isRequestedReservation && (
+          <>
+            <Button
+              bsStyle="danger"
+              onClick={() => onEditReservation(normalizedReservation, RESERVATION_STATE.DENIED)}
+            >
+              {t('ReservationInfoModal.denyButton')}
+            </Button>
 
-        <Button
-          bsStyle="success"
-          onClick={() => onEditReservation(normalizedReservation, RESERVATION_STATE.CONFIRMED)}
-        >
-          {t('ReservationInfoModal.approveButton')}
-        </Button>
+            <Button
+              bsStyle="success"
+              onClick={() => onEditReservation(normalizedReservation, RESERVATION_STATE.CONFIRMED)}
+            >
+              {t('ReservationInfoModal.approveButton')}
+            </Button>
+          </>
+        )}
       </Modal.Footer>
       <ConnectedReservationCancelModal
         onEditReservation={onEditReservation}

--- a/src/domain/reservation/modal/__tests__/ReservationInfomationModal.test.js
+++ b/src/domain/reservation/modal/__tests__/ReservationInfomationModal.test.js
@@ -5,21 +5,50 @@ import { shallowWithIntl, globalDateMock } from '../../../../../app/utils/testUt
 import ReservationInformationModal from '../ReservationInformationModal';
 import reservation from '../../../../common/data/fixtures/reservation';
 
+const findButtonByLabel = (wrapper, label) => wrapper.find({ children: `ReservationInfoModal.${label}` });
+
 describe('ReservationInformationModal', () => {
+  const mockReservation = reservation.build({
+    begin: '2019-08-14T14:00:00+03:00',
+    end: '2019-08-14T15:00:00+03:00',
+    state: 'confirmed',
+  });
+  const defaultProps = {
+    reservation: mockReservation,
+    onHide: jest.fn(),
+    onSaveComment: jest.fn(),
+    isOpen: true,
+    onEditReservation: jest.fn(),
+    t: path => path,
+  };
+  const getWrapper = props => shallowWithIntl(
+    <ReservationInformationModal {...defaultProps} {...props} />,
+  );
+
   test('renders correctly', () => {
     globalDateMock();
-    const mockReservation = reservation.build({ begin: '2019-08-14T14:00:00+03:00', end: '2019-08-14T15:00:00+03:00' });
-    const props = {
-      reservation: mockReservation,
-      onHide: jest.fn(),
-      onSaveComment: jest.fn(),
-      isOpen: true,
-      onEditReservation: jest.fn(),
-    };
-    const wrapper = shallowWithIntl(
-      <ReservationInformationModal {...props} />,
-    );
 
-    expect(toJSON(wrapper)).toMatchSnapshot();
+    expect(toJSON(getWrapper())).toMatchSnapshot();
+  });
+
+  test('does not render deny and approve buttons by default', () => {
+    const wrapper = getWrapper();
+
+    expect(findButtonByLabel(wrapper, 'approveButton').length).toEqual(0);
+    expect(findButtonByLabel(wrapper, 'denyButton').length).toEqual(0);
+  });
+
+  describe('when state is requested', () => {
+    const getWrapperInRequestedState = props => getWrapper({
+      reservation: { ...defaultProps.reservation, state: 'requested' },
+      ...props,
+    });
+
+    test('render deny and approve buttons', () => {
+      const wrapper = getWrapperInRequestedState();
+
+      expect(findButtonByLabel(wrapper, 'approveButton').length).toEqual(1);
+      expect(findButtonByLabel(wrapper, 'denyButton').length).toEqual(1);
+    });
   });
 });

--- a/src/domain/reservation/modal/__tests__/__snapshots__/ReservationInfomationModal.test.js.snap
+++ b/src/domain/reservation/modal/__tests__/__snapshots__/ReservationInfomationModal.test.js.snap
@@ -292,7 +292,7 @@ exports[`ReservationInformationModal renders correctly 1`] = `
       disabled={false}
       onClick={[Function]}
     >
-      ReservationInfoModal.confirmButton
+      ReservationInfoModal.approveButton
     </Button>
   </ModalFooter>
   <Connect(InjectT(UnconnectedReservationCancelModal))

--- a/src/domain/reservation/modal/__tests__/__snapshots__/ReservationInfomationModal.test.js.snap
+++ b/src/domain/reservation/modal/__tests__/__snapshots__/ReservationInfomationModal.test.js.snap
@@ -56,7 +56,7 @@ exports[`ReservationInformationModal renders correctly 1`] = `
           "its_own": false,
           "resource": 1,
           "staff_event": false,
-          "state": "requested",
+          "state": "confirmed",
           "url": "https://respa.koe.hel.ninja/v1/reservation/192388/",
           "user": Object {},
           "user_permissions": null,
@@ -194,7 +194,7 @@ exports[`ReservationInformationModal renders correctly 1`] = `
             "its_own": false,
             "resource": 1,
             "staff_event": false,
-            "state": "requested",
+            "state": "confirmed",
             "url": "https://respa.koe.hel.ninja/v1/reservation/192388/",
             "user": Object {},
             "user_permissions": null,
@@ -274,26 +274,6 @@ exports[`ReservationInformationModal renders correctly 1`] = `
     >
       ReservationInfoModal.cancelButton
     </Button>
-    <Button
-      active={false}
-      block={false}
-      bsClass="btn"
-      bsStyle="danger"
-      disabled={false}
-      onClick={[Function]}
-    >
-      ReservationInfoModal.denyButton
-    </Button>
-    <Button
-      active={false}
-      block={false}
-      bsClass="btn"
-      bsStyle="success"
-      disabled={false}
-      onClick={[Function]}
-    >
-      ReservationInfoModal.approveButton
-    </Button>
   </ModalFooter>
   <Connect(InjectT(UnconnectedReservationCancelModal))
     onEditReservation={[MockFunction]}
@@ -310,7 +290,7 @@ exports[`ReservationInformationModal renders correctly 1`] = `
         "its_own": false,
         "resource": 1,
         "staff_event": false,
-        "state": "requested",
+        "state": "confirmed",
         "url": "https://respa.koe.hel.ninja/v1/reservation/192388/",
         "user": Object {},
         "user_permissions": null,


### PR DESCRIPTION
After these changes, approve and deny buttons should be hidden when the `reservation`'s state is not `requested` in these cases:  
1) Dropdown menu in the list of reservations
2) Information modal that the user can access by opening the dropdown and selecting "Information"

The English version of the application should also now use "Approve" instead of "Confirm" when it comes to the forementioned buttons and locations.