### PR TITLE
VAR-358 | Use a single link in resource card title area

### DIFF
--- a/src/domain/resource/card/ResourceCard.js
+++ b/src/domain/resource/card/ResourceCard.js
@@ -81,22 +81,15 @@ class ResourceCard extends React.Component {
           <BackgroundImage height={420} image={getMainImage(resource.images)} width={700} />
         </Link>
         <div className="app-resourceCard__content">
-          <div className="app-resourceCard__unit-name">
-            <a
-              className="app-resourceCard__unit-name-link"
-              onClick={() => this.onSearchClick({ unit: resource.unit })}
-              role="button"
-              tabIndex="-1"
-            >
-              <span>{dataUtils.getLocalizedFieldValue(unit.name, locale)}</span>
-            </a>
-            <div className="app-resourceCard__unit-name-labels">
-              <ResourceAvailability date={date} resource={resource} />
-              {!resource.public && <UnpublishedLabel />}
-            </div>
-          </div>
           <Link onClick={this.handleLinkClick} to={this.getResourcePageLink()}>
-            <h4>{dataUtils.getLocalizedFieldValue(resource.name, locale, true)}</h4>
+            <h3>{dataUtils.getLocalizedFieldValue(resource.name, locale, true)}</h3>
+            <div className="app-resourceCard__unit-name">
+              <span>{dataUtils.getLocalizedFieldValue(unit.name, locale)}</span>
+              <div className="app-resourceCard__unit-name-labels">
+                <ResourceAvailability date={date} resource={resource} />
+                {!resource.public && <UnpublishedLabel />}
+              </div>
+            </div>
           </Link>
           <div className="app-resourceCard__description">
             {dataUtils.getLocalizedFieldValue(resource.description, locale, true)}

--- a/src/domain/resource/card/__tests__/__snapshots__/ResourceCard.test.js.snap
+++ b/src/domain/resource/card/__tests__/__snapshots__/ResourceCard.test.js.snap
@@ -26,54 +26,6 @@ exports[`ResourceCard renders correctly 1`] = `
   <div
     className="app-resourceCard__content"
   >
-    <div
-      className="app-resourceCard__unit-name"
-    >
-      <a
-        className="app-resourceCard__unit-name-link"
-        onClick={[Function]}
-        role="button"
-        tabIndex="-1"
-      >
-        <span>
-          Unit (en) - 1
-        </span>
-      </a>
-      <div
-        className="app-resourceCard__unit-name-labels"
-      >
-        <InjectT(ResourceAvailability)
-          date="30-07-2019"
-          resource={
-            Object {
-              "available_hours": Array [],
-              "equipment": Array [],
-              "id": 1,
-              "is_favorite": false,
-              "name": Object {
-                "en": "Resource (en) - 1",
-                "fi": "Resource (fi) - 1",
-                "sv": "Resource (sv) - 1",
-              },
-              "need_manual_confirmation": false,
-              "opening_hours": Array [],
-              "products": Array [],
-              "public": true,
-              "required_reservation_extra_fields": Array [],
-              "reservable": true,
-              "reservable_after": null,
-              "slot_size": "00:30:00",
-              "supported_reservation_extra_fields": Array [],
-              "unit": 1,
-              "user_permissions": Object {
-                "canMakeReservations": true,
-                "isAdmin": false,
-              },
-            }
-          }
-        />
-      </div>
-    </div>
     <Link
       replace={false}
       to={
@@ -86,9 +38,50 @@ exports[`ResourceCard renders correctly 1`] = `
         }
       }
     >
-      <h4>
+      <h3>
         Resource (en) - 1
-      </h4>
+      </h3>
+      <div
+        className="app-resourceCard__unit-name"
+      >
+        <span>
+          Unit (en) - 1
+        </span>
+        <div
+          className="app-resourceCard__unit-name-labels"
+        >
+          <InjectT(ResourceAvailability)
+            date="30-07-2019"
+            resource={
+              Object {
+                "available_hours": Array [],
+                "equipment": Array [],
+                "id": 1,
+                "is_favorite": false,
+                "name": Object {
+                  "en": "Resource (en) - 1",
+                  "fi": "Resource (fi) - 1",
+                  "sv": "Resource (sv) - 1",
+                },
+                "need_manual_confirmation": false,
+                "opening_hours": Array [],
+                "products": Array [],
+                "public": true,
+                "required_reservation_extra_fields": Array [],
+                "reservable": true,
+                "reservable_after": null,
+                "slot_size": "00:30:00",
+                "supported_reservation_extra_fields": Array [],
+                "unit": 1,
+                "user_permissions": Object {
+                  "canMakeReservations": true,
+                  "isAdmin": false,
+                },
+              }
+            }
+          />
+        </div>
+      </div>
     </Link>
     <div
       className="app-resourceCard__description"

--- a/src/domain/resource/card/_resourceCard.scss
+++ b/src/domain/resource/card/_resourceCard.scss
@@ -61,10 +61,8 @@ $resourceCardTitleBottomMargin: 6px;
     margin-top: 0;
     margin-bottom: $resourceCardTitleBottomMargin;
 
-    font-size: 2.4rem;
-
     @media (max-width: $screen-xs-max) {
-      font-size: 2.4rem;
+      font-size: 1.6rem;
       line-height: 1;
     }
   }

--- a/src/domain/resource/card/_resourceCard.scss
+++ b/src/domain/resource/card/_resourceCard.scss
@@ -3,6 +3,7 @@
 $card-border-color: #d6d6d6;
 $image-items-margin: 5px;
 $resourceCardPadding: 15px;
+$resourceCardTitleBottomMargin: 6px;
 
 .app-resourceCard {
   margin: 20px 0;
@@ -56,11 +57,14 @@ $resourceCardPadding: 15px;
     }
   }
 
-  h4 {
+  h3 {
     margin-top: 0;
-    margin-bottom: 0;
+    margin-bottom: $resourceCardTitleBottomMargin;
+
+    font-size: 2.4rem;
+
     @media (max-width: $screen-xs-max) {
-      font-size: 1.6rem;
+      font-size: 2.4rem;
       line-height: 1;
     }
   }


### PR DESCRIPTION
Generally, having two links will make it harder for a screen reader
user to know where they are going. More specifically, the first link
was broken and drew away user attention from the most important click
target that will navigate the user into the resource page.