### PR TITLE
VAR-384 | Replace camelcase library

### DIFF
--- a/app/shared/reservation-controls/ReservationControlsContainer.js
+++ b/app/shared/reservation-controls/ReservationControlsContainer.js
@@ -3,7 +3,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 import { bindActionCreators } from 'redux';
-import camelCaseKeys from 'camelcase-keys';
+import camelCaseKeys from 'camelcase-keys-deep';
 
 import {
   confirmPreliminaryReservation,

--- a/app/shared/reservation-controls/__tests__/ReservationControlsContainer.test.js
+++ b/app/shared/reservation-controls/__tests__/ReservationControlsContainer.test.js
@@ -2,7 +2,7 @@ import { shallow } from 'enzyme';
 import React from 'react';
 import simple from 'simple-mock';
 import snakeCaseKeys from 'snakecase-keys';
-import camelCaseKeys from 'camelcase-keys';
+import camelCaseKeys from 'camelcase-keys-deep';
 
 import Reservation from '../../../utils/fixtures/Reservation';
 import Resource from '../../../utils/fixtures/Resource';

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@fullcalendar/timegrid": "^4.3.0",
     "axios": "^0.19.0",
     "bootstrap-sass": "3.4.1",
-    "camelcase-keys": "^6.1.2",
+    "camelcase-keys-deep": "^0.1.0",
     "classnames": "2.2.5",
     "dotenv": "7.0.0",
     "dragscroll": "0.0.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2352,6 +2352,14 @@ camel-case@3.0.x:
     no-case "^2.2.0"
     upper-case "^1.1.1"
 
+camelcase-keys-deep@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/camelcase-keys-deep/-/camelcase-keys-deep-0.1.0.tgz#2e0dd61739c99f068efd8de606a629ed808bbba3"
+  integrity sha1-Lg3WFznJnwaO/Y3mBqYp7YCLu6M=
+  dependencies:
+    camelcase "^2.1.1"
+    map-obj "^1.0.1"
+
 camelcase-keys@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/camelcase-keys/-/camelcase-keys-2.1.0.tgz#308beeaffdf28119051efa1d932213c91b8f92e7"
@@ -2360,20 +2368,11 @@ camelcase-keys@^2.0.0:
     camelcase "^2.0.0"
     map-obj "^1.0.0"
 
-camelcase-keys@^6.1.2:
-  version "6.1.2"
-  resolved "https://registry.yarnpkg.com/camelcase-keys/-/camelcase-keys-6.1.2.tgz#531a289aeea93249b63ec1249db9265f305041f7"
-  integrity sha512-QfFrU0CIw2oltVvpndW32kuJ/9YOJwUnmWrjlXt1nnJZHCaS9i6bfOpg9R4Lw8aZjStkJWM+jc0cdXjWBgVJSw==
-  dependencies:
-    camelcase "^5.3.1"
-    map-obj "^4.0.0"
-    quick-lru "^4.0.1"
-
 camelcase@5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.0.0.tgz#03295527d58bd3cd4aa75363f35b2e8d97be2f42"
 
-camelcase@^2.0.0, camelcase@^2.0.1:
+camelcase@^2.0.0, camelcase@^2.0.1, camelcase@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-2.1.1.tgz#7c1d16d679a1bbe59ca02cacecfb011e201f5a1f"
 
@@ -7447,11 +7446,6 @@ querystring@0.2.0, querystring@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
   integrity sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=
-
-quick-lru@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-4.0.1.tgz#5b8878f113a58217848c6482026c73e1ba57727f"
-  integrity sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==
 
 raf@3.4.1, raf@^3.4.0:
   version "3.4.1"


### PR DESCRIPTION
The previous library does not guarantee browser compatibility and our
build setup doesn't transpile the dependency. To avoid bigger changes
in the build process, I just replaced the dependency with a browser
safe alternative.