### PR TITLE
TILA-2687: fix missing payment states

### DIFF
--- a/app/constants/AppConstants.js
+++ b/app/constants/AppConstants.js
@@ -58,7 +58,7 @@ export default {
       labelBsStyle: 'success',
       labelTextId: 'payment.success',
     },
-    waiting: {
+    waiting_for_payment: {
       labelBsStyle: 'warning',
       labelTextId: 'payment.processing',
     },
@@ -69,6 +69,14 @@ export default {
     cancelled: {
       labelBsStyle: 'danger',
       labelTextId: 'payment.cancelled',
+    },
+    requested: {
+      labelBsStyle: 'primary',
+      labelTextId: 'common.requested',
+    },
+    created: {
+      labelBsStyle: 'default',
+      labelTextId: 'common.created',
     },
   },
   SEARCH_PAGE_SIZE: 30,

--- a/app/i18n/messages/en.json
+++ b/app/i18n/messages/en.json
@@ -426,6 +426,7 @@
   "Reservation.stateLabelConfirmed": "Approved",
   "Reservation.stateLabelDenied": "Denied",
   "Reservation.stateLabelRequested": "Requested",
+  "Reservation.stateLabelWaiting_for_payment": "Waiting for payment",
   "ResourceReservationCalendar.reserveButton": "Reserve",
   "ResourceReservationCalendar.selectedDateLabel": "Selected time:",
   "ResourceReservationCalendar.selectedDateValue": "{date} at {start} - at {end} ({duration})",

--- a/app/i18n/messages/fi.json
+++ b/app/i18n/messages/fi.json
@@ -435,6 +435,7 @@
   "Reservation.stateLabelConfirmed": "Hyväksytty",
   "Reservation.stateLabelDenied": "Evätty",
   "Reservation.stateLabelRequested": "Käsiteltävänä",
+  "Reservation.stateLabelWaiting_for_payment": "Odottaa maksua",
   "ResourceReservationCalendar.reserveButton": "Tee varaus",
   "ResourceReservationCalendar.selectedDateLabel": "Valittu aika:",
   "ResourceReservationCalendar.selectedDateValue": "{date} klo {start} - klo {end} ({duration})",

--- a/app/i18n/messages/sv.json
+++ b/app/i18n/messages/sv.json
@@ -428,6 +428,7 @@
   "Reservation.stateLabelConfirmed": "Godkänd",
   "Reservation.stateLabelDenied": "Nekad",
   "Reservation.stateLabelRequested": "Begärda",
+  "Reservation.stateLabelWaiting_for_payment": "Väntar på betalning",
   "ResourceReservationCalendar.reserveButton": "Boka",
   "ResourceReservationCalendar.selectedDateLabel": "Utvald tidpunkt:",
   "ResourceReservationCalendar.selectedDateValue": "{date} kl. {start} - kl. {end} ({duration})",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "varaamo",
-  "version": "0.12.8",
+  "version": "0.12.9",
   "repository": {
     "type": "git",
     "url": "https://github.com/City-of-Helsinki/varaamo"

--- a/src/domain/footer/__tests__/__snapshots__/Footer.test.js.snap
+++ b/src/domain/footer/__tests__/__snapshots__/Footer.test.js.snap
@@ -56,7 +56,7 @@ exports[`domain/footer/Footer When there is no customization in use renders corr
           <span
             className="app-varaamo-version"
           >
-            v0.12.8
+            v0.12.9
           </span>
         </div>
       </Col>
@@ -121,7 +121,7 @@ exports[`domain/footer/Footer renders correctly 1`] = `
           <span
             className="app-varaamo-version"
           >
-            v0.12.8
+            v0.12.9
           </span>
         </div>
       </Col>

--- a/src/domain/reservation/manage/status/ManageReservationsStatus.js
+++ b/src/domain/reservation/manage/status/ManageReservationsStatus.js
@@ -16,6 +16,7 @@ export const getLabelStyle = (status) => {
     case RESERVATION_STATE.DENIED:
       return 'danger';
     case RESERVATION_STATE.REQUESTED:
+    case RESERVATION_STATE.WAITING_FOR_PAYMENT:
       return 'warning';
     default:
       return '';


### PR DESCRIPTION
- Avoid null when using constants.
- Add a label that is used when i18n is constructed directly from state name.
- Bump version.