### PR TITLE
VAR-337 | Fix missing results in search results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   - Fixed missing line breaks in generic terms and specific terms
   - Changed approve and deny buttons to be hidden when irrelevant in the manage reservations view
   - Fixed translation error in the English version that caused confusion when approving reservations
+  - Fixed missing results in search results
 
   **CHANGELOG**
   - [#1118](https://github.com/City-of-Helsinki/varaamo/pull/1118) Added support for unit manager role; unit managers now have the same permissions as unit admins do

--- a/src/domain/search/results/SearchListResults.js
+++ b/src/domain/search/results/SearchListResults.js
@@ -102,7 +102,7 @@ class SearchListResults extends React.Component {
             search: searchUtils.getSearchFromFilters({ ...filters, page: newPage }),
           })}
           page={filters && filters.page ? Number(filters.page) : 1}
-          pages={Math.round(totalCount / constants.SEARCH_PAGE_SIZE)}
+          pages={Math.ceil(totalCount / constants.SEARCH_PAGE_SIZE)}
         />
       </div>
     );

--- a/src/domain/search/results/__tests__/SearchListResults.test.js
+++ b/src/domain/search/results/__tests__/SearchListResults.test.js
@@ -7,8 +7,10 @@ import resource from '../../../../common/data/fixtures/resource';
 import unit from '../../../../common/data/fixtures/unit';
 import { globalDateMock } from '../../../../../app/utils/testUtils';
 import SearchSort from '../../sort/SearchSort';
+import Pagination from '../../../../common/pagination/Pagination';
 
 const findSearchSort = wrapper => wrapper.find(SearchSort);
+const findPagination = wrapper => wrapper.find(Pagination);
 
 describe('SearchListResults', () => {
   globalDateMock();
@@ -37,5 +39,11 @@ describe('SearchListResults', () => {
     const wrapper = getWrapper({ location });
 
     expect(findSearchSort(wrapper).prop('value')).toEqual(orderBy);
+  });
+
+  test('correctly passes pages to Pagination', () => {
+    const wrapper = getWrapper({ totalCount: 67 });
+
+    expect(findPagination(wrapper).prop('pages')).toEqual(3);
   });
 });


### PR DESCRIPTION
When counting pages, we want to all pages that have at least some
content. With Math.round, values liek 2.4 would be rounded to 2 and the
0.4 pages worth of resources would be hidden from users.