### PR TITLE
VAR-340 | Fix calendar failing to render opening time of 23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
   - Fixed missing results in search results
   - Fixed scrollbar flickering in reservation calendar when business hours were of short duration
   - Fixed premise dropdown returning empty labels
+  - Fixed resource calendar not rendering anything when closing time was 23:00 or later
 
   **CHANGELOG**
   - [#1118](https://github.com/City-of-Helsinki/varaamo/pull/1118) Added support for unit manager role; unit managers now have the same permissions as unit admins do

--- a/src/common/calendar/_timePickerCalendar.scss
+++ b/src/common/calendar/_timePickerCalendar.scss
@@ -37,6 +37,18 @@
     font-size: 1.25rem;
   }
 
+  & .fc-time-grid {
+    /* Add a fixed margin to the bottom of the calendar which allows
+       events to overflow the container by the margin's amount without
+       causing a scroll bar to appear. Previously the drag indicator on
+       an event could cause an overflow, whose amount would depend on
+       the hover state of the event. The change in the overflow amount 
+       would cause the position of the event to flicker when the event
+       spanned the final hour visible in the calendar in the week view.
+      */
+    margin-bottom: 12px;
+  }
+
   .fc-event,
   .fc-event:hover {
     font-size: 1.75rem;
@@ -45,8 +57,6 @@
     border: 1px solid $hel-coat;
     color: $hel-coat;
   }
-
-
 
   .fc-event.fc-selected::after {
     background-color: #bddbf0;

--- a/src/domain/resource/__tests__/utils.test.js
+++ b/src/domain/resource/__tests__/utils.test.js
@@ -255,16 +255,31 @@ describe('domain resource utility function', () => {
     expect(minTimeWeek).toBe('06:00:00');
   });
 
-  test('getFullCalendarMaxTime', () => {
-    const resource = resourceFixture.build({
-      opening_hours: OPENING_HOURS,
+  describe('getFullCalendarMaxTime', () => {
+    test('acts properly with basic cases', () => {
+      const resource = resourceFixture.build({
+        opening_hours: OPENING_HOURS,
+      });
+
+      const minTimeDay = resourceUtils.getFullCalendarMaxTime(resource, DATE, 'timeGridDay', 3);
+      expect(minTimeDay).toBe('23:00:00');
+
+      const minTimeWeek = resourceUtils.getFullCalendarMaxTime(resource, DATE, 'timeGridWeek', 2);
+      expect(minTimeWeek).toBe('22:00:00');
     });
 
-    const minTimeDay = resourceUtils.getFullCalendarMaxTime(resource, DATE, 'timeGridDay', 3);
-    expect(minTimeDay).toBe('23:00:00');
+    test('does not overflow date when opening hours end at 23', () => {
+      const resource = resourceFixture.build({
+        opening_hours: [{
+          date: DATE,
+          opens: `${DATE}T08:00:00+03:00`,
+          closes: `${DATE}T23:00:00+03:00`,
+        }],
+      });
+      const maxTimeWeek = resourceUtils.getFullCalendarMaxTime(resource, DATE, 'timeGridWeek', 2);
 
-    const minTimeWeek = resourceUtils.getFullCalendarMaxTime(resource, DATE, 'timeGridWeek', 2);
-    expect(minTimeWeek).toBe('22:00:00');
+      expect(maxTimeWeek).toBe('23:00:00');
+    });
   });
 
   test('getFullCalendarBusinessHoursForDate', () => {


### PR DESCRIPTION
Previously the getFullCalendarMaxTime function would return 00:00:00
when a resources closing time was 23:00:00. This caused the max time to
be smaller than the end time, which in turn caused the calendar to not
render any timeslots.