### PR TITLE
VAR-350 | Disable calendar when no permission to reserve

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
   - Fixed scrollbar flickering in reservation calendar when business hours were of short duration
   - Fixed premise dropdown returning empty labels
   - Fixed resource calendar not rendering anything when closing time was 23:00 or later
+  - Changed calendar to be disabled when the user doesn't have privileges to make reservations to the resource
 
   **CHANGELOG**
   - [#1118](https://github.com/City-of-Helsinki/varaamo/pull/1118) Added support for unit manager role; unit managers now have the same permissions as unit admins do

--- a/app/i18n/messages/en.json
+++ b/app/i18n/messages/en.json
@@ -413,6 +413,7 @@
   "TimePickerCalendar.info.minPeriodText": "Reservation must be at least {duration}h long",
   "TimePickerCalendar.info.maxPeriodText": "Reservation must be shorter than {duration}h",
   "TimePickerCalendar.info.today": "Today",
+  "TimePickerCalendar.info.displayedMessage": "The resource cannot be reserved at this time",
 
   "CalendarLegend.closed": "Unavailable",
   "CalendarLegend.selection": "Selected",

--- a/app/i18n/messages/fi.json
+++ b/app/i18n/messages/fi.json
@@ -422,6 +422,7 @@
   "TimePickerCalendar.info.minPeriodText": "Varauksen on kestettävä vähintään {duration} tuntia.",
   "TimePickerCalendar.info.maxPeriodText": "Varaus saa kestää enimmillään {duration} tuntia.",
   "TimePickerCalendar.info.today": "Tänään",
+  "TimePickerCalendar.info.displayedMessage": "Kohde ei ole varattavissa",
 
   "CalendarLegend.closed": "Ei varattavissa",
   "CalendarLegend.selection": "Varauksesi",

--- a/app/i18n/messages/sv.json
+++ b/app/i18n/messages/sv.json
@@ -414,6 +414,7 @@
   "TimePickerCalendar.info.minPeriodText": "Bokningen måste vara minst {duration} timmar lång.",
   "TimePickerCalendar.info.maxPeriodText": "Bokningen får vara högst {duration} timmar lång.",
   "TimePickerCalendar.info.today": "Idag",
+  "TimePickerCalendar.info.displayedMessage": "För tillfället kan resursen inte bokas",
 
   "CalendarLegend.closed": "Inte tillgänglig",
   "CalendarLegend.selection": "Vald",

--- a/src/common/calendar/TimePickerCalendar.js
+++ b/src/common/calendar/TimePickerCalendar.js
@@ -30,6 +30,7 @@ class TimePickerCalendar extends Component {
 
   static propTypes = {
     date: PropTypes.string,
+    disabled: PropTypes.bool,
     isStaff: PropTypes.bool.isRequired,
     resource: PropTypes.object.isRequired,
     onDateChange: PropTypes.func.isRequired,
@@ -301,10 +302,12 @@ class TimePickerCalendar extends Component {
   }
 
   getCalendarOptions = () => {
+    const isDisabled = this.props.disabled;
+
     return {
       timeZone: constants.TIME_ZONE,
       height: 'auto',
-      editable: true,
+      editable: !isDisabled,
       eventConstraint: 'businessHours',
       eventOverlap: false,
       firstDay: 1,
@@ -312,7 +315,7 @@ class TimePickerCalendar extends Component {
       locales: [enLocale, svLocale, fiLocale],
       nowIndicator: true,
       plugins: [timeGridPlugin, momentTimezonePlugin, interactionPlugin],
-      selectable: true,
+      selectable: !isDisabled,
       selectOverlap: false,
       selectConstraint: 'businessHours',
       selectMirror: true,
@@ -363,11 +366,16 @@ class TimePickerCalendar extends Component {
       onDateChange,
       resource,
       t,
+      disabled,
     } = this.props;
     const { viewType, header } = this.state;
     const addValue = viewType === 'timeGridWeek' ? 'w' : 'd';
     return (
-      <div className="app-TimePickerCalendar">
+      <div className={classNames([
+        'app-TimePickerCalendar',
+        { 'app-TimePickerCalendar--disabled': disabled },
+      ])}
+      >
         <FullCalendar
           {...this.getCalendarOptions()}
           allDaySlot={false}
@@ -402,6 +410,11 @@ class TimePickerCalendar extends Component {
           slotLabelInterval={resourceUtils.getFullCalendarSlotLabelInterval(resource)}
         />
         <CalendarLegend />
+        {disabled && (
+          <div className="app-TimePickerCalendar__blocker">
+            <div className="app-TimePickerCalendar__inline-modal">{t('TimePickerCalendar.info.displayedMessage')}</div>
+          </div>
+        )}
       </div>
     );
   }

--- a/src/common/calendar/_timePickerCalendar.scss
+++ b/src/common/calendar/_timePickerCalendar.scss
@@ -1,4 +1,8 @@
 .app-TimePickerCalendar {
+  &--disabled {
+    position: relative;
+  }
+
   &__event {
     color: $hel-coat !important;
     border-radius: 0 !important;
@@ -35,6 +39,29 @@
 
   &__maxDuration {
     font-size: 1.25rem;
+  }
+
+  &__blocker {
+    position: absolute;
+    z-index: 1;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    background: rgba(29, 27, 49, 0.3);
+
+    cursor: not-allowed;
+  }
+
+  &__inline-modal {
+    padding: 16px 18px;
+
+    box-shadow: 4px 4px 14px 4px rgba(29, 27, 49, 0.4);
+    background: $white;
   }
 
   & .fc-time-grid {

--- a/src/domain/resource/reservationCalendar/ResourceReservationCalendar.js
+++ b/src/domain/resource/reservationCalendar/ResourceReservationCalendar.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import Button from 'react-bootstrap/lib/Button';
 import moment from 'moment';
 import isEmpty from 'lodash/isEmpty';
+import get from 'lodash/get';
 
 import injectT from '../../../../app/i18n/injectT';
 import TimePickerCalendar from '../../../common/calendar/TimePickerCalendar';
@@ -106,10 +107,13 @@ class UntranslatedResourceReservationCalendar extends React.Component {
       selected,
     } = this.state;
 
+    const canMakeReservations = get('resource.user_permissions.can_make_reservations', false);
+
     return (
       <div className="app-ResourceReservationCalendar">
         <TimePickerCalendar
           date={date}
+          disabled={!canMakeReservations}
           isStaff={isStaff}
           onDateChange={onDateChange}
           onTimeChange={selectedTime => this.setState({ selected: selectedTime })}
@@ -143,6 +147,7 @@ class UntranslatedResourceReservationCalendar extends React.Component {
             <Button
               bsStyle="primary"
               className="app-ResourceReservationCalendar__reserveButton"
+              disabled={!canMakeReservations}
               onClick={this.onReserveButtonClick}
             >
               {t('ResourceReservationCalendar.reserveButton')}

--- a/src/domain/resource/reservationCalendar/__tests__/__snapshots__/ResourceReservationCalendar.test.js.snap
+++ b/src/domain/resource/reservationCalendar/__tests__/__snapshots__/ResourceReservationCalendar.test.js.snap
@@ -6,6 +6,7 @@ exports[`ResourceReservationCalendar renders correctly 1`] = `
 >
   <InjectT(TimePickerCalendar)
     date="2019-08-15"
+    disabled={true}
     onDateChange={[MockFunction]}
     onTimeChange={[Function]}
     resource={


### PR DESCRIPTION
Calendar is disabled when the current user does not have have permission to make reservations.

<img width="770" alt="Screenshot 2020-03-24 at 13 51 27" src="https://user-images.githubusercontent.com/9090689/77422704-9779eb00-6dd6-11ea-8d64-2c2013061f97.png">
