### PR TITLE
VAR-227 | Fix empty values in premise dropdown for English locale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   - Fixed resource page sometimes being scrolled to its end after it had been opened
   - Fixed missing results in search results
   - Fixed scrollbar flickering in reservation calendar when business hours were of short duration
+  - Fixed premise dropdown returning empty labels
 
   **CHANGELOG**
   - [#1118](https://github.com/City-of-Helsinki/varaamo/pull/1118) Added support for unit manager role; unit managers now have the same permissions as unit admins do

--- a/src/domain/search/__tests__/utils.test.js
+++ b/src/domain/search/__tests__/utils.test.js
@@ -22,22 +22,33 @@ describe('src/domain/search/utils.js', () => {
     expect(search).toBe(expectedSearch);
   });
 
-  test('getUnitOptions', () => {
-    const units = [
-      { id: 1, name: { fi: 'B' } },
-      { id: 2, name: { fi: 'C' } },
-      { id: 3, name: { fi: 'A' } },
-    ];
+  describe('getUnitOptions', () => {
+    test('behave well with common cases', () => {
+      const units = [
+        { id: 1, name: { fi: 'B' } },
+        { id: 2, name: { fi: 'C' } },
+        { id: 3, name: { fi: 'A' } },
+      ];
 
-    const options = searchUtils.getUnitOptions(units, 'fi');
+      const options = searchUtils.getUnitOptions(units, 'fi');
 
-    expect(Array.isArray(options)).toBe(true);
-    expect(options.length).toBe(3);
-    expect(Object.keys(options[0])).toContainEqual('value');
-    expect(Object.keys(options[0])).toContainEqual('label');
-    expect(options[0]).toMatchObject({ value: 3 });
-    expect(options[1]).toMatchObject({ value: 1 });
-    expect(options[2]).toMatchObject({ value: 2 });
+      expect(Array.isArray(options)).toBe(true);
+      expect(options.length).toBe(3);
+      expect(Object.keys(options[0])).toContainEqual('value');
+      expect(Object.keys(options[0])).toContainEqual('label');
+      expect(options[0]).toMatchObject({ value: 3 });
+      expect(options[1]).toMatchObject({ value: 1 });
+      expect(options[2]).toMatchObject({ value: 2 });
+    });
+
+    test('returns label in Finnish if current locale doesn\'t exist', () => {
+      const units = [
+        { id: 1, name: { fi: 'B' } },
+      ];
+      const [option] = searchUtils.getUnitOptions(units, 'en');
+
+      expect(option.label).toEqual(units[0].name.fi);
+    });
   });
 
   test('getPurposeOptions', () => {

--- a/src/domain/search/utils.js
+++ b/src/domain/search/utils.js
@@ -42,10 +42,15 @@ export const getApiParamsFromFilters = (filters) => {
 };
 
 export const getUnitOptions = (units, locale) => {
-  const options = units.map(unit => ({
-    value: unit.id,
-    label: get(unit, `name[${locale}]`, ''),
-  }));
+  const options = units.map((unit) => {
+    const finnishName = get(unit, 'name.fi');
+
+    return ({
+      value: unit.id,
+      // Use name in Finnish in case it doesn't exist for current locale
+      label: get(unit, `name[${locale}]`, finnishName),
+    });
+  });
 
   return sortBy(options, 'label');
 };


### PR DESCRIPTION
Some premises do not have their names defined in English (or Swedish). In these cases we use the the Finnish name as a fallback.