### PR TITLE
VAR-383 | Remove initialisation of state

### DIFF
--- a/app/shared/modals/reservation-cancel/ReservationCancelModalContainer.js
+++ b/app/shared/modals/reservation-cancel/ReservationCancelModalContainer.js
@@ -22,16 +22,6 @@ class UnconnectedReservationCancelModalContainer extends Component {
     this.state = { checkboxDisabled: null };
   }
 
-  componentDidMount() {
-    const {
-      resource,
-    } = this.props;
-
-    hasProducts(resource)
-      ? this.setState({ checkboxDisabled: false })
-      : this.setState({ checkboxDisabled: true });
-  }
-
   handleCancel() {
     const { actions, reservation } = this.props;
     actions.deleteReservation(reservation);


### PR DESCRIPTION
The resource is not guaranteed to be available when the check is
completed, which causes the check to always return false. This breaks
the logic of the view.