### PR TITLE
VAR-394 | Fix lack of color indicator in availability view

### DIFF
--- a/app/assets/styles/customization/espoo/customization.scss
+++ b/app/assets/styles/customization/espoo/customization.scss
@@ -127,8 +127,6 @@
       background-color: $blue;
     }
     .reservation {
-      background-color: $blue;
-
       &-link:hover {
         text-decoration: none;
       }

--- a/app/assets/styles/customization/vantaa/customization.scss
+++ b/app/assets/styles/customization/vantaa/customization.scss
@@ -132,8 +132,6 @@
       background-color: $blue;
     }
     .reservation {
-      background-color: $blue;
-
       &-link:hover {
         text-decoration: none;
       }


### PR DESCRIPTION
Previously Espoo's and Vantaa's versions of Varaamo did not indicate
between types of reservations. In this commit we are removing the
custom styling in order to allow the default colours to come through.