### PR TITLE
VAR-442 | Show Select Action dropdown for canceled reservations 

### DIFF
--- a/src/domain/reservation/manage/action/ManageReservationsDropdown.js
+++ b/src/domain/reservation/manage/action/ManageReservationsDropdown.js
@@ -16,45 +16,43 @@ const UntranslatedManageReservationsDropdown = ({
 
   return (
     <div className="app-ManageReservationDropdown">
-      {userCanModify && (
-        <DropdownButton
-          id="app-ManageReservationDropdown"
-          title={t('ManageReservationsList.actionsHeader')}
-        >
-          <MenuItem onClick={onInfoClick}>
-            {t('ManageReservationsList.actionLabel.information')}
-          </MenuItem>
+      <DropdownButton
+        id="app-ManageReservationDropdown"
+        title={t('ManageReservationsList.actionsHeader')}
+      >
+        <MenuItem onClick={onInfoClick}>
+          {t('ManageReservationsList.actionLabel.information')}
+        </MenuItem>
 
-          {isRequestedReservation && (
-            <>
-              <MenuItem
-                onClick={() => onEditReservation(reservation, RESERVATION_STATE.CONFIRMED)}
-              >
-                {t('ManageReservationsList.actionLabel.approve')}
-              </MenuItem>
-              <MenuItem
-                onClick={() => onEditReservation(reservation, RESERVATION_STATE.DENIED)}
-              >
-                {t('ManageReservationsList.actionLabel.deny')}
-              </MenuItem>
-            </>
-          )}
-
+        {userCanModify && isRequestedReservation && (
+          <>
+            <MenuItem
+              onClick={() => onEditReservation(reservation, RESERVATION_STATE.CONFIRMED)}
+            >
+              {t('ManageReservationsList.actionLabel.approve')}
+            </MenuItem>
+            <MenuItem
+              onClick={() => onEditReservation(reservation, RESERVATION_STATE.DENIED)}
+            >
+              {t('ManageReservationsList.actionLabel.deny')}
+            </MenuItem>
+          </>
+        )}
+        {userCanModify && (
           <MenuItem
             onClick={onEditClick}
           >
             {t('ManageReservationsList.actionLabel.edit')}
           </MenuItem>
-
-          {userCanCancel && (
-            <MenuItem
-              onClick={() => onEditReservation(reservation, RESERVATION_STATE.CANCELLED, true)}
-            >
-              {t('ManageReservationsList.actionLabel.cancel')}
-            </MenuItem>
-          )}
-        </DropdownButton>
-      )}
+        )}
+        {userCanCancel && (
+          <MenuItem
+            onClick={() => onEditReservation(reservation, RESERVATION_STATE.CANCELLED, true)}
+          >
+            {t('ManageReservationsList.actionLabel.cancel')}
+          </MenuItem>
+        )}
+      </DropdownButton>
     </div>
   );
 };

--- a/src/domain/reservation/manage/page/ManageReservationsPage.js
+++ b/src/domain/reservation/manage/page/ManageReservationsPage.js
@@ -384,6 +384,7 @@ class ManageReservationsPage extends React.Component {
             <ReservationInformationModal
               isAdmin={isAdmin}
               isOpen={isModalOpen}
+              onCancelReservation={() => this.parentToggle(true)}
               onEditClick={this.onEditClick}
               onEditReservation={this.onEditReservation}
               onHide={this.onInfoModalClose}

--- a/src/domain/reservation/modal/ReservationInformationModal.js
+++ b/src/domain/reservation/modal/ReservationInformationModal.js
@@ -82,10 +82,11 @@ const ReservationInformationModal = ({
           {payerEmail && renderField('payment_email', payerEmail)}
           {renderField('reservation_time', getDateAndTime(reservation))}
           {renderField('resource', get(reservation, 'resource.name.fi', ''))}
-          {renderInfoRow(t('ReservationInformationForm.cancellationReason'), [
-            get(reservation, ['cancel_reason', 'category', 'name', locale || 'fi']),
-            get(reservation, ['cancel_reason', 'category', 'description', locale || 'fi']),
-          ])
+          {renderInfoRow(t('ReservationInformationForm.cancellationReason'),
+            get(reservation, 'cancel_reason') && [
+              get(reservation, ['cancel_reason', 'category', 'name', locale || 'fi']),
+              get(reservation, ['cancel_reason', 'category', 'description', locale || 'fi']),
+            ])
           }
           {renderInfoRow(t('ReservationInformationForm.cancellationDescription'),
             get(reservation, 'cancel_reason.description') || null)

--- a/src/domain/reservation/modal/ReservationInformationModal.js
+++ b/src/domain/reservation/modal/ReservationInformationModal.js
@@ -11,21 +11,25 @@ import injectT from '../../../../app/i18n/injectT';
 import { getDateAndTime } from '../manage/list/ManageReservationsList';
 import { RESERVATION_STATE } from '../../../constants/ReservationState';
 import ReservationMetadata from '../information/ReservationMetadata';
-import ConnectedReservationCancelModal from './ReservationCancelModal';
 import { getShowRefundPolicy } from '../utils';
 import ReservationInformationModalContentRow from './ReservationInformationModalContentRow';
 
 const ReservationInformationModal = ({
-  t, reservation, resource, onHide, isOpen, isAdmin, onEditClick, onEditReservation, onSaveComment,
+  t,
+  locale,
+  reservation,
+  resource,
+  onHide,
+  isOpen,
+  isAdmin,
+  onEditClick,
+  onEditReservation,
+  onCancelReservation,
+  onSaveComment,
 }) => {
   const [comment, setComment] = useState(get(reservation, 'comments') || '');
-  const [isReservationCancelModalOpen, toggleReservationCancelModal] = useState(false);
   const saveComment = () => onSaveComment(reservation, comment);
   const normalizedReservation = Object.assign({}, reservation, { resource: reservation.resource.id });
-
-  const parentToggle = (bool) => {
-    toggleReservationCancelModal(bool);
-  };
 
   const renderField = (label, value) => {
     return (
@@ -54,6 +58,7 @@ const ReservationInformationModal = ({
   const payerEmail = get(reservation, 'billing_email_address', '');
   const isRequestedReservation = reservation.state === RESERVATION_STATE.REQUESTED;
   const showRefundPolicy = resource !== null && getShowRefundPolicy(isAdmin, reservation, resource);
+  const canEdit = reservation.state !== 'cancelled';
 
   return (
     <Modal
@@ -77,7 +82,14 @@ const ReservationInformationModal = ({
           {payerEmail && renderField('payment_email', payerEmail)}
           {renderField('reservation_time', getDateAndTime(reservation))}
           {renderField('resource', get(reservation, 'resource.name.fi', ''))}
-          {renderField('resource', get(reservation, 'resource.name.fi', ''))}
+          {renderInfoRow(t('ReservationInformationForm.cancellationReason'), [
+            get(reservation, ['cancel_reason', 'category', 'name', locale || 'fi']),
+            get(reservation, ['cancel_reason', 'category', 'description', locale || 'fi']),
+          ])
+          }
+          {renderInfoRow(t('ReservationInformationForm.cancellationDescription'),
+            get(reservation, 'cancel_reason.description') || null)
+          }
 
           {/* Render reservation metadata (extra) fields */}
           <ReservationMetadata
@@ -100,35 +112,39 @@ const ReservationInformationModal = ({
           }
 
         </div>
-        <div className="app-ReservationInformationModal__edit-reservation-btn">
-          <Button
-            bsStyle="primary"
-            onClick={() => onEditClick(reservation)}
-          >
-            {t('ReservationEditForm.startEdit')}
-          </Button>
-        </div>
-        <div className="app-ReservationInformationModal__comments-section">
-          <ControlLabel>
-            {`${t('common.commentsLabel')}:`}
-          </ControlLabel>
-          <FormControl
-            className="app-ReservationInformationModal__comments-field"
-            componentClass="textarea"
-            onChange={e => setComment(e.target.value)}
-            placeholder={t('common.commentsPlaceholder')}
-            rows={5}
-            value={comment}
-          />
-          <div className="app-ReservationInformationModal__save-comment">
+        {canEdit && (
+          <div className="app-ReservationInformationModal__edit-reservation-btn">
             <Button
               bsStyle="primary"
-              onClick={saveComment}
+              onClick={() => onEditClick(reservation)}
             >
-              {t('ReservationInfoModal.saveComment')}
+              {t('ReservationEditForm.startEdit')}
             </Button>
           </div>
-        </div>
+        )}
+        {canEdit && (
+          <div className="app-ReservationInformationModal__comments-section">
+            <ControlLabel>
+              {`${t('common.commentsLabel')}:`}
+            </ControlLabel>
+            <FormControl
+              className="app-ReservationInformationModal__comments-field"
+              componentClass="textarea"
+              onChange={e => setComment(e.target.value)}
+              placeholder={t('common.commentsPlaceholder')}
+              rows={5}
+              value={comment}
+            />
+            <div className="app-ReservationInformationModal__save-comment">
+              <Button
+                bsStyle="primary"
+                onClick={saveComment}
+              >
+                {t('ReservationInfoModal.saveComment')}
+              </Button>
+            </div>
+          </div>
+        )}
       </Modal.Body>
       <Modal.Footer>
         <Button
@@ -138,12 +154,14 @@ const ReservationInformationModal = ({
           {t('common.back')}
         </Button>
 
-        <Button
-          bsStyle="default"
-          onClick={() => toggleReservationCancelModal(!isReservationCancelModalOpen)}
-        >
-          {t('ReservationInfoModal.cancelButton')}
-        </Button>
+        {canEdit && (
+          <Button
+            bsStyle="default"
+            onClick={() => onCancelReservation(true)}
+          >
+            {t('ReservationInfoModal.cancelButton')}
+          </Button>
+        )}
 
         {isRequestedReservation && (
           <>
@@ -163,21 +181,17 @@ const ReservationInformationModal = ({
           </>
         )}
       </Modal.Footer>
-      <ConnectedReservationCancelModal
-        onEditReservation={onEditReservation}
-        parentToggle={parentToggle}
-        reservation={reservation}
-        toggleShow={isReservationCancelModalOpen}
-      />
     </Modal>
   );
 };
 
 ReservationInformationModal.propTypes = {
   t: PropTypes.func.isRequired,
+  locale: PropTypes.string.isRequired,
   reservation: PropTypes.object.isRequired,
   resource: PropTypes.object,
   onHide: PropTypes.func,
+  onCancelReservation: PropTypes.func,
   onEditClick: PropTypes.func,
   onEditReservation: PropTypes.func,
   onSaveComment: PropTypes.func.isRequired,

--- a/src/domain/reservation/modal/__tests__/__snapshots__/ReservationInfomationModal.test.js.snap
+++ b/src/domain/reservation/modal/__tests__/__snapshots__/ReservationInfomationModal.test.js.snap
@@ -106,15 +106,6 @@ exports[`ReservationInformationModal renders correctly 1`] = `
           </span>
         }
       />
-      <ReservationInformationModalContentRow
-        content=""
-        key="resource"
-        label={
-          <span>
-            common.resourceLabel
-          </span>
-        }
-      />
       <InjectT(ReservationMetadata)
         customField={[Function]}
         reservation={
@@ -210,28 +201,5 @@ exports[`ReservationInformationModal renders correctly 1`] = `
       ReservationInfoModal.cancelButton
     </Button>
   </ModalFooter>
-  <InjectT(ReservationCancelModal)
-    onEditReservation={[MockFunction]}
-    parentToggle={[Function]}
-    reservation={
-      Object {
-        "begin": "2019-08-14T14:00:00+03:00",
-        "comments": "",
-        "end": "2019-08-14T15:00:00+03:00",
-        "event_description": "",
-        "event_subject": "",
-        "has_catering_order": false,
-        "id": 1,
-        "its_own": false,
-        "resource": 1,
-        "staff_event": false,
-        "state": "confirmed",
-        "url": "https://respa.koe.hel.ninja/v1/reservation/192388/",
-        "user": Object {},
-        "user_permissions": null,
-      }
-    }
-    toggleShow={false}
-  />
 </Modal>
 `;


### PR DESCRIPTION
## Description :sparkles:
- Show Select Action dropdown for canceled reservations, with the ability to display the information modal
- Remove the Cancel Reservation modal from the Reservation Information Modal since the parent component can control it.

## Issues :bug:

### Closes :no_good_woman:

### Related :handshake:

## Testing :alembic:

### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:
![image](https://user-images.githubusercontent.com/23040926/94552386-74396800-025f-11eb-93a3-ed1151a86219.png)
![image](https://user-images.githubusercontent.com/23040926/94552406-7ac7df80-025f-11eb-9a30-35a9279d1476.png)

## Additional notes :spiral_notepad:
Additional unit tests to be added in a follow-up PR 