### PR TITLE
VAR-360 | Fix remaining font size issues

### DIFF
--- a/app/pages/resource/ResourcePage.js
+++ b/app/pages/resource/ResourcePage.js
@@ -43,6 +43,7 @@ class UnconnectedResourcePage extends Component {
     id: PropTypes.string.isRequired,
     isFetchingResource: PropTypes.bool.isRequired,
     isLoggedIn: PropTypes.bool.isRequired,
+    isLargeFontSize: PropTypes.bool.isRequired,
     isStaff: PropTypes.bool.isRequired,
     location: PropTypes.object.isRequired,
     resource: PropTypes.object.isRequired,
@@ -195,6 +196,7 @@ class UnconnectedResourcePage extends Component {
       date,
       isFetchingResource,
       isLoggedIn,
+      isLargeFontSize,
       isStaff,
       location,
       resource,
@@ -240,7 +242,10 @@ class UnconnectedResourcePage extends Component {
           {showMap && (<ResourceMap resource={resource} unit={unit} />)}
           {!showMap && (
             <PageWrapper title={resource.name || ''} transparent>
-              <Row>
+              <Row className={classNames('app-ResourcePage__columns', {
+                'app-ResourcePage__columns--is-large-font-size': isLargeFontSize,
+              })}
+              >
                 <Col lg={8} md={8} xs={12}>
                   <div className="app-ResourcePage__content">
                     {mainImage

--- a/app/pages/resource/__tests__/resourcePageSelector.test.js
+++ b/app/pages/resource/__tests__/resourcePageSelector.test.js
@@ -26,6 +26,9 @@ function getState(resources = [], units = [], user = defaultUser) {
       resourceMap: Immutable({
         showMap: true,
       }),
+      accessibility: Immutable({
+        fontSize: 'fontSizeSmall',
+      }),
     }),
   };
 }

--- a/app/pages/resource/_resource-page.scss
+++ b/app/pages/resource/_resource-page.scss
@@ -37,6 +37,18 @@ $content-padding: 10px;
     }
   }
 
+  &__columns {
+    &--is-large-font-size {
+      // Use a single column layout on ResourcePage when font size is
+      // large. Otherwise the resource calendar doesn't have enough
+      // room to render its content.
+      & > div {
+        width: 100%;
+        float: unset;
+      }
+    }
+  }
+
   &__content {
     padding: 30px 0;
     background-color: $white;

--- a/app/pages/resource/resourcePageSelector.js
+++ b/app/pages/resource/resourcePageSelector.js
@@ -1,5 +1,6 @@
 import { createSelector, createStructuredSelector } from 'reselect';
 
+import FontSizes from '../../constants/FontSizes';
 import ActionTypes from '../../constants/ActionTypes';
 import { createIsStaffSelector, isAdminSelector, isLoggedInSelector } from '../../state/selectors/authSelectors';
 import { createResourceSelector, unitsSelector } from '../../state/selectors/dataSelectors';
@@ -14,6 +15,7 @@ const unitSelector = createSelector(
   unitsSelector,
   (resource, units) => units[resource.unit] || {},
 );
+const isLargeFontSizeSelector = state => state.ui.accessibility.fontSize === FontSizes.LARGE;
 
 const resourcePageSelector = createStructuredSelector({
   date: dateSelector,
@@ -21,6 +23,7 @@ const resourcePageSelector = createStructuredSelector({
   isAdmin: isAdminSelector,
   isFetchingResource: requestIsActiveSelectorFactory(ActionTypes.API.RESOURCE_GET_REQUEST),
   isLoggedIn: isLoggedInSelector,
+  isLargeFontSize: isLargeFontSizeSelector,
   isStaff: createIsStaffSelector(resourceSelector),
   resource: resourceSelector,
   showMap: showMapSelector,

--- a/app/pages/user-reservations/reservation-list/ReservationListItem.js
+++ b/app/pages/user-reservations/reservation-list/ReservationListItem.js
@@ -64,7 +64,7 @@ class ReservationListItem extends Component {
     };
 
     return (
-      <li className="reservation" ref={this.wrapperRef}>
+      <li className="reservation container" ref={this.wrapperRef}>
         <div className="col-md-3 col-lg-2 image-container">
           <Link
             aria-hidden="true"

--- a/app/pages/user-reservations/reservation-list/_reservation-list.scss
+++ b/app/pages/user-reservations/reservation-list/_reservation-list.scss
@@ -10,6 +10,7 @@ $reservation-list-label-height: 20px;
     position: relative;
     margin-bottom: 50px;
     min-height: 180px;
+    padding: 0;
 
     @media (max-width: $screen-xs-max) {
       min-height: 230px;

--- a/app/shared/reservation-controls/ReservationControls.js
+++ b/app/shared/reservation-controls/ReservationControls.js
@@ -55,6 +55,7 @@ class ReservationControls extends Component {
       info: (
         <Button
           bsStyle="default"
+          id="info"
           key="infoButton"
           onClick={this.props.onInfoClick}
         >
@@ -122,8 +123,8 @@ class ReservationControls extends Component {
     const reservationIsInThePast = !reservation || moment() > moment(reservation.end);
 
     return (
-      <div className="buttons">
-        <div className="app-ReservationControls__info-button-wrapper">{this.buttons.info}</div>
+      <div className="app-ReservationControls">
+        {this.buttons.info}
         {!reservationIsInThePast && this.renderButtons(this.buttons, isAdmin, this.isStaff, reservation)}
       </div>
     );

--- a/app/shared/reservation-controls/_reservation_controls.scss
+++ b/app/shared/reservation-controls/_reservation_controls.scss
@@ -1,7 +1,26 @@
 .app-ReservationControls {
-  &__info-button-wrapper {
-    &:not(:last-child) {
-      margin-bottom: 14px;
+  $vertical-spacing: 20px;
+  $container-min-height: 180px;
+  $button-gap: 14px;
+  $button-width: 100px;
+
+  align-content: end;
+  display: grid;
+  grid-auto-rows: max-content;
+  grid-template-columns: 1fr;
+  grid-gap: $button-gap;
+  padding: $vertical-spacing 0;
+  min-height: $container-min-height;
+
+  @media (min-width: $screen-sm-min) {
+    grid-template-columns: 1fr 1fr;
+
+    & button {
+      grid-row-start: 2;
     }
+  }
+
+  & #info {
+    grid-area: 1 / 1;
   }
 }

--- a/src/domain/feature-flags/getIsFeatureEnabled.js
+++ b/src/domain/feature-flags/getIsFeatureEnabled.js
@@ -9,7 +9,7 @@ import FeatureFlags from './FeatureFlags';
 function getIsFeatureEnabled(flagName) {
   switch (flagName) {
     case FeatureFlags.FONT_SIZE_CONTROLS:
-      return false;
+      return true;
     default:
       return false;
   }

--- a/src/domain/search/filters/filter/_dateFilter.scss
+++ b/src/domain/search/filters/filter/_dateFilter.scss
@@ -12,6 +12,18 @@
     width: 22px;
   }
 
+  &__input {
+    // The date input makes use of input addons. These addons may scale
+    // based on font size. However, the form-control element itself is
+    // hard coded to a height of 40px. This causes a glitch in the UI.
+    // This behaviour became a problem when we added controls for
+    // increasing font size.
+    //
+    // The fix here is to unset the height of the input so that it may
+    // scale based on fon-size as well.
+    height: unset;
+  }
+
   &__triangle {
     text-align: right;
   }


### PR DESCRIPTION
The normal font sizes were corrected previously. They were caused by HDS and were bugs that were "inherited from other" features. These changes look to fix issues with medium and large font sizes. Descriptions can be found from the comments of VAR-360.

**User reservations page, controls button labels overflow containers**
*Fix buttons overflowing on large font sizes*

The buttons were hard coded to a fixed width of 100px which didn't allow them to span even though there was room for it. I changed the layout to a grid layout, which provides more flexibility for the buttons to resizes based on label length. Optimal sizing varies by language and screen size.

I also improved the behaviour of the buttons on small screens.

**Fix access code breaking layout with large font sizes**
The access code would often overflow the container of a single reservation list item. This would cause glitches in the next items layout, which would cause issues with the next one. With this change I am allowing the reservation list item container to expand vertically to facilitate the access code.

**Fix date filter breaking on large font sizes**
On the search page, the date filter would have a visual glitch with larger font sizes.

**Fix resource calendar with large font size**
Resource calendar would glitch with the large font sizes as it simply didn't have enough room to render its content. I changed this page to render in a single column instead of two when font size is large.