### PR TITLE
VAR-377

### DIFF
--- a/app/shared/modals/reservation-info/ReservationEditForm.js
+++ b/app/shared/modals/reservation-info/ReservationEditForm.js
@@ -16,6 +16,7 @@ import { resourceRoles, resourcePermissionTypes } from '../../../../src/domain/r
 import { hasPermissionForResource } from '../../../../src/domain/resource/permissions/utils';
 import { getReservationPrice, getTaxPercentage } from '../../../../src/domain/resource/utils';
 import FormTypes from '../../../constants/FormTypes';
+import { hasProducts } from '../../../utils/resourceUtils';
 import ReduxFormField from '../../form-fields/ReduxFormField';
 import ReservationTimeControls from '../../form-fields/ReservationTimeControls';
 import TimeRange from '../../time-range/TimeRange';
@@ -234,7 +235,7 @@ class UnconnectedReservationEditForm extends Component {
             {isAdminOrOwner && !isEditing && (
               <Button
                 bsStyle="primary"
-                disabled={isSaving}
+                disabled={isSaving || (!isAdmin && hasProducts(resource))}
                 onClick={onStartEditClick}
               >
                 {t('ReservationEditForm.startEdit')}

--- a/app/shared/modals/reservation-info/ReservationEditForm.js
+++ b/app/shared/modals/reservation-info/ReservationEditForm.js
@@ -63,10 +63,10 @@ class UnconnectedReservationEditForm extends Component {
     return this.renderInfoRow(label, value);
   }
 
-  renderInfoRow(label, value) {
+  renderInfoRow(label, value, rest) {
     if (!value && value !== '') return null;
     return (
-      <FormGroup>
+      <FormGroup {...rest}>
         <Col sm={3}>
           <ControlLabel>{label}</ControlLabel>
         </Col>
@@ -185,6 +185,7 @@ class UnconnectedReservationEditForm extends Component {
     } = reservation;
 
     const isAdminOrOwner = (isAdmin || isOwn);
+    const showRefundPolicy = isAdmin && !reservation.staffEvent && price > 0;
 
     return (
       <Form
@@ -213,10 +214,13 @@ class UnconnectedReservationEditForm extends Component {
           && price > 0
           && this.renderInfoRow(t('common.priceLabel'), t('ReservationEditForm.priceWithTax', tVariables))}
 
-        {!reservation.staffEvent
-          && price > 0
-        // eslint-disable-next-line max-len
-          && this.renderInfoRow(t('ReservationInformationForm.refundPolicyTitle'), t('ReservationInformationForm.refundPolicyText'))}
+        {showRefundPolicy
+          && this.renderInfoRow(
+            t('ReservationInformationForm.refundPolicyTitle'),
+            t('ReservationInformationForm.refundPolicyText'),
+            { id: 'refund-policy' },
+          )
+        }
         {canViewExtraFields && this.renderStaticInfoRow('reserverId')}
         {this.renderStaticInfoRow('reserverPhoneNumber')}
         {this.renderStaticInfoRow('reserverEmailAddress')}

--- a/app/shared/modals/reservation-info/__tests__/ReservationEditForm.test.js
+++ b/app/shared/modals/reservation-info/__tests__/ReservationEditForm.test.js
@@ -236,6 +236,42 @@ describe('shared/modals/reservation-info/ReservationEditForm', () => {
               expect(timeControlProps.disabled).toEqual(true);
             });
           });
+
+          test('renders refund policy for correct roles', () => {
+            // Should only be rendered for admin level users, should
+            // only be rendered for reservations that are not made by
+            // staff and should only be rendered when the price is
+            // greater than 0.
+            const getRefundPolicy = (wrapper) => {
+              return wrapper.find({ id: 'refund-policy' });
+            };
+            const notAdmin = getWrapper({ isEditing: true, isAdmin: false });
+            const admin = getWrapper({
+              isEditing: true,
+              isAdmin: true,
+              reservation: {
+                ...reservation,
+                isStaffEvent: false,
+                begin: new Date(2017, 10, 1, 9, 0, 0, 0).toJSON(),
+                end: new Date(2017, 10, 1, 11, 0, 0, 0).toJSON(),
+              },
+              resource: {
+                ...resource,
+                products: [
+                  {
+                    price: {
+                      type: 'per_period',
+                      period: '01:00',
+                      amount: 100,
+                    },
+                  },
+                ],
+              },
+            });
+
+            expect(getRefundPolicy(notAdmin).length).toEqual(0);
+            expect(getRefundPolicy(admin).length).toEqual(1);
+          });
         });
       });
 

--- a/app/shared/modals/reservation-info/__tests__/ReservationEditForm.test.js
+++ b/app/shared/modals/reservation-info/__tests__/ReservationEditForm.test.js
@@ -331,6 +331,36 @@ describe('shared/modals/reservation-info/ReservationEditForm', () => {
         test('is not rendered if isEditing is true', () => {
           expect(getEditButton({ isEditing: true })).toHaveLength(0);
         });
+
+        test('disabled when the resource has a cost and the user is not an admin', () => {
+          const isAdmin = getEditButton({
+            isEditing: false,
+            isAdmin: true,
+            resource: {
+              ...resource,
+              products: [{
+                price: {},
+              }],
+            },
+          });
+          const isUser = getEditButton({
+            isEditing: false,
+            isAdmin: false,
+            reservation: {
+              ...reservation,
+              isOwn: true,
+            },
+            resource: {
+              ...resource,
+              products: [{
+                price: {},
+              }],
+            },
+          });
+
+          expect(isAdmin.prop('disabled')).toEqual(false);
+          expect(isUser.prop('disabled')).toEqual(true);
+        });
       });
 
       describe('cancel button', () => {


### PR DESCRIPTION
Hide refund policy from non admin users and disable edit reservation button when reservation is "paid" and the user is not an admin.

Nice screenshots in the Jira task.

Unfortunately paid reservations can not be made in the test environment, so these fixes can't be tested in the application with the actual code.