### PR TITLE
VAR-382 | Show billing address when reservation is billable

### DIFF
--- a/app/pages/reservation/reservation-confirmation/ReservationConfirmation.js
+++ b/app/pages/reservation/reservation-confirmation/ReservationConfirmation.js
@@ -67,8 +67,11 @@ class ReservationConfirmation extends Component {
     const { reservationPrice } = this.state;
     const refUrl = window.location.href;
     const href = `${constants.FEEDBACK_URL}&ref=${refUrl}`;
+    const isBillable = reservationPrice > 0;
     let email = '';
-    if (reservation.reserverEmailAddress) {
+    if (isBillable && reservation.billingEmailAddress) {
+      email = reservation.billingEmailAddress;
+    } else if (reservation.reserverEmailAddress) {
       email = reservation.reserverEmailAddress;
     } else if (reservation.user && reservation.user.email) {
       email = reservation.user.email;


### PR DESCRIPTION
When a reservation is billable and the billing email address is set,
respa will send the reminder email into this address.