### PR TITLE
VAR-339 | Fix upcoming tab crashing for some users

### DIFF
--- a/app/pages/user-reservations/reservation-list/ReservationListItem.js
+++ b/app/pages/user-reservations/reservation-list/ReservationListItem.js
@@ -72,7 +72,7 @@ class ReservationListItem extends Component {
                 <div className="reservation-state-label-container">
                   {hasCompleteResource && (
                     hasProducts(completeResource)
-                    && !completeResource.data.staff_event
+                    && !completeResource.staff_event
                     && price > 0 && (
                       <InfoLabel labelStyle={paymentLabel.labelBsStyle} labelText={t(paymentLabel.labelTextId)} />
                     )


### PR DESCRIPTION
During a refactor, I had made an error when accessing this object. The `completeResource` object is the data field. Asking for `data.data` will yield undefined and results in an error.

Previously, the view would crash when the user had reservations to resources with products.