### PR TITLE
VAR-341 | Fix scroll bar flickering on short business hours

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   - Fixed translation error in the English version that caused confusion when approving reservations
   - Fixed resource page sometimes being scrolled to its end after it had been opened
   - Fixed missing results in search results
+  - Fixed scrollbar flickering in reservation calendar when business hours were of short duration
 
   **CHANGELOG**
   - [#1118](https://github.com/City-of-Helsinki/varaamo/pull/1118) Added support for unit manager role; unit managers now have the same permissions as unit admins do

--- a/src/common/calendar/_timePickerCalendar.scss
+++ b/src/common/calendar/_timePickerCalendar.scss
@@ -65,7 +65,7 @@
 
       &::before {
         width: 80px;
-        height: 80px;
+        max-height: 80px;
         top: 0;
         left: 0;
         margin-left: -40px;


### PR DESCRIPTION
Previously, when the user hovered on a reservation in the calendar of a
resource that had short business hours, a scroll bar was removed from
the calendar. This caused the width of the calendar to change. This
change would for instance move the remove button for a reservation
enough where a user might have missed their target.

The scroll bar didn't have a purpose to begin with and was caused by
our application styles overflowing a container. As a fix I changed the
rule that caused the unused scroll bar to remove it entirely.