### PR TITLE
VAR-412 | Fix small font size

### DIFF
--- a/app/assets/styles/_rem-text-size.scss
+++ b/app/assets/styles/_rem-text-size.scss
@@ -6,7 +6,7 @@
 
 $font-size-base:          1.6rem;  /* ~16px */
 $font-size-large:         1.8rem;  /* ~18px */
-$font-size-small:         1.8rem;  /* ~12px */ 
+$font-size-small:         1.4rem;  /* ~14px */ 
 
 $font-size-h1:            4.2rem ; /* ~42px */
 $font-size-h2:            3.6rem ; /* ~34px */


### PR DESCRIPTION
Due to a copy paste error, the small font size had been set
incorrectly.