### PR TITLE
Fix default municipality breaking search in test environment

### DIFF
--- a/src/domain/reservation/manage/page/__tests__/__snapshots__/ManageReservationsPage.test.js.snap
+++ b/src/domain/reservation/manage/page/__tests__/__snapshots__/ManageReservationsPage.test.js.snap
@@ -31,7 +31,6 @@ exports[`ManageReservationsPage renders correctly 1`] = `
       filters={
         Object {
           "date": "2017-12-10",
-          "municipality": undefined,
         }
       }
       onSearchChange={[Function]}

--- a/src/domain/search/page/__tests__/__snapshots__/SearchPage.test.js.snap
+++ b/src/domain/search/page/__tests__/__snapshots__/SearchPage.test.js.snap
@@ -8,7 +8,6 @@ exports[`SearchPage renders correctly 1`] = `
     filters={
       Object {
         "date": "2017-12-10",
-        "municipality": undefined,
       }
     }
     isGeolocationEnabled={false}

--- a/src/domain/search/utils.js
+++ b/src/domain/search/utils.js
@@ -21,10 +21,13 @@ export const getFiltersFromUrl = (location, supportedFilters = constants.SUPPORT
     // Otherwise, reservations property under resource data will be
     // empty.
     date: defaultDate,
+  };
+
+  if (defaultMunicipality) {
     // Determine current version of Varaamo (Helsinki, Espoo, Vantaa)
     // and filter results to target that municipality by default.
-    municipality: defaultMunicipality,
-  };
+    filters.municipality = defaultMunicipality;
+  }
 
   query.forEach((value, key) => {
     if (!supportedFilters || supportedFilters[key] !== undefined) {


### PR DESCRIPTION
In the testing environment, the default municipality would be undefined, which ended up in the query, and would break search.