### PR TITLE
VAR-356 | Allow uneven minute values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
   - [#1127](https://github.com/City-of-Helsinki/varaamo/pull/1127) Added support for resource payment terms
   - [#1126](https://github.com/City-of-Helsinki/varaamo/pull/1126) Fixed my reservation crashing on some devices and improved performance
   - [#1131](https://github.com/City-of-Helsinki/varaamo/pull/1131) Changed labelling for event name field to distinct it as public instead of private
+  - [#1137](https://github.com/City-of-Helsinki/varaamo/pull/1137) Added support for daily, weekly and fixed resource prices
+  - [#1138](https://github.com/City-of-Helsinki/varaamo/pull/1138) Added support for longer slot sizes
 
 # 0.9.0
   **MINOR CHANGES**

--- a/docs/DEV_DIARY.md
+++ b/docs/DEV_DIARY.md
@@ -1,0 +1,33 @@
+# Dev Diary
+
+_The dev diary is a document that contains insights from individual developers who engage in this project. It's unofficial documentation._
+
+## Spring 2020
+
+### Notes about current architecture
+
+The architecture of this application is in a flux state (but only figuratively). From the root of the application you will find two folders: `app` and `src`. Both of these contain code that is in active use.
+
+As far as I understand, `src` is the direction the project was taken towards--so in a sense it's the more current style. The `app` folder was likely the architecture that was preferred originally. The explicit reasons for a change in the architectural style are not known to me--but implicitly it seems like the motivation were, at least in part, to bring this project in line with other JS projects that are developed within Ratkaisutoimisto.
+
+Likely due to resource and time limitations, the refactor isn't complete and likely won't be for a while. Some of the vision for the new architectural direction is hard to decipher--this time it's difficult to see the trees instead of the forest. I'll write down the noteworthy things I think are true with relative confidence.
+
+#### Future direction
+
+Varaamo's architecture will be looked into in a way that will likely yield a future direction the project is going to be moved towards. I do not know the depth of the process, but the knowledge of its existence is enough to suggest some conclusions: (1) we should not spend too much effort in refurbishing the architecture and (2) the death of these notes should be imminent.
+
+#### Notes about redux
+
+This application makes use of `redux` for a lot of things. It's no wonder as this project was first developed during a time when state management still lived its wild west phase and `redux` looked to be a solid way of creating consistency. However, the mood around redux has changed since and that shift is visible in the newer projects under Ratkaisutoimisto's care--as well as older ones like Varaamo. Generally the trend seems to be to avoid using redux when you do not have a specific reason for using it.
+
+Generally speaking, code living within `app` tends to be more `redux` dependent than code living within `src`, but there are exceptions.
+
+In this project you can see the shift in the two ways requests are made into the API. The original model relied on purpose crafted middleware, but since an api client with a more traditional pattern has been added.
+
+This introduces a pesky problem--**depending on how you access the API, response objects may be in either `snake_case` or `camelCase`**. Generally speaking, requests made with the `apiClient` yield `snake_case` responses and requests made through `redux` yield `camelCase` responses. The middleware for making requests seems to transform the by default `snake_case` api responses into `camelCase`.
+
+You'll need to make note of this behaviour when you are building interoperability between the two state management styles. Some components have been built with the `camelCase` assumption--and the `redux` state naturally relies on this assumption.
+
+The project now has a dependency, `camelcase-keys`, which you can use to transform API responses into `camelCase`. For consistency, and as a way to decrease the scope of required changes, you can use this dependency to change API responses into `camelCase`.
+
+Another quirk in `redux` is that some of the selectors translate the object's content for you. Some information, like titles, can be in multiple languages (`en`, `fi`, `sv`). In these instances, the translated field will be an object consisting of `locale` and `translation` key value pairs. With some models, the selectors magically infer the correct translation by using the current locale and will yield a `string` instead of a `translationObject`. The `apiClient` won't do this for you--you'll have to display the correct translation "manually".

--- a/src/common/calendar/TimePickerCalendar.js
+++ b/src/common/calendar/TimePickerCalendar.js
@@ -370,11 +370,13 @@ class TimePickerCalendar extends Component {
     } = this.props;
     const { viewType, header } = this.state;
     const addValue = viewType === 'timeGridWeek' ? 'w' : 'd';
+    const slotTallness = resourceUtils.getSlotTallness(resource);
+
     return (
-      <div className={classNames([
-        'app-TimePickerCalendar',
-        { 'app-TimePickerCalendar--disabled': disabled },
-      ])}
+      <div className={classNames(['app-TimePickerCalendar', {
+        'app-TimePickerCalendar--disabled': disabled,
+        [`app-TimePickerCalendar--${slotTallness}-slots`]: slotTallness,
+      }])}
       >
         <FullCalendar
           {...this.getCalendarOptions()}

--- a/src/common/calendar/_timePickerCalendar.scss
+++ b/src/common/calendar/_timePickerCalendar.scss
@@ -2,6 +2,21 @@
   &--disabled {
     position: relative;
   }
+  
+  /* These hacks change slot sizes so that a slot size of 3 hours is
+     greater than that of 1 hour. If these styles are problematic, i.e.
+     they break resizing or dragging, feel free to remove them. */
+  &--big-slots {
+    .fc-slats td { 
+      height: 4.5em !important; 
+    } 
+  }
+
+  &--huge-slots {
+    .fc-slats td { 
+      height: 9em !important; 
+    } 
+  }
 
   &__event {
     color: $hel-coat !important;
@@ -74,7 +89,7 @@
        spanned the final hour visible in the calendar in the week view.
       */
     margin-bottom: 12px;
-  }
+  } 
 
   .fc-event,
   .fc-event:hover {

--- a/src/domain/resource/__tests__/utils.test.js
+++ b/src/domain/resource/__tests__/utils.test.js
@@ -276,10 +276,10 @@ describe('domain resource utility function', () => {
       opening_hours: OPENING_HOURS,
     });
 
-    const minTimeDay = resourceUtils.getFullCalendarMinTime(resource, DATE, 'timeGridDay', 3);
-    expect(minTimeDay).toBe('05:00:00');
+    const minTimeDay = resourceUtils.getFullCalendarMinTime(resource, DATE, 'timeGridDay');
+    expect(minTimeDay).toBe('06:00:00');
 
-    const minTimeWeek = resourceUtils.getFullCalendarMinTime(resource, DATE, 'timeGridWeek', 2);
+    const minTimeWeek = resourceUtils.getFullCalendarMinTime(resource, DATE, 'timeGridWeek');
     expect(minTimeWeek).toBe('06:00:00');
   });
 
@@ -289,24 +289,24 @@ describe('domain resource utility function', () => {
         opening_hours: OPENING_HOURS,
       });
 
-      const minTimeDay = resourceUtils.getFullCalendarMaxTime(resource, DATE, 'timeGridDay', 3);
-      expect(minTimeDay).toBe('23:00:00');
+      const maxTimeDay = resourceUtils.getFullCalendarMaxTime(resource, DATE, 'timeGridDay');
+      expect(maxTimeDay).toBe('20:30:00');
 
-      const minTimeWeek = resourceUtils.getFullCalendarMaxTime(resource, DATE, 'timeGridWeek', 2);
-      expect(minTimeWeek).toBe('22:00:00');
+      const maxTimeWeek = resourceUtils.getFullCalendarMaxTime(resource, DATE, 'timeGridWeek');
+      expect(maxTimeWeek).toBe('20:30:00');
     });
 
-    test('does not overflow date when opening hours end at 23', () => {
+    test('does not overflow date when opening hours end at 23:59', () => {
       const resource = resourceFixture.build({
         opening_hours: [{
           date: DATE,
           opens: `${DATE}T08:00:00+03:00`,
-          closes: `${DATE}T23:00:00+03:00`,
+          closes: `${DATE}T23:59:00+03:00`,
         }],
       });
-      const maxTimeWeek = resourceUtils.getFullCalendarMaxTime(resource, DATE, 'timeGridWeek', 2);
+      const maxTimeWeek = resourceUtils.getFullCalendarMaxTime(resource, DATE, 'timeGridWeek');
 
-      expect(maxTimeWeek).toBe('23:00:00');
+      expect(maxTimeWeek).toBe('23:59:00');
     });
   });
 

--- a/src/domain/resource/utils.js
+++ b/src/domain/resource/utils.js
@@ -652,7 +652,7 @@ export const getTaxPercentage = (resource) => {
 };
 
 export const getSlotTallness = (resource) => {
-  const [hours, minutes, seconds] = get(resource, 'slot_size', '00:03:00').split(':').map(val => Number(val));
+  const [hours, minutes, seconds] = get(resource, 'slot_size', '00:30:00').split(':').map(val => Number(val));
   const startOfTodayTime = new Date().setHours(0, 0, 0, 0);
   const slotSizeTime = new Date().setHours(hours, minutes, seconds, 0);
   const slotSizeDurationTime = slotSizeTime - startOfTodayTime;

--- a/src/domain/resource/utils.js
+++ b/src/domain/resource/utils.js
@@ -350,15 +350,6 @@ export const getFullCalendarMaxTime = (resource, date, viewType, buffer = 1) => 
       max.add(buffer, 'hour');
     }
 
-    // Make sure that the max value is an even hour.
-    if (max.minutes() > 0) {
-      max.minutes(0);
-
-      if (hasTimeUntilEndOfDay(max, 1)) {
-        max.add(1, 'hour');
-      }
-    }
-
     return max
       .format('HH:mm:ss');
   }


### PR DESCRIPTION
**Trust API when configuring slot size**  
>Some resources have slot sizes that span a greater portion of the day.
For instance, a resource may have a configuration as follows: opening
time of 09:00, closing time of 15:00 and a mininum slot duration of 3
hours. In this case the day has two possible slots: 09:00-11:59 and
12:00-14:59.

>With our previous approach, we did some scaffolding to ensure that the
00:30:00 and 01:00:00 slot sizes worked well even if the API returned
with an unexpected value for slot_size. Because this would have been
laboursome to do for a more open eded set of possible slot sizes, I
removed the special checks. Now the slot size that is returned from the
API gets used as is.

>I also removed the buffer setting and use the slot size as the buffer
instead. This ensures that slots get spaced appropriately in the
calendar. The buffer setting was not in use in application code.

This change makes fullcalendar's slot size dynamic. Currently it's either `00:30:00` or `01:00:00`, after this change it can be anything.

I changed the styling so that slots are rendered taller when their slot size is bigger.

**Allow uneven minute values**  
>Some spaces are open through the entire day. In these cases the opening
hours are set to end at 23:59. If we ignore minutes, or round the
minutes up, we end up with "lost slots". In the first case we lose the
slot from 23:00-23:30, in the second case we lose all the slots.

>When we are using a closing time of 23:59, the "last" slot
(23:30-23:59) can't be reserved, but it is rendered in the calendar.

This is a fix to VAR-340. Currently it's possible to reserve times until 23:00. Now the calendar also supports reservations until 23:30. The last slot of the day is not reservable and according to the current spec it won't be made available.