### PR TITLE
VAR-425 | Manage reservation page: Support for cancellation reason

### DIFF
--- a/app/i18n/messages/en.json
+++ b/app/i18n/messages/en.json
@@ -274,6 +274,8 @@
   "ReservationInformationForm.refundPolicyText.2": "talpa@hel.fi",
   "ReservationInformationForm.refundPolicyText.3": " and include customer name, email, resource name, date and time. You can cancel customer reservation after getting confirmation email from TALPA. Internal reservations by staff are free.",
   "ReservationInformationForm.refundCheckBox": " I have read refund instructions.",
+  "ReservationInformationForm.cancellationReason": "Cancellation reason:",
+  "ReservationInformationForm.explanation": "Explanation (optional):",
   "ReservationListContainer.emptyMessage": "You do not have any reservations yet.",
   "ReservationListContainer.comingReservations": "Coming",
   "ReservationListContainer.pastReservations": "Past",

--- a/app/i18n/messages/fi.json
+++ b/app/i18n/messages/fi.json
@@ -274,6 +274,8 @@
   "ReservationInformationForm.refundPolicyText.2": "kuva.talous@hel.fi",
   "ReservationInformationForm.refundPolicyText.3": ". Voit tämän jälkeen ilmoittaa onnistuneesta peruutuksesta asiakkaalle ja perua varauksen. Henkilökunnan varaukset ovat maksuttomia.",
   "ReservationInformationForm.refundCheckBox": "Olen lukenut rahojen palautus ohjeet.",
+  "ReservationInformationForm.cancellationReason": "Peruutussyy:",
+  "ReservationInformationForm.explanation": "Selitys (valinnainen):",
   "ReservationListContainer.emptyMessage": "Sinulla ei vielä ole yhtään varausta.",
   "ReservationListContainer.comingReservations": "Tulevat",
   "ReservationListContainer.pastReservations": "Menneet",

--- a/app/i18n/messages/sv.json
+++ b/app/i18n/messages/sv.json
@@ -277,6 +277,8 @@
   "ReservationInformationForm.refundPolicyText.2": "talpa@hel.fi",
   "ReservationInformationForm.refundPolicyText.3": " och inkludera kundnamn, e-post, resursnamn, datum och tid. Du kan avbryta kundreservation efter att du fått bekräftelsemail från TALPA. Interna reservationer av personalen är gratis.",
   "ReservationInformationForm.refundCheckBox": "Jag har läst återbetalningsinstruktioner.",
+  "ReservationInformationForm.cancellationReason": "Orsak till avbokning:",
+  "ReservationInformationForm.explanation": "Förklaring (frivillig):",
   "ReservationListContainer.emptyMessage": "Du har ännu inte några bokningar.",
   "ReservationListContainer.comingReservations": "Kommande",
   "ReservationListContainer.pastReservations": "Dåtid",

--- a/src/common/form/fields/TextAreaField.js
+++ b/src/common/form/fields/TextAreaField.js
@@ -1,0 +1,40 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import FormGroup from 'react-bootstrap/lib/FormGroup';
+import ControlLabel from 'react-bootstrap/lib/ControlLabel';
+import FormControl from 'react-bootstrap/lib/FormControl';
+
+const TextAreaField = ({
+  onChange,
+  onKeyPress,
+  label,
+  placeholder,
+  value,
+  id,
+  rows,
+}) => (
+  <FormGroup controlId={`textAreaField-${id}`}>
+    {label && <ControlLabel className="app-TextAreaField__label">{label}</ControlLabel>}
+    <FormControl
+      className="app-TextAreaField__textarea"
+      componentClass="textarea"
+      onChange={onChange}
+      onKeyPress={onKeyPress}
+      placeholder={placeholder}
+      rows={rows}
+      value={value}
+    />
+  </FormGroup>
+);
+
+TextAreaField.propTypes = {
+  id: PropTypes.string.isRequired,
+  onChange: PropTypes.func.isRequired,
+  onKeyPress: PropTypes.func,
+  label: PropTypes.string,
+  placeholder: PropTypes.string,
+  rows: PropTypes.number,
+  value: PropTypes.string.isRequired,
+};
+
+export default TextAreaField;

--- a/src/domain/reservation/modal/ReservationCancelModal.js
+++ b/src/domain/reservation/modal/ReservationCancelModal.js
@@ -5,9 +5,11 @@ import { connect } from 'react-redux';
 import Toggle from 'react-toggle';
 import Button from 'react-bootstrap/lib/Button';
 
+import SelectField from '../../../common/form/fields/SelectField';
 import injectT from '../../../../app/i18n/injectT';
 import CompactReservationList from '../../../../app/shared/compact-reservation-list/CompactReservationList';
 import { RESERVATION_STATE } from '../../../constants/ReservationState';
+import TextAreaField from '../../../common/form/fields/TextAreaField';
 
 const mapStateToProps = (state) => {
   return {
@@ -19,9 +21,11 @@ const mapStateToProps = (state) => {
 const UnconnectedReservationCancelModal = ({
   // Remove eslint-disable later!
   // eslint-disable-next-line no-unused-vars
-  onEditReservation, parentToggle, reservation, toggleShow, t, userId, users,
+  cancelCategories, onEditReservation, parentToggle, reservation, toggleShow, t, userId, users,
 }) => {
   const [show, setShow] = useState(toggleShow);
+  const [cancelCategoryId, setCancelCategoryId] = useState();
+  const [cancelDescription, setCancelDescription] = useState('');
   /**
    * Until we have billable information in resource data the checkbox disabled is false. See below...
    */
@@ -84,7 +88,10 @@ const UnconnectedReservationCancelModal = ({
   };
 
   const handleCancel = () => {
-    onEditReservation(reservation, RESERVATION_STATE.CANCELLED);
+    onEditReservation(reservation, RESERVATION_STATE.CANCELLED, false, {
+      category_id: cancelCategoryId,
+      description: cancelDescription || null,
+    });
   };
 
   return (
@@ -120,6 +127,20 @@ const UnconnectedReservationCancelModal = ({
             )
           }
         </div>
+        <SelectField
+          id="cancelReasonCategory"
+          label="Cancellation reason:"
+          onChange={option => setCancelCategoryId(option.value)}
+          options={cancelCategories}
+          value={cancelCategoryId}
+        />
+        <TextAreaField
+          id="cancelReasonExplanation"
+          label="Explanation (optional):"
+          onChange={e => setCancelDescription(e.target.value)}
+          rows={5}
+          value={cancelDescription}
+        />
       </Modal.Body>
 
       <Modal.Footer>
@@ -142,6 +163,7 @@ const UnconnectedReservationCancelModal = ({
 };
 
 UnconnectedReservationCancelModal.propTypes = {
+  cancelCategories: PropTypes.array.isRequired,
   onEditReservation: PropTypes.func.isRequired,
   parentToggle: PropTypes.func.isRequired,
   reservation: PropTypes.object.isRequired,

--- a/src/domain/reservation/modal/ReservationCancelModal.js
+++ b/src/domain/reservation/modal/ReservationCancelModal.js
@@ -129,14 +129,14 @@ const UnconnectedReservationCancelModal = ({
         </div>
         <SelectField
           id="cancelReasonCategory"
-          label="Cancellation reason:"
+          label={t('ReservationInformationForm.cancellationReason')}
           onChange={option => setCancelCategoryId(option.value)}
           options={cancelCategories}
           value={cancelCategoryId}
         />
         <TextAreaField
           id="cancelReasonExplanation"
-          label="Explanation (optional):"
+          label={t('ReservationInformationForm.explanation')}
           onChange={e => setCancelDescription(e.target.value)}
           rows={5}
           value={cancelDescription}
@@ -152,7 +152,7 @@ const UnconnectedReservationCancelModal = ({
         </Button>
         <Button
           bsStyle="danger"
-          disabled={checkboxDisabled}
+          disabled={checkboxDisabled || !cancelCategoryId}
           onClick={handleCancel}
         >
           {t('ReservationCancelModal.cancelAllowedConfirm')}

--- a/src/domain/reservation/modal/__tests__/ReservationCancelModal.test.js
+++ b/src/domain/reservation/modal/__tests__/ReservationCancelModal.test.js
@@ -20,6 +20,7 @@ describe('domain/reservation/modal/ReservationCancelModal', () => {
       parentToggle: jest.fn(),
       reservation: mockReservation,
       toggleShow: mockBoolean,
+      cancelCategories: [],
     };
     const wrapper = shallowWithIntl(
       <UnconnectedReservationCancelModal {...props} {...extraProps} />,

--- a/src/domain/reservation/modal/__tests__/__snapshots__/ReservationCancelModal.test.js.snap
+++ b/src/domain/reservation/modal/__tests__/__snapshots__/ReservationCancelModal.test.js.snap
@@ -83,6 +83,19 @@ exports[`domain/reservation/modal/ReservationCancelModal renders correctly 1`] =
           }
         />
       </div>
+      <InjectT(SelectField)
+        id="cancelReasonCategory"
+        label="Cancellation reason:"
+        onChange={[Function]}
+        options={Array []}
+      />
+      <TextAreaField
+        id="cancelReasonExplanation"
+        label="Explanation (optional):"
+        onChange={[Function]}
+        rows={5}
+        value=""
+      />
     </ModalBody>
     <ModalFooter
       bsClass="modal-footer"

--- a/src/domain/reservation/modal/__tests__/__snapshots__/ReservationCancelModal.test.js.snap
+++ b/src/domain/reservation/modal/__tests__/__snapshots__/ReservationCancelModal.test.js.snap
@@ -85,13 +85,11 @@ exports[`domain/reservation/modal/ReservationCancelModal renders correctly 1`] =
       </div>
       <InjectT(SelectField)
         id="cancelReasonCategory"
-        label="Cancellation reason:"
         onChange={[Function]}
         options={Array []}
       />
       <TextAreaField
         id="cancelReasonExplanation"
-        label="Explanation (optional):"
         onChange={[Function]}
         rows={5}
         value=""
@@ -114,7 +112,7 @@ exports[`domain/reservation/modal/ReservationCancelModal renders correctly 1`] =
         block={false}
         bsClass="btn"
         bsStyle="danger"
-        disabled={false}
+        disabled={true}
         onClick={[Function]}
       />
     </ModalFooter>

--- a/src/domain/reservation/utils.js
+++ b/src/domain/reservation/utils.js
@@ -62,11 +62,15 @@ export const putReservation = (reservation, fields) => {
 /**
  * Delete/Cancel reservation
  *
- * @param {Object} reservation
+ * @param {string} reservationID
+ * @param {string} cancelReasonCategoryID
  * @returns {Promise}
  */
-export const cancelReservation = (reservation) => {
-  return client.delete(`reservation/${reservation.id}`);
+export const cancelReservation = (reservationID, cancelReason) => {
+  return client.patch(`reservation/${reservationID}`, {
+    state: RESERVATION_STATE.CANCELLED,
+    cancel_reason: cancelReason,
+  });
 };
 
 /**


### PR DESCRIPTION
## Description :sparkles:
- Implement `TextAreaField` component
- Support cancellation raeson for Manage Reservations page

### Closes :no_good_woman:
**[VAR-425](https://helsinkisolutionoffice.atlassian.net/browse/VAR-425)**: Manage reservations page: Add support for cancellation reason 

### Related :handshake:

## Testing :alembic:

### Automated tests :gear:️

### Manual testing :construction_worker_man:
- Log in with an admin account
- With a reservation in place, go to `Manage reservations` page
- Click on `select action` then `cancel` 
- A modal will be open where you can specify the reason and the explanation 

## Screenshots :camera_flash:
![image](https://user-images.githubusercontent.com/23040926/90246509-79705e00-de3d-11ea-972a-fccaebb5091c.png)


## Additional notes :spiral_notepad:
